### PR TITLE
feat(bench): hidden_gem_hit_rate metric — useful-disagreement eval axis (plan 003-gem)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ uv run scripts/bench.py audit --collinearity                             # Pairw
 uv run scripts/bench.py audit --expect-identity                          # Assert bitwise-identical scores (for pure refactors)
 uv run scripts/bench.py audit --repin --yes                              # Rebuild pinned fixture from current working tree
 uv run scripts/bench.py audit --unknowns                                 # List port_nodes rows with node_kind='UNKNOWN' (plan 003 Unit 6)
+uv run scripts/bench.py audit --inspect-gems                             # Per-commander lost/gained hidden-gem diff (plan 003-gem)
+uv run scripts/bench.py audit --trend hidden_gems --trend-n 20           # CSV history of aggregate hidden_gem_hit_rate across audit runs
 ```
 
 The bench.py hook also runs advisorily on pre-commit when edits touch
@@ -122,6 +124,36 @@ of Python code.
   `port_nodes` rows classified as `UNKNOWN`, ranked by distinct
   cards × EDHREC rank weight. Run after each Forge cardsfolder
   refresh to see candidate shapes for vocabulary expansion.
+
+### Evaluation — `hidden_gem_hit_rate` (plan 003-gem)
+
+A second evaluation axis tracked alongside the existing histogram
+verdict: `hidden_gem_hit_rate = |plausible_hidden| / 30` per
+commander, where `plausible_hidden = (our_top_30 \ edhrec_top_30)`
+filtered by a mechanical-plausibility gate (`N_rules_firing >= 2`
+OR `total_contribution > per-commander-median`). Operationalizes
+`memory/feedback_edhrec_not_goal.md` — the stated "find hidden gems
+from mechanics" intent, now measurable.
+
+- **Tracking-only at MVP.** Commit gate stays on the histogram
+  verdict; a stderr warning fires when aggregate delta < −0.02 but
+  the audit still exits 0. Promotion to a commit-gate requires a
+  separate `ce-brainstorm` + `ce-plan` cycle per FR6 escalation.
+  See `src/mtg_synergy_graph/bench/hidden_gems.py` module docstring
+  for the criteria.
+- **Persisted in `FixtureEntry.legacy`** — no schema bump. Old pins
+  without gem keys are tolerated (aggregator filters on key
+  presence); re-pinning populates them via the new
+  `build_fixture(conn, commanders, edhrec_conn=...)` path.
+- **`.audit/history.csv`** — every `bench.py audit` run appends a
+  row (timestamp, commit_sha, config_hash, aggregate_score_delta,
+  hidden_gem_hit_rate, delta, n_commanders, verdict). Gitignored;
+  regenerable on fresh checkout.
+- **`--inspect-gems` CLI** — per-commander diff of lost/gained
+  hidden-gem sets between pin and live. Δ column shows integer
+  count out of 30 for legibility.
+- **`--trend hidden_gems`** — CSV reader over `.audit/history.csv`;
+  `--format md` + `--format json` also supported.
 
 ### Algorithm
 

--- a/docs/RULE_HISTORY.md
+++ b/docs/RULE_HISTORY.md
@@ -57,6 +57,39 @@ See `docs/RULE_PLANNING.md` for the forward-looking planning workflow.
   `card_hints` revisit, `scales_with.value` vs `scales_with.valid`
   field split for future BM25F revisits.
 
+### Useful-disagreement plan 003-gem (`hidden_gem_hit_rate`, tracking-only)
+
+- Second evaluation axis for `bench.py audit`:
+  `hidden_gem_hit_rate = |plausible_hidden| / 30` where
+  `plausible_hidden = our_top_30 \ edhrec_top_30` filtered by the
+  mechanical-plausibility gate (N_rules_firing ≥ 2 OR
+  total_contribution > per-commander-median, strict inequality).
+  Operationalizes `memory/feedback_edhrec_not_goal.md`.
+- Six implementation units landed on `feat/hidden-gem-metric`:
+  (1) pure metric core in `bench/hidden_gems.py`,
+  (2) `build_fixture` writes per-commander rate + hidden_cards into
+  `FixtureEntry.legacy` when an EDHREC DB conn is provided,
+  (3) `AuditReport` surfaces aggregate + delta + FR4 stderr warning
+  when delta drops below `-_HIDDEN_GEM_WARN_THRESHOLD` (= −0.02),
+  (4) `bench.py audit --inspect-gems` per-commander lost/gained
+  diff (Δ as integer count out of 30),
+  (5) `.audit/history.csv` append-on-every-audit + `bench.py audit
+  --trend hidden_gems` CSV reader with md/json format support,
+  (6) docs + FR6 escalation block in `hidden_gems.py` docstring.
+- **Tracking-only at MVP.** Existing histogram-based commit gate is
+  unchanged; the new warning is advisory. Promotion to a commit-
+  gate requires a separate brainstorm + plan per FR6: ≥20 commits
+  of tracking + human correlation + <10% false-positive rate.
+- **Identity-preserving.** `bench.py audit --expect-identity` PASS
+  on every unit — gem fields live in `legacy`, the `scores` dict
+  is untouched.
+- Post-landing validation plan: manually replay `hidden_gem_hit_rate`
+  against three historical reverted experiments (broad
+  `gy_retrieval`, deck-hint-match, Survivor 3 BM25F branch) to
+  confirm at least one produces a ≤0 retrospective delta. Finding
+  to be recorded as a memory note alongside
+  `memory/project_reanimator_hisyn_gap.md`.
+
 ## 2026-04-21
 
 ### creature_died_feeder

--- a/docs/plans/2026-04-22-003-feat-useful-disagreement-hidden-gem-metric-plan.md
+++ b/docs/plans/2026-04-22-003-feat-useful-disagreement-hidden-gem-metric-plan.md
@@ -1,7 +1,8 @@
 ---
 title: "feat: Useful-disagreement objective — hidden_gem_hit_rate metric + warning, tracking-only at MVP"
 type: feat
-status: active
+status: landed
+landed: 2026-04-22
 date: 2026-04-22
 origin: docs/brainstorms/2026-04-21-useful-disagreement-requirements.md
 ---
@@ -223,7 +224,7 @@ external docs or prior art needed.
 
 ## Implementation Units
 
-- [ ] **Unit 1: Hidden-gem metric core — plausibility gate + aggregate**
+- [x] **Unit 1: Hidden-gem metric core — plausibility gate + aggregate**
 
 **Goal:** Pure functions that compute `plausibility(cmdr, cand,
 contributions)` and `hidden_gem_hit_rate(our_top_30, edhrec_top_30,
@@ -300,7 +301,7 @@ each formula branch before the implementation.
   dataclass instances (deep equality).
 - Module exports and constants match what Units 2-5 import against.
 
-- [ ] **Unit 2: Fixture integration — compute metric at `build_fixture`, persist in legacy dict**
+- [x] **Unit 2: Fixture integration — compute metric at `build_fixture`, persist in legacy dict**
 
 **Goal:** `build_fixture` opens the EDHREC DB, computes per-commander
 `hidden_gem_hit_rate` + `hidden_cards` while the tensor sink is
@@ -372,7 +373,7 @@ new keys so the pinned JSON carries the baseline.
 - `bench.py audit --expect-identity` on the new fixture stays PASS
   (identity check is over `scores` dict, gem fields don't affect it).
 
-- [ ] **Unit 3: Audit report integration — aggregate, delta, warning**
+- [x] **Unit 3: Audit report integration — aggregate, delta, warning**
 
 **Goal:** `bench.py audit` computes aggregate `hidden_gem_hit_rate`
 (live) and delta vs pinned; renders one line in Markdown + JSON
@@ -448,7 +449,7 @@ output + `_print_summary`; prints an FR4 stderr warning when
 - Running with `--format json` produces valid JSON containing the
   four new keys.
 
-- [ ] **Unit 4: `--inspect-gems` CLI handler**
+- [x] **Unit 4: `--inspect-gems` CLI handler**
 
 **Goal:** New mode `bench.py audit --inspect-gems` that produces a
 per-commander table of `(commander, Δ, lost_gems, gained_gems)` by
@@ -513,7 +514,7 @@ filter, `--format md/json`, `--output`.
 - `bench.py audit --inspect-gems --commander "Korvold, Fae-Cursed King"`
   emits one row or a "no delta" line.
 
-- [ ] **Unit 5: `.audit/history.csv` persistence + `--trend hidden_gems` handler**
+- [x] **Unit 5: `.audit/history.csv` persistence + `--trend hidden_gems` handler**
 
 **Goal:** Every successful `bench.py audit` run appends one row to
 `.audit/history.csv`; new `--trend hidden_gems` mode reads the file
@@ -587,7 +588,7 @@ already be in `AuditReport`).
 - `bench.py audit --trend hidden_gems --trend-n 5` prints the last
   five rows.
 
-- [ ] **Unit 6: Documentation, escalation-path comment, CLAUDE.md**
+- [x] **Unit 6: Documentation, escalation-path comment, CLAUDE.md**
 
 **Goal:** Document the metric, the warning threshold, the escalation
 path, and the memory-note connection. No code changes beyond a

--- a/docs/plans/2026-04-22-003-feat-useful-disagreement-hidden-gem-metric-plan.md
+++ b/docs/plans/2026-04-22-003-feat-useful-disagreement-hidden-gem-metric-plan.md
@@ -1,0 +1,741 @@
+---
+title: "feat: Useful-disagreement objective — hidden_gem_hit_rate metric + warning, tracking-only at MVP"
+type: feat
+status: active
+date: 2026-04-22
+origin: docs/brainstorms/2026-04-21-useful-disagreement-requirements.md
+---
+
+# feat: Useful-disagreement — `hidden_gem_hit_rate`, tracking-only
+
+## Overview
+
+Add a second evaluation axis to `bench.py audit`: `hidden_gem_hit_rate`,
+the fraction of our top-30 that both (a) EDHREC's top-30 synergy list
+omitted and (b) our own rule tensor rates mechanically plausible. Track
+it alongside the existing score-delta + histogram verdict, without
+gating commits on it. First rollout is advisory: the audit prints the
+aggregate + delta vs the pin, warns when the delta drops below
+`_HIDDEN_GEM_WARN_THRESHOLD = 0.02`, and offers `--inspect-gems` for
+per-commander diagnosis and `--trend hidden_gems` for longitudinal
+review. Gating stays on NDCG@30 (via the existing histogram-based
+verdict); promotion to a commit-gate is deferred and requires a future
+brainstorm per FR6.
+
+## Problem Frame
+
+The project's stated intent — recorded three times in auto-memory
+(`feedback_edhrec_not_goal`, `feedback_edhrec_hivemind`,
+`feedback_edhrec_synergy_formula`) — is to find mechanically-plausible
+"hidden gems" that EDHREC missed. EDHREC is a sanity check, not the
+goal. But every acceptance gate today (pre-commit `bench.py audit`,
+`docs/RULE_HISTORY.md` verdicts) grades rules by score deltas /
+NDCG-proxy histogram buckets against EDHREC. A rule that lifts scoring
+purely by concentrating lift on EDHREC top-10 staples scores
+"POSITIVE" even though it moves us further from the stated goal.
+
+Survivor 3 (IDF reforms) is a concrete instance: its BM25F variant
+nudged aggregate NDCG and was abandoned largely because its per-
+commander effects looked like popularity-chasing. We lacked a metric
+that made that instinct measurable — the call was made by inspection,
+not by a number. This plan builds that number.
+
+(see origin: docs/brainstorms/2026-04-21-useful-disagreement-requirements.md)
+
+## Requirements Trace
+
+- **R1** (FR1) — Define and compute `hidden_gem_hit_rate(cmdr)` =
+  `|plausible_hidden(cmdr)| / 30` where
+  `plausible_hidden = (our_top_30 \ edhrec_top_30)` filtered by the
+  mechanical-plausibility gate. Aggregate = mean over commanders with
+  EDHREC data.
+- **R2** (FR2) — Plausibility gate, purely mechanical:
+  `N_rules_firing(cmdr, c) >= 2` OR
+  `total_rule_contribution(cmdr, c) > median_contribution(cmdr)`.
+  Reads from the persisted `rule_contributions` tensor under the live
+  `config_hash` — no new data sources, no learned classifier.
+- **R3** (FR3) — `bench.py audit` prints the aggregate metric + delta
+  vs pinned baseline on every run. `--trend hidden_gems` emits CSV
+  history (decision resolved in planning — no sparkline at MVP).
+- **R4** (FR4) — Warning on aggregate delta < `-0.02` printed to
+  stderr; commit still proceeds (tracking-only gate).
+- **R5** (FR5) — `--inspect-gems` diagnostic: per-commander lost/gained
+  hidden-gems table, respects `--commander NAME` filter.
+- **R6** (FR6) — Escalation path documented in-code (near the
+  threshold constant) and in CLAUDE.md: ≥20 commits tracked, human-
+  correlation check, <10% false-positive rate before promotion to a
+  commit-gate is proposed as a separate brainstorm.
+- **R7** (Success criterion 1) — Metric is deterministic: three
+  consecutive audit runs on an unchanged tree produce identical
+  values.
+- **R8** (Success criterion 2) — Baseline value pinned in
+  `tests/fixtures/golden_set_run.json` (alongside existing `scores`).
+- **R9** (Success criterion 5) — Explainability: `--inspect-gems`
+  output names specific gained/lost cards per commander.
+
+## Scope Boundaries
+
+- No replacing NDCG / histogram verdict with this metric (non-goal 1).
+- No gating commits on `hidden_gem_hit_rate` regressions (non-goal 2).
+- No learned plausibility classifier, no text heuristics (non-goal 3).
+- No pairwise-Jaccard diversity metric (non-goal 4).
+- No move to the 2,761-commander pool (Survivor 1 scope; non-goal 5).
+- Commander pool is the same 100-commander golden set the pinned
+  fixture already uses — no second set at MVP.
+- No promotion to a gate — FR6 promotion is itself a future brainstorm.
+
+### Deferred to Separate Tasks
+
+- **Embedding-based plausibility clause** — FR2 + Open Question 1:
+  tighten plausibility with a commander-target cosine ≥ τ once
+  Survivor 6 (content embeddings) lands. Separate plan.
+- **Commander-popularity weighting** — Open Question 2 resolved as
+  "equal weight at MVP." Revisit only if the metric proves useful.
+- **EDHREC-agreement delta companion metric** — Open Question 6
+  resolved as "skip at MVP" (hi_syn_gain / hi_syn_loss histogram
+  buckets already capture this).
+- **Explicit aggregate NDCG@30 line in audit output** — brainstorm
+  FR3 example shows it, but the current histogram verdict already
+  captures NDCG-direction signal. Adding explicit NDCG reporting is
+  a separate (low-risk) follow-up; this plan keeps NDCG implicit to
+  stay focused.
+- **Retrospective replay harness** — user-chosen manual one-off;
+  documented under Success Criteria section 3 for post-landing
+  validation.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/mtg_synergy_graph/bench/fixture.py` — `FixtureEntry`, `legacy`
+  dict (already carries `ndcg30`, `hi_syn_hits`, `edhrec_top10`),
+  `build_fixture(conn, commanders, existing, tensor_writer)`. This is
+  the host for the new per-commander metric.
+- `src/mtg_synergy_graph/bench/report.py` — `AuditReport`,
+  `CommanderDelta`, `build_report(pinned, live)`, `_render_markdown`,
+  `_as_json_dict`. Pattern for adding aggregate numbers + markdown
+  rows.
+- `src/mtg_synergy_graph/bench/audit.py` — `handle_audit`,
+  `_print_summary`, `_write_default_output` (writes `.audit/last.md`).
+  Same module will own the `.audit/history.csv` append.
+- `src/mtg_synergy_graph/bench/handlers.py` — pattern for new CLI
+  handlers. See `handle_inspect`, `handle_unknowns`.
+- `src/mtg_synergy_graph/bench/cli.py` — mutually-exclusive mode group
+  at `audit.add_mutually_exclusive_group()`. New flags slot in here.
+- `src/mtg_synergy_graph/validate.py` — `_fetch_edhrec_sections`,
+  `commander_to_slug`, `edhrec_labels_for_commander`. Reused for
+  EDHREC top-30 fetch.
+- `src/mtg_synergy_graph/bench/tensor.py` — `rule_contributions`
+  table schema + `compute_config_hash`. The tensor already has every
+  `(cmdr, cand, rule)` contribution row; the plausibility gate is a
+  SQL `GROUP BY` over that table.
+
+### Institutional Learnings
+
+- `memory/feedback_edhrec_not_goal.md`,
+  `memory/feedback_edhrec_hivemind.md`,
+  `memory/feedback_edhrec_synergy_formula.md` — the stated intent
+  this plan operationalizes.
+- `memory/feedback_audit_every_change.md` — existing guardrail:
+  every scoring-path change runs `bench.py audit`. The new metric
+  rides that rail; it does not introduce a new hook.
+- `memory/feedback_strategy_mapping.md`,
+  `memory/project_reanimator_hisyn_gap.md` — reverted experiments
+  that would be candidate retrospective validation subjects
+  post-landing.
+
+### External References
+
+None. This is a local metric built on data we already have; no
+external docs or prior art needed.
+
+## Key Technical Decisions
+
+- **Metric lives in a new module** (`bench/hidden_gems.py`), not bolted
+  onto `report.py` or `fixture.py`. Small pure-function surface
+  (plausibility + aggregate) is easier to test and reason about than
+  an entanglement with the existing report builder.
+- **Persist per-commander metric + hidden-gem list in
+  `FixtureEntry.legacy`** rather than as first-class fields. Keeps
+  `SCHEMA_VERSION` unchanged — load tolerates missing keys, repin adds
+  them. No migration for existing fixtures.
+- **Recompute at `build_fixture` time**, not at audit comparison. The
+  computation reads the persisted tensor + EDHREC DB; both are
+  available during `build_fixture`. Audit comparison stays a pure diff
+  of pinned vs live entries.
+- **Skip commanders without EDHREC data** (planning answer to Open
+  Question 3). Aggregate = mean over commanders *with* EDHREC. Audit
+  output reports `hidden_gem_hit_rate : 0.1467 (Δ -0.0034, 97 cmdrs)`
+  so skip count is visible.
+- **CSV-only trend output** (planning answer to Open Question 5). One
+  row appended to `.audit/history.csv` per `bench.py audit` run.
+  `--trend hidden_gems` prints the last N rows; no sparkline, no
+  matplotlib dep.
+- **History is append-only, untracked by git.** `.audit/` is already
+  gitignored by pre-commit convention (writes `.audit/last.md`).
+  `.audit/history.csv` lives there too. Regeneration on a fresh
+  checkout means an empty trend until the first run — acceptable
+  tradeoff vs carrying volatile data in git.
+- **Threshold is a module-level constant** (`_HIDDEN_GEM_WARN_THRESHOLD
+  = 0.02` in `bench/hidden_gems.py`), commented with the FR6
+  escalation criteria. Future tuning is a one-line edit + audit run.
+- **Warning is stderr, not stdout.** Mirrors the existing
+  `_print_summary` pattern. `.audit/last.md` still captures the
+  aggregate + delta for review.
+- **Determinism via the tensor's `config_hash`.** The persisted tensor
+  is deterministic under unchanged scoring config. Since the metric
+  reads from the tensor + static EDHREC DB, the metric inherits
+  determinism automatically. Test Unit 1 verifies this explicitly.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Q1** (origin OQ #1): Plausibility expansion with embeddings after
+  Survivor 6 lands → deferred to a separate plan (see Deferred to
+  Separate Tasks).
+- **Q2** (origin OQ #2): Commander-popularity weighting → "Likely OK
+  at MVP"; equal weight confirmed (see Deferred to Separate Tasks).
+- **Q3** (origin OQ #3): Commanders without EDHREC data → **Skip**,
+  report skip count (decided via AskUserQuestion).
+- **Q4** (origin OQ #4): "High synergy" vs "all top N" → use the
+  existing "High Synergy Cards" section (origin doc's current answer;
+  matches the NDCG reference set via the `synergy` sort order).
+- **Q5** (origin OQ #5): Trend rendering → **CSV only** (decided via
+  AskUserQuestion).
+- **Q6** (origin OQ #6): EDHREC-agreement delta companion → skip at
+  MVP (see Deferred to Separate Tasks).
+- **Q7** (success criterion 3 validation): Replay harness vs manual →
+  **Manual one-off after landing** (decided via AskUserQuestion).
+
+### Deferred to Implementation
+
+- Exact SQL vs Python shape for the plausibility gate (a `GROUP BY`
+  on `rule_contributions` vs an in-memory aggregation over tensor
+  rows returned by `build_fixture`'s sink). Will fall out naturally
+  when writing Unit 1 — whichever is faster on a 100-commander pass.
+- Whether `--inspect-gems` should default to Markdown or one-table-
+  per-commander format. Depends on what the output looks like on real
+  data. Pick at implementation time.
+- Whether the `.audit/history.csv` write should be gated behind a
+  success (identity OK) or every run. Default to every run; revisit
+  if trend gets polluted by runs with obvious errors.
+
+## Implementation Units
+
+- [ ] **Unit 1: Hidden-gem metric core — plausibility gate + aggregate**
+
+**Goal:** Pure functions that compute `plausibility(cmdr, cand,
+contributions)` and `hidden_gem_hit_rate(our_top_30, edhrec_top_30,
+contributions)` for a single commander. No DB side effects, no CLI
+coupling.
+
+**Requirements:** R1, R2, R7.
+
+**Dependencies:** None (the `rule_contributions` tensor schema +
+tensor writer already exist on main).
+
+**Files:**
+- Create: `src/mtg_synergy_graph/bench/hidden_gems.py`
+- Test: `tests/bench/test_hidden_gems_core.py`
+
+**Approach:**
+- Module exposes: `_HIDDEN_GEM_WARN_THRESHOLD = 0.02` (with a
+  docstring-commented FR6 escalation path),
+  `HiddenGemReport` dataclass
+  (frozen, `aggregate: float | None`, `per_commander: dict[str,
+  HiddenGemEntry]`, `skipped_commanders: tuple[str, ...]`,
+  `HiddenGemEntry(commander, rate, hidden_cards: tuple[str, ...])`),
+  `plausibility(cmdr, cand, rows)` returning bool,
+  `hidden_gem_hit_rate_for_commander(our_top_30, edhrec_top_30,
+  contributions)` returning `HiddenGemEntry | None`,
+  `aggregate_hidden_gem_hit_rate(entries)` returning mean.
+- `contributions` input is an iterable of tensor rows
+  `(candidate, rule_id, contribution)` for one commander — caller
+  shapes it. Module stays DB-agnostic.
+- Plausibility: count rules with `contribution > 0` (the `>= 2` leg)
+  OR sum of contributions > per-commander median — with edge case of
+  "one non-zero candidate" median = that one value itself; short-
+  circuit when median is 0 (use the N_rules leg only).
+- `our_top_30 \ edhrec_top_30` = set subtraction on card names.
+- Return `None` aggregate when entries is empty; audit report prints
+  `hidden_gem_hit_rate : — (no commanders with EDHREC data)`.
+
+**Execution note:** Test-first. Metric definition is a pure function
+and the plausibility formula is subtle — write the failing tests for
+each formula branch before the implementation.
+
+**Patterns to follow:**
+- `src/mtg_synergy_graph/bench/histogram.py` — dataclass shape,
+  pure-function aggregation, `Bucket` enum style.
+- `src/mtg_synergy_graph/bench/collinearity.py` — how another pure
+  numeric module exposes its surface (dataclass + compute function).
+
+**Test scenarios:**
+- Happy path — Commander has 5 cards in our top-30, EDHREC covers 3
+  of them, remaining 2 each have `N_rules = 3` firing → plausibility
+  True for both → `rate = 2/30 ≈ 0.0667`.
+- Happy path — Commander has 1 hidden card with `N_rules = 1` but
+  contribution > per-commander median → plausibility True via the OR
+  leg → `rate = 1/30`.
+- Edge case — Commander's hidden set is empty (EDHREC covers all of
+  our top-30) → `rate = 0.0`, entry exists with empty `hidden_cards`.
+- Edge case — Commander has no EDHREC top-30 data at all (caller
+  passes `edhrec_top_30=None`) → function returns `None`; aggregator
+  records commander under `skipped_commanders`.
+- Edge case — Commander has exactly one candidate in our top-30 with
+  any contribution → median-based branch short-circuits cleanly; no
+  ZeroDivisionError.
+- Edge case — All tensor contributions equal zero → N_rules_firing
+  requires `> 0`; falls through to median branch which is also 0;
+  plausibility False for every candidate.
+- Error path — `our_top_30` has duplicates → `ValueError("our_top_30
+  must be unique")` before computation.
+- Integration — Running the same inputs twice returns identical
+  floats (determinism for R7).
+
+**Verification:**
+- Pytest green on the new test file.
+- Running the function twice on identical inputs yields identical
+  dataclass instances (deep equality).
+- Module exports and constants match what Units 2-5 import against.
+
+- [ ] **Unit 2: Fixture integration — compute metric at `build_fixture`, persist in legacy dict**
+
+**Goal:** `build_fixture` opens the EDHREC DB, computes per-commander
+`hidden_gem_hit_rate` + `hidden_cards` while the tensor sink is
+writing rows, and stores the results in `FixtureEntry.legacy` under
+new keys so the pinned JSON carries the baseline.
+
+**Requirements:** R1, R8.
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `src/mtg_synergy_graph/bench/fixture.py`
+- Modify: `tests/bench/test_fixture.py` (or create if absent — check
+  existing pattern)
+- Test: `tests/bench/test_fixture_hidden_gems.py` (new)
+
+**Approach:**
+- Extend `build_fixture(conn, commanders, existing=None,
+  tensor_writer=None, edhrec_conn=None)`. `edhrec_conn` defaults to
+  `None`; callers that want the metric pass one.
+- Inside the per-commander loop, collect tensor rows for that
+  commander (the tensor writer already batches; extract via
+  `score_commander`'s returned `_rows` tuple, currently discarded)
+  and fetch EDHREC top-30 via `_fetch_edhrec_sections` + sort by
+  synergy desc.
+- Call `hidden_gem_hit_rate_for_commander` from Unit 1. Store
+  `legacy["hidden_gem_hit_rate"] = entry.rate`,
+  `legacy["hidden_cards"] = list(entry.hidden_cards)`.
+- When `edhrec_conn is None` or EDHREC has no rows: skip — leave the
+  legacy keys unset (not `None`, not `0`). Unit 3's aggregator filters
+  on key presence. This way old fixtures without the keys behave the
+  same as skipped commanders.
+- EDHREC top-30 derivation: query
+  `SELECT card_name FROM edhrec_card_synergy WHERE commander_slug = ?
+  AND section = 'High Synergy Cards' ORDER BY synergy DESC LIMIT 30`.
+  Same shape as `validate.py:_run_one` but at top-30 instead of
+  top-10.
+- `handle_repin` opens the EDHREC DB (path from `--edhrec-db` if
+  added, otherwise env var, otherwise reuse existing discovery
+  pattern from `validate.py`) and passes it to `build_fixture`.
+
+**Patterns to follow:**
+- `src/mtg_synergy_graph/validate.py:_run_one` — the working pattern
+  for opening EDHREC, fetching sections, extracting top-N by synergy.
+- `src/mtg_synergy_graph/bench/fixture.py:score_commander` — returned
+  `_rows` gives us the tensor rows without re-scoring; use them.
+
+**Test scenarios:**
+- Happy path — `build_fixture` with EDHREC conn populates
+  `legacy["hidden_gem_hit_rate"]` on every commander with EDHREC
+  data. A fixture built without EDHREC conn produces entries with
+  the legacy dict empty of gem keys (backwards compatible).
+- Edge case — Commander with no rows in `edhrec_card_synergy` →
+  `legacy["hidden_gem_hit_rate"]` key absent; aggregator skips.
+- Edge case — EDHREC section exists but has 0 rows in "High Synergy
+  Cards" → EDHREC top-30 is empty set → every our-top-30 card is
+  "hidden"; plausibility gate decides.
+- Integration — Build fixture once, reload from disk, compare: values
+  round-trip through the legacy dict intact. Covers R8 (pinned
+  baseline).
+- Integration — Running `build_fixture` twice on the same DB + same
+  commanders produces byte-identical `hidden_gem_hit_rate` floats
+  (determinism for R7).
+
+**Verification:**
+- Running `bench.py audit --repin --yes` on the 100-commander golden
+  set produces a fixture with gem fields populated on the
+  EDHREC-covered commanders.
+- `bench.py audit --expect-identity` on the new fixture stays PASS
+  (identity check is over `scores` dict, gem fields don't affect it).
+
+- [ ] **Unit 3: Audit report integration — aggregate, delta, warning**
+
+**Goal:** `bench.py audit` computes aggregate `hidden_gem_hit_rate`
+(live) and delta vs pinned; renders one line in Markdown + JSON
+output + `_print_summary`; prints an FR4 stderr warning when
+`delta < -_HIDDEN_GEM_WARN_THRESHOLD`.
+
+**Requirements:** R3, R4.
+
+**Dependencies:** Unit 2.
+
+**Files:**
+- Modify: `src/mtg_synergy_graph/bench/report.py`
+- Modify: `src/mtg_synergy_graph/bench/audit.py`
+- Test: `tests/bench/test_report_hidden_gems.py` (new)
+- Test: `tests/bench/test_audit_warning.py` (new)
+
+**Approach:**
+- `AuditReport` gains: `aggregate_hidden_gem_hit_rate: float | None`,
+  `pinned_hidden_gem_hit_rate: float | None`,
+  `hidden_gem_hit_rate_delta: float | None`,
+  `hidden_gem_warning: bool`,
+  `commanders_with_edhrec: int`.
+- Aggregation helper in `report.py` reads `legacy["hidden_gem_hit_rate"]`
+  across entries, skips missing keys, returns mean + count. Same for
+  pinned side; delta is live − pinned (both `None` → delta `None`).
+- `hidden_gem_warning = (delta is not None and delta <
+  -_HIDDEN_GEM_WARN_THRESHOLD)`.
+- `_render_markdown` appends after the existing `**Aggregate score Δ:**`
+  line: `**hidden_gem_hit_rate:** \`0.1467 (Δ -0.0034, 97 cmdrs with
+  EDHREC)\``. Emits `—` when `None`.
+- `_as_json_dict` adds four keys: `aggregate_hidden_gem_hit_rate`,
+  `hidden_gem_hit_rate_delta`, `hidden_gem_warning`,
+  `commanders_with_edhrec`.
+- `_print_summary` in audit.py appends
+  `gem_Δ=-0.0034 WARN` (or `gem_Δ=0.0001`) to the single-line summary.
+- FR4 warning printed separately to stderr when `hidden_gem_warning`:
+  ```
+  ⚠ hidden_gem_hit_rate dropped 0.034 on this change (from 0.147 to 0.113).
+    Inspect: `bench.py audit --inspect-gems` to see which gems were lost.
+  ```
+  Printed before `_print_summary` so it's the first thing the user
+  sees.
+
+**Patterns to follow:**
+- `src/mtg_synergy_graph/bench/report.py:_render_markdown` — how
+  other aggregate lines are formatted.
+- `src/mtg_synergy_graph/bench/audit.py:_print_summary` — the
+  single-line stderr pattern.
+
+**Test scenarios:**
+- Happy path — Pinned + live both have gem data → aggregate, delta
+  computed, markdown contains the new line with the expected number.
+- Happy path — Pinned + live both clean → `hidden_gem_warning` False;
+  no stderr warning printed.
+- Edge case — Delta = -0.019 (just above threshold) → no warning
+  (strictly less-than).
+- Edge case — Delta = -0.02 exactly → no warning (strict inequality).
+- Edge case — Delta = -0.021 → warning printed; exact wording matches
+  the FR4 spec.
+- Edge case — Live has gem data but pinned does not (old pin) →
+  delta = `None`; markdown shows `Δ —`; no warning.
+- Edge case — No commanders have EDHREC data → aggregate = `None`;
+  markdown shows `—`; `commanders_with_edhrec = 0`.
+- Integration — `handle_audit` writes the same content to
+  `.audit/last.md` and stdout; the warning fires exactly once (not
+  twice because of the two sinks).
+- Integration — JSON output is valid (parseable) and contains all
+  four new keys.
+
+**Verification:**
+- `bench.py audit` on the 100-cmdr set shows the new line.
+- When the live tree is unchanged, delta = 0.0 and no warning fires.
+- Running with `--format json` produces valid JSON containing the
+  four new keys.
+
+- [ ] **Unit 4: `--inspect-gems` CLI handler**
+
+**Goal:** New mode `bench.py audit --inspect-gems` that produces a
+per-commander table of `(commander, Δ, lost_gems, gained_gems)` by
+diffing pinned vs live `hidden_cards` sets. Respects `--commander`
+filter, `--format md/json`, `--output`.
+
+**Requirements:** R5, R9.
+
+**Dependencies:** Unit 3.
+
+**Files:**
+- Modify: `src/mtg_synergy_graph/bench/cli.py` (add mode flag,
+  register handler)
+- Modify: `src/mtg_synergy_graph/bench/handlers.py` (new
+  `handle_inspect_gems`)
+- Modify: `src/mtg_synergy_graph/bench/__init__.py` (register)
+- Test: `tests/bench/test_handle_inspect_gems.py` (new)
+
+**Approach:**
+- Add `--inspect-gems` to the existing mutex mode group in `cli.py`
+  (sibling of `--inspect`, `--collinearity`, `--unknowns`).
+- `handle_inspect_gems(args)` loads pinned fixture (from `--fixture`)
+  and re-scores live via `build_fixture` to get live gem data.
+- Row = `(commander, rate_delta, lost: tuple[str, ...], gained:
+  tuple[str, ...])`. `lost = pinned.hidden_cards - live.hidden_cards`,
+  `gained = live.hidden_cards - pinned.hidden_cards`.
+- Sort by `abs(rate_delta)` desc; truncate by `--limit` (default 50).
+- Markdown output is a table matching FR5 shape:
+  ```
+  | commander | Δ | lost gems | gained gems |
+  |-----------|--:|-----------|-------------|
+  ```
+  JSON output is a list of the row dataclass + aggregate summary on
+  top.
+- `--commander NAME` filter runs before sort and truncation.
+
+**Patterns to follow:**
+- `src/mtg_synergy_graph/bench/handlers.py:handle_inspect` — argparse
+  extraction + `--format md/json` branch.
+- `src/mtg_synergy_graph/bench/handlers.py:handle_unknowns` — the
+  most recently-added handler; same skeleton shape.
+
+**Test scenarios:**
+- Happy path — Synthetic pinned + live with known deltas → output
+  lists commanders in correct order; lost / gained cards match.
+- Edge case — Empty pinned (no gem data) → handler exits 0 with
+  "no baseline gems to compare" message.
+- Edge case — `--commander "NameNotInFixture"` → handler exits 2 with
+  actionable error.
+- Edge case — `--limit 0` → empty table rendered (no rows).
+- Error path — Fixture missing → exits 2 with the same message as
+  `handle_audit`.
+- Integration — CLI dispatch routes `--inspect-gems` through the
+  `register()` table (matches the pattern other modes use).
+- Integration — `--format json` output parseable and contains both
+  per-row data and aggregate delta.
+
+**Verification:**
+- `bench.py audit --inspect-gems` on a mutated tree (scored once,
+  then a weight tweaked) shows non-zero rows and the lost/gained
+  cards are believable on manual inspection.
+- `bench.py audit --inspect-gems --commander "Korvold, Fae-Cursed King"`
+  emits one row or a "no delta" line.
+
+- [ ] **Unit 5: `.audit/history.csv` persistence + `--trend hidden_gems` handler**
+
+**Goal:** Every successful `bench.py audit` run appends one row to
+`.audit/history.csv`; new `--trend hidden_gems` mode reads the file
+and prints the last N entries as CSV (default N=20).
+
+**Requirements:** R3 (the `--trend` subcommand portion).
+
+**Dependencies:** Unit 3 (needs `hidden_gem_hit_rate_delta` to
+already be in `AuditReport`).
+
+**Files:**
+- Modify: `src/mtg_synergy_graph/bench/audit.py` (append to history)
+- Create: `src/mtg_synergy_graph/bench/history.py` (reader + writer)
+- Modify: `src/mtg_synergy_graph/bench/cli.py` (add `--trend` flag)
+- Modify: `src/mtg_synergy_graph/bench/handlers.py` (new
+  `handle_trend_hidden_gems`)
+- Modify: `src/mtg_synergy_graph/bench/__init__.py` (register)
+- Test: `tests/bench/test_history.py` (new)
+- Test: `tests/bench/test_handle_trend_hidden_gems.py` (new)
+
+**Approach:**
+- CSV schema:
+  ```
+  timestamp,commit_sha,config_hash,aggregate_score_delta,
+  hidden_gem_hit_rate,hidden_gem_hit_rate_delta,
+  commanders_compared,commanders_with_edhrec,verdict
+  ```
+  Header written on first run; subsequent runs append only.
+- `history.py` exposes: `append_run(report, path=".audit/history.csv")`,
+  `read_last(n, path)` returning dataclass rows. `commit_sha` read
+  via `git rev-parse HEAD`; on failure (not a git checkout), write
+  an empty string so the row shape is stable.
+- `audit.py` calls `append_run(report)` after
+  `_write_default_output`; failure to write history logs a warning
+  to stderr but does NOT fail the audit (the primary output is the
+  rendered report).
+- `--trend hidden_gems` flag in the mutex mode group, takes optional
+  `--trend-n` (default 20). Handler reads the last N rows + prints
+  either CSV (default) or a Markdown table if `--format md`.
+- Rows omit the header when `--format md` is chosen; full CSV
+  (including header) when `--format csv` (or default). JSON format
+  also supported for symmetry with the other handlers.
+
+**Patterns to follow:**
+- `src/mtg_synergy_graph/bench/audit.py:_write_default_output` — the
+  `.audit/` directory convention.
+- Standard-library `csv` module (no third-party dep).
+
+**Test scenarios:**
+- Happy path — `append_run` on an empty `.audit/` creates the file
+  with header + one data row. Second append writes only the row.
+- Happy path — `read_last(3)` on a 10-row file returns the 3 newest.
+- Edge case — Row written outside a git checkout → `commit_sha` is
+  empty, row still written.
+- Edge case — `commanders_with_edhrec = 0` → `hidden_gem_hit_rate`
+  column is empty string, not a spurious 0.
+- Edge case — `--trend-n` larger than the file length → returns all
+  rows; does not pad.
+- Error path — Corrupted CSV (malformed line) → `read_last` skips
+  the bad row with a stderr warning and returns the rest.
+- Error path — `--trend hidden_gems` on a fresh checkout with no
+  `.audit/history.csv` → exits 0 with "no history yet — run
+  `bench.py audit` first" message.
+- Integration — `bench.py audit` followed by `bench.py audit --trend
+  hidden_gems` shows the just-appended row.
+
+**Verification:**
+- Running `bench.py audit` three times on the same tree produces three
+  CSV rows with identical `hidden_gem_hit_rate` (covers R7
+  determinism).
+- `bench.py audit --trend hidden_gems --trend-n 5` prints the last
+  five rows.
+
+- [ ] **Unit 6: Documentation, escalation-path comment, CLAUDE.md**
+
+**Goal:** Document the metric, the warning threshold, the escalation
+path, and the memory-note connection. No code changes beyond a
+prominent in-module docstring block.
+
+**Requirements:** R6.
+
+**Dependencies:** Units 1-5 landed.
+
+**Files:**
+- Modify: `src/mtg_synergy_graph/bench/hidden_gems.py` (prominent
+  docstring block near `_HIDDEN_GEM_WARN_THRESHOLD`)
+- Modify: `CLAUDE.md` (new subsection under Scoring Architecture or
+  adjacent to `bench.py` docs)
+- Modify: `docs/RULE_HISTORY.md` (add landing entry under 2026-04-22)
+- Create: `memory/feedback_hidden_gem_metric.md` (new memory note)
+- Modify: `memory/MEMORY.md` (add the reference line)
+
+**Approach:**
+- Docstring block lists FR6 promotion criteria:
+  1. Tracked for ≥ 20 commits.
+  2. Human-confirmed that metric drops correlate with subjectively-
+     bad scoring changes.
+  3. False-positive rate ≤ 10% (at most 1 in 10 recent accepted
+     commits triggered a spurious warning).
+  4. Promotion is itself a new `ce-brainstorm` + `ce-plan` cycle —
+     not a silent config change.
+- CLAUDE.md addition: one paragraph under "Scoring Architecture" (or
+  near the `bench.py audit` command table) introducing the metric +
+  its tracking-only status + pointer to the docstring for the
+  escalation path.
+- `docs/RULE_HISTORY.md` entry documents the landing: purpose,
+  threshold, link to brainstorm + plan.
+- Memory note `feedback_hidden_gem_metric.md` — captures: "we now
+  track hidden_gem_hit_rate alongside NDCG; metric is advisory at
+  MVP; escalation path exists but requires a separate brainstorm."
+  Same shape as existing feedback notes.
+
+**Test expectation:** none — pure documentation changes.
+
+**Verification:**
+- `grep -q _HIDDEN_GEM_WARN_THRESHOLD` in `hidden_gems.py` returns a
+  docstring block with the four promotion criteria.
+- `CLAUDE.md` rendering shows the new subsection.
+- `memory/MEMORY.md` has the new reference line.
+
+## System-Wide Impact
+
+- **Interaction graph:** `build_fixture` gains a new dependency on
+  the EDHREC DB connection when gem metric is desired. Callers that
+  pass `None` get the old behavior (no gem fields). Existing
+  `bench.py audit --expect-identity` is unaffected — identity check
+  is over `scores` dict only.
+- **Error propagation:** A missing or malformed EDHREC DB should not
+  crash `build_fixture` — it should skip the metric and log. Warning
+  failures in history write do not break audits.
+- **State lifecycle risks:** `.audit/history.csv` grows unbounded
+  over time. Acceptable at MVP (one row per audit, ~200 bytes,
+  1000 runs ≈ 200KB). Pruning is a future follow-up if it becomes a
+  problem.
+- **API surface parity:** `--trend`, `--inspect-gems` are new mode
+  flags in the audit subcommand. They slot into the existing mutex
+  group; no new subcommand.
+- **Integration coverage:** Unit 2 and Unit 3 tests exercise
+  `build_fixture` → `build_report` → markdown/JSON output with real
+  EDHREC data (not mocked) to ensure the pipeline works end-to-end.
+- **Unchanged invariants:**
+  - Pinned fixture schema version (no bump — additive via `legacy`
+    dict).
+  - `rule_contributions` tensor schema (read-only from here).
+  - `bench.py audit --expect-identity` semantics (gem fields don't
+    affect score identity).
+  - NDCG@30 histogram buckets and verdict rollup (untouched; stays
+    the primary commit gate).
+  - Pre-commit `bench-audit` hook (no threshold change; FR4 warning
+    does not fail the hook because warnings print to stderr and the
+    hook's exit code is from `bench.py audit` itself).
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Metric is noisy — small scoring changes produce large gem-rate swings, triggering warning fatigue. | Threshold starts permissive (0.02). FR6 escalation path requires validation before any gating. If noise proves unacceptable, raise threshold or redefine plausibility — both are one-liners. |
+| Plausibility gate is too loose — flags random cards as "gems." | Tests Unit 1 + post-landing manual retrospective (Success Criterion 3) validate the gate on real data. If loose, tighten `N_rules_firing >= 3` or scale median threshold. |
+| Plausibility gate is too tight — zero hidden gems for every commander. | Aggregate of 0 is valid and surfaces the issue immediately. Same mitigation as above, reversed. |
+| EDHREC DB path discovery inconsistent between `validate.py` and `build_fixture`. | Unit 2 reuses the same discovery pattern (pass `edhrec_conn` explicitly); no new path-guessing code. |
+| `.audit/history.csv` data is lost on fresh checkouts. | Documented as acceptable at MVP; file is regenerable on future runs. Git-tracking the file is rejected — would pollute PRs and be noisy in code review. |
+| Metric tied to a specific `config_hash`; a repin changes baseline in a way hidden from humans. | `--trend hidden_gems` shows `config_hash` per row so the user can see when the baseline shifted. |
+
+## Documentation / Operational Notes
+
+- Update `CLAUDE.md` Common Commands section with the two new
+  subcommands (`--inspect-gems`, `--trend hidden_gems`).
+- `.audit/history.csv` is automatically gitignored via the existing
+  `.audit/` ignore.
+- No new env vars, no new config file.
+- Memory note added per Unit 6.
+
+## Success Criteria
+
+1. **Deterministic metric** — three runs of `bench.py audit` on an
+   unchanged tree produce identical `hidden_gem_hit_rate` values.
+   Verified by Unit 1 + Unit 2 tests.
+2. **Baseline pinned** — after `bench.py audit --repin --yes`, the
+   fixture JSON contains `legacy.hidden_gem_hit_rate` for every
+   commander with EDHREC data. Verified by Unit 2 integration test.
+3. **Retrospective discrimination (manual, post-landing)** — check
+   out one of these previously-reverted experiments and run `bench.py
+   audit`, confirming `hidden_gem_hit_rate_delta` is ≤ 0:
+   - 2026-04-18 broad `gy_retrieval` rule (reverted; reanimator
+     hi-syn gap — see `memory/project_reanimator_hisyn_gap.md`)
+   - The deck-hint-match experiment (reverted; see
+     `memory/feedback_edhrec_not_goal.md` context)
+   - Survivor 3's BM25F feat branch (`feat/idf-reforms-bm25f-
+     conditional`)
+   At least one of the three should retrospectively flag non-
+   positively. Document the finding in a follow-up memory note.
+4. **Low false-positive rate** — Over 10 recent accepted commits
+   replayed via `--trend hidden_gems`, at most 1 triggers a spurious
+   warning (delta < -0.02 despite the commit being accepted). If more
+   than 1, tune the threshold before promotion.
+5. **Explainability** — `bench.py audit --inspect-gems --commander
+   "Korvold, Fae-Cursed King"` emits a human-readable lost/gained
+   list. A human can sanity-check at least 3 commanders this way.
+
+## Alternative Approaches Considered
+
+- **Gate commits on `hidden_gem_hit_rate` at MVP.** Rejected by
+  origin-doc non-goal 2 — the metric isn't validated yet, gating
+  prematurely would block legitimate changes.
+- **Replace NDCG with hidden-gems.** Rejected by origin-doc non-goal
+  1 — paradigm shift is too risky without validation.
+- **Learned plausibility classifier (semantic similarity, learned
+  weights).** Rejected by origin-doc non-goal 3. Mechanical-only
+  gate keeps the project's no-ML discipline intact.
+- **Make EDHREC-agreement a first-class metric alongside.** Skipped:
+  the existing `hi_syn_gain` / `hi_syn_loss` histogram buckets
+  already capture that signal; adding a parallel metric bloats the
+  report without new information.
+- **Store history in SQLite instead of CSV.** Rejected for MVP: CSV
+  is git-diffable if a user wants to commit a snapshot, human-
+  readable, and needs no schema. Revisit if history-query complexity
+  grows.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-21-useful-disagreement-requirements.md](../brainstorms/2026-04-21-useful-disagreement-requirements.md)
+- **Prerequisite plan:** [docs/plans/2026-04-22-001-feat-unified-eval-harness-plan.md](2026-04-22-001-feat-unified-eval-harness-plan.md) — rule-contribution tensor, `bench.py` CLI surface.
+- **Related plan:** [docs/plans/2026-04-22-002-feat-typed-port-graph-substrate-plan.md](2026-04-22-002-feat-typed-port-graph-substrate-plan.md) — just landed; orthogonal but tensor-consuming.
+- **Memory alignment:** `memory/feedback_edhrec_not_goal.md`, `memory/feedback_edhrec_hivemind.md`, `memory/feedback_edhrec_synergy_formula.md`, `memory/feedback_audit_every_change.md`.
+- **Memory context for retrospective validation:** `memory/project_reanimator_hisyn_gap.md`, `memory/feedback_strategy_mapping.md`.

--- a/src/mtg_synergy_graph/bench/__init__.py
+++ b/src/mtg_synergy_graph/bench/__init__.py
@@ -28,6 +28,7 @@ from mtg_synergy_graph.bench.handlers import (
     handle_inspect_gems,
     handle_repin,
     handle_rule,
+    handle_trend_hidden_gems,
     handle_unknowns,
 )
 from mtg_synergy_graph.bench.histogram import Bucket, Histogram, Verdict
@@ -51,6 +52,8 @@ _cli.register("unknowns", handle_unknowns)
 # Hidden-gem plan Unit 4 — per-commander diff of hidden-gem sets
 # between pinned and live.
 _cli.register("inspect_gems", handle_inspect_gems)
+# Hidden-gem plan Unit 5 — print last N rows of .audit/history.csv.
+_cli.register("trend", handle_trend_hidden_gems)
 
 __all__ = [
     "AuditReport",

--- a/src/mtg_synergy_graph/bench/__init__.py
+++ b/src/mtg_synergy_graph/bench/__init__.py
@@ -25,6 +25,7 @@ from mtg_synergy_graph.bench.handlers import (
     handle_collinearity,
     handle_expect_identity,
     handle_inspect,
+    handle_inspect_gems,
     handle_repin,
     handle_rule,
     handle_unknowns,
@@ -47,6 +48,9 @@ _cli.register("inspect", handle_inspect)
 _cli.register("collinearity", handle_collinearity)
 # Plan 003 Unit 6 — UNKNOWN port_nodes reporter.
 _cli.register("unknowns", handle_unknowns)
+# Hidden-gem plan Unit 4 — per-commander diff of hidden-gem sets
+# between pinned and live.
+_cli.register("inspect_gems", handle_inspect_gems)
 
 __all__ = [
     "AuditReport",

--- a/src/mtg_synergy_graph/bench/_stubs.py
+++ b/src/mtg_synergy_graph/bench/_stubs.py
@@ -43,3 +43,7 @@ def collinearity_stub(args: argparse.Namespace) -> int:
 
 def unknowns_stub(args: argparse.Namespace) -> int:
     _unimplemented("bench.py audit --unknowns")
+
+
+def inspect_gems_stub(args: argparse.Namespace) -> int:
+    _unimplemented("bench.py audit --inspect-gems")

--- a/src/mtg_synergy_graph/bench/_stubs.py
+++ b/src/mtg_synergy_graph/bench/_stubs.py
@@ -47,3 +47,7 @@ def unknowns_stub(args: argparse.Namespace) -> int:
 
 def inspect_gems_stub(args: argparse.Namespace) -> int:
     _unimplemented("bench.py audit --inspect-gems")
+
+
+def trend_stub(args: argparse.Namespace) -> int:
+    _unimplemented("bench.py audit --trend")

--- a/src/mtg_synergy_graph/bench/audit.py
+++ b/src/mtg_synergy_graph/bench/audit.py
@@ -13,6 +13,7 @@ import argparse
 import sys
 from pathlib import Path
 
+from mtg_synergy_graph.bench import history as bench_history
 from mtg_synergy_graph.bench.fixture import (
     PinnedFixture,
     build_fixture,
@@ -74,6 +75,21 @@ def handle_audit(args: argparse.Namespace) -> int:
 
     _print_hidden_gem_warning(report)
     _print_summary(report)
+
+    # Append a row to ``.audit/history.csv`` so ``bench.py audit --trend
+    # hidden_gems`` can replay deltas over time. ``append_run`` swallows
+    # I/O errors internally; the outer try/except is belt-and-suspenders
+    # in case a future refactor lets an exception leak — a history-write
+    # failure must never turn a PASS audit into a failure.
+    history_path = getattr(args, "history", ".audit/history.csv")
+    try:
+        bench_history.append_run(report, path=history_path)
+    except Exception as exc:  # pragma: no cover — defensive
+        print(
+            f"bench.py audit: warning: unexpected error appending history row: {exc}",
+            file=sys.stderr,
+        )
+
     return 0 if report.is_identical else 1
 
 

--- a/src/mtg_synergy_graph/bench/audit.py
+++ b/src/mtg_synergy_graph/bench/audit.py
@@ -129,11 +129,24 @@ def handle_audit(args: argparse.Namespace) -> int:
 
 def _write_default_output(rendered: str, fixture_path: Path, fmt: str) -> None:
     """Also persist the rendered report to `.audit/last.{md,json}` for
-    pre-commit-hook consumption (Unit 7)."""
+    pre-commit-hook consumption (Unit 7).
+
+    A read-only ``.audit/`` (or any other OSError during mkdir / write)
+    must NOT turn a PASS audit into a failure — the primary output
+    has already been printed to stdout. Degrade to a stderr warning
+    and return.
+    """
     default_dir = Path(".audit")
-    default_dir.mkdir(exist_ok=True)
     suffix = "json" if fmt == "json" else "md"
-    (default_dir / f"last.{suffix}").write_text(rendered, encoding="utf-8")
+    target = default_dir / f"last.{suffix}"
+    try:
+        default_dir.mkdir(exist_ok=True)
+        target.write_text(rendered, encoding="utf-8")
+    except OSError as exc:
+        print(
+            f"bench.py audit: warning: could not write {target}: {exc.__class__.__name__}: {exc}",
+            file=sys.stderr,
+        )
 
 
 def _print_hidden_gem_warning(report: AuditReport) -> None:

--- a/src/mtg_synergy_graph/bench/audit.py
+++ b/src/mtg_synergy_graph/bench/audit.py
@@ -10,6 +10,7 @@ ProcessPoolExecutor without changing the reporting contract.
 from __future__ import annotations
 
 import argparse
+import sqlite3
 import sys
 from pathlib import Path
 
@@ -22,16 +23,49 @@ from mtg_synergy_graph.bench.report import AuditReport, build_report
 from mtg_synergy_graph.db import open_db
 
 
-def run_audit(db_path: str | Path, fixture_path: str | Path) -> AuditReport:
-    """Load fixture, re-score, return an aggregated AuditReport."""
+def run_audit(
+    db_path: str | Path,
+    fixture_path: str | Path,
+    edhrec_db: str | Path | None = None,
+) -> AuditReport:
+    """Load fixture, re-score, return an aggregated AuditReport.
+
+    When ``edhrec_db`` is provided and exists, the EDHREC DB is opened
+    and passed to ``build_fixture`` so per-commander
+    ``hidden_gem_hit_rate`` gets computed on the live side. This makes
+    the aggregate hidden-gem metric and its FR3/FR4 delta+warning
+    functional in the normal audit path — without it, the legacy path
+    produces gem-less live entries and the delta is always ``—``.
+
+    If ``edhrec_db`` is ``None`` or the path doesn't exist, we skip the
+    open silently (for ``None``) or emit a stderr warning (for a
+    non-existent explicit path) and build the fixture without an
+    ``edhrec_conn`` — the metric is then unavailable but the audit
+    still completes normally.
+    """
     fixture_path = Path(fixture_path)
     pinned = PinnedFixture.load(fixture_path)
     commanders = [e.commander for e in pinned.entries]
+
+    edhrec_conn: sqlite3.Connection | None = None
+    if edhrec_db is not None:
+        edhrec_path = Path(edhrec_db)
+        if edhrec_path.exists():
+            edhrec_conn = sqlite3.connect(edhrec_path)
+            edhrec_conn.row_factory = sqlite3.Row
+        else:
+            print(
+                f"bench.py audit: warning: edhrec_db {edhrec_path} not found — hidden_gem_hit_rate will be unavailable",
+                file=sys.stderr,
+            )
+
     conn = open_db(db_path)
     try:
-        live = build_fixture(conn, commanders)
+        live = build_fixture(conn, commanders, edhrec_conn=edhrec_conn)
     finally:
         conn.close()
+        if edhrec_conn is not None:
+            edhrec_conn.close()
     return build_report(str(fixture_path), pinned, live)
 
 
@@ -56,7 +90,7 @@ def handle_audit(args: argparse.Namespace) -> int:
         print(f"error: fixture {fixture_path} has no entries.", file=sys.stderr)
         return 2
 
-    report = run_audit(args.db, fixture_path)
+    report = run_audit(args.db, fixture_path, edhrec_db=getattr(args, "edhrec_db", None))
 
     rendered = report.to_json() if args.format == "json" else report.to_markdown()
 

--- a/src/mtg_synergy_graph/bench/audit.py
+++ b/src/mtg_synergy_graph/bench/audit.py
@@ -72,6 +72,7 @@ def handle_audit(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
 
+    _print_hidden_gem_warning(report)
     _print_summary(report)
     return 0 if report.is_identical else 1
 
@@ -85,15 +86,52 @@ def _write_default_output(rendered: str, fixture_path: Path, fmt: str) -> None:
     (default_dir / f"last.{suffix}").write_text(rendered, encoding="utf-8")
 
 
+def _print_hidden_gem_warning(report: AuditReport) -> None:
+    """FR4 warning: drop in aggregate ``hidden_gem_hit_rate`` exceeded threshold.
+
+    Printed to stderr once per audit run, before the single-line summary,
+    so it is the first thing the user sees. Advisory only — does not
+    affect the audit exit code.
+    """
+    if not report.hidden_gem_warning:
+        return
+    delta = report.hidden_gem_hit_rate_delta
+    pinned = report.pinned_hidden_gem_hit_rate
+    live = report.aggregate_hidden_gem_hit_rate
+    if delta is None or pinned is None or live is None:
+        # Defensive — ``hidden_gem_warning`` is only True when all three
+        # are set, but the type system can't prove it at this call site.
+        return
+    print(
+        f"⚠ hidden_gem_hit_rate dropped {abs(delta):.3f} on this change "
+        f"(from {pinned:.3f} to {live:.3f}).\n"
+        f"  Inspect: `bench.py audit --inspect-gems` to see which gems were lost.",
+        file=sys.stderr,
+    )
+
+
 def _print_summary(report: AuditReport) -> None:
     """One-line status summary to stderr (visible in pre-commit output)."""
     status = "PASS" if report.is_identical else "DRIFT"
+    gem_summary = _format_gem_summary(report)
     print(
         f"bench.py audit: {status} [{report.verdict.value}] "
         f"(Δ={report.aggregate_score_delta:+.4f}, "
         f"{report.commanders_compared} cmdrs, "
         f"{len(report.per_commander)} changed, "
         f"no_change={report.histogram.no_change}, "
-        f"shuffle_across={report.histogram.rank_shuffle_across_top30_boundary})",
+        f"shuffle_across={report.histogram.rank_shuffle_across_top30_boundary}, "
+        f"{gem_summary})",
         file=sys.stderr,
     )
+
+
+def _format_gem_summary(report: AuditReport) -> str:
+    """Render the trailing ``gem_Δ=...`` fragment for the audit summary."""
+    delta = report.hidden_gem_hit_rate_delta
+    if delta is None:
+        return "gem_Δ=—"
+    fragment = f"gem_Δ={delta:+.4f}"
+    if report.hidden_gem_warning:
+        fragment += " WARN"
+    return fragment

--- a/src/mtg_synergy_graph/bench/cli.py
+++ b/src/mtg_synergy_graph/bench/cli.py
@@ -61,7 +61,10 @@ Environment variables (hook mode):
   BENCH_DB       Override --db for the pre-commit hook. Default: data/synergy.db.
   BENCH_FIXTURE  Override --fixture for the pre-commit hook.
                  Default: tests/fixtures/golden_set_run.json.
-  BENCH_FORMAT   Override --format for the pre-commit hook. md | json. Default: md.
+  BENCH_FORMAT   Override --format for the pre-commit hook. md | json | csv.
+                 Default: md. The csv value is only meaningful for
+                 `--trend`; the pre-commit hook treats csv as "skip
+                 writing .audit/last.*" and emits a stderr warning.
 
 Exit codes:
   0  Clean / identical to pinned baseline.

--- a/src/mtg_synergy_graph/bench/cli.py
+++ b/src/mtg_synergy_graph/bench/cli.py
@@ -39,6 +39,9 @@ _HANDLERS: dict[str, Callable[[Namespace], int]] = {
     # Unit 6 of plan 003 — report UNKNOWN-kind port_nodes rows
     # ranked by distinct cards × EDHREC rank weight.
     "unknowns": _stubs.unknowns_stub,
+    # Unit 4 of hidden-gem metric plan — per-commander diff of
+    # hidden-gem sets between pinned and live.
+    "inspect_gems": _stubs.inspect_gems_stub,
 }
 
 
@@ -118,6 +121,12 @@ def _build_parser() -> argparse.ArgumentParser:
         "distinct_cards x EDHREC rank weight. Surfaces novel Forge "
         "port shapes that need canonical-vocabulary coverage.",
     )
+    mode.add_argument(
+        "--inspect-gems",
+        action="store_true",
+        help="Per-commander diff of hidden-gem sets between pinned and live. "
+        "Shows lost/gained gems. Reads pinned fixture + re-scores live.",
+    )
 
     # Shared flags.
     audit.add_argument(
@@ -160,6 +169,13 @@ def _build_parser() -> argparse.ArgumentParser:
         default="tests/fixtures/golden_set_run.json",
         help="Path to the pinned reference fixture. Default: tests/fixtures/golden_set_run.json.",
     )
+    audit.add_argument(
+        "--edhrec-db",
+        metavar="PATH",
+        default="data/tags.db",
+        help="Path to the EDHREC synergy DB. Used by --inspect-gems to "
+        "rebuild live hidden-gem data. Default: data/tags.db.",
+    )
 
     return parser
 
@@ -179,6 +195,8 @@ def _resolve_mode(args: Namespace) -> str:
         return "expect_identity"
     if args.unknowns:
         return "unknowns"
+    if args.inspect_gems:
+        return "inspect_gems"
     return "audit"
 
 

--- a/src/mtg_synergy_graph/bench/cli.py
+++ b/src/mtg_synergy_graph/bench/cli.py
@@ -42,6 +42,9 @@ _HANDLERS: dict[str, Callable[[Namespace], int]] = {
     # Unit 4 of hidden-gem metric plan — per-commander diff of
     # hidden-gem sets between pinned and live.
     "inspect_gems": _stubs.inspect_gems_stub,
+    # Unit 5 of hidden-gem metric plan — print last N rows of
+    # .audit/history.csv.
+    "trend": _stubs.trend_stub,
 }
 
 
@@ -127,6 +130,14 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Per-commander diff of hidden-gem sets between pinned and live. "
         "Shows lost/gained gems. Reads pinned fixture + re-scores live.",
     )
+    mode.add_argument(
+        "--trend",
+        choices=("hidden_gems",),
+        metavar="METRIC",
+        help="Print the last N rows of .audit/history.csv. MVP supports "
+        "METRIC=hidden_gems; argparse choices leaves room for additional "
+        "metrics without breaking users.",
+    )
 
     # Shared flags.
     audit.add_argument(
@@ -142,9 +153,22 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     audit.add_argument(
         "--format",
-        choices=("md", "json"),
-        default="md",
-        help="Output format. Default: md.",
+        choices=("md", "json", "csv"),
+        default=None,
+        help="Output format. Default: md (csv for --trend).",
+    )
+    audit.add_argument(
+        "--trend-n",
+        type=int,
+        default=20,
+        metavar="N",
+        help="Number of rows to show for --trend. Default: 20. Meaningful only with --trend.",
+    )
+    audit.add_argument(
+        "--history",
+        metavar="PATH",
+        default=".audit/history.csv",
+        help="Path to the append-only history CSV. Default: .audit/history.csv.",
     )
     audit.add_argument(
         "--output",
@@ -197,6 +221,8 @@ def _resolve_mode(args: Namespace) -> str:
         return "unknowns"
     if args.inspect_gems:
         return "inspect_gems"
+    if getattr(args, "trend", None) is not None:
+        return "trend"
     return "audit"
 
 
@@ -209,6 +235,23 @@ def main(argv: list[str] | None = None) -> int:
     # subcommands later (e.g. `compare-edhrec`) is straightforward.
     if args.subcommand != "audit":
         parser.error(f"unknown subcommand: {args.subcommand!r}")
+
+    # ``--format`` is stored as ``None`` when not passed so we can
+    # apply mode-specific defaults: ``--trend`` defaults to CSV (the
+    # history file is already CSV), every other mode defaults to ``md``
+    # (matches the legacy behaviour). Users still get ``md`` / ``json``
+    # / ``csv`` explicit overrides.
+    if getattr(args, "format", None) is None:
+        args.format = "csv" if getattr(args, "trend", None) is not None else "md"
+
+    # ``--trend-n`` only makes sense with ``--trend``. A lone
+    # ``--trend-n`` is harmless — warn on stderr rather than erroring so
+    # the user sees the flag had no effect.
+    if getattr(args, "trend", None) is None and getattr(args, "trend_n", 20) != 20:
+        print(
+            "bench.py audit: warning: --trend-n has no effect without --trend.",
+            file=sys.stderr,
+        )
 
     mode = _resolve_mode(args)
     handler = _HANDLERS[mode]

--- a/src/mtg_synergy_graph/bench/cli.py
+++ b/src/mtg_synergy_graph/bench/cli.py
@@ -28,6 +28,24 @@ from mtg_synergy_graph.bench import _stubs
 if TYPE_CHECKING:
     from argparse import Namespace
 
+
+def _nonneg_int(s: str) -> int:
+    """argparse type callable: parse non-negative ``int``, else raise.
+
+    Used for ``--trend-n`` so negative values (which silently produce
+    empty output) are rejected at the CLI boundary with an actionable
+    ``argparse.ArgumentTypeError``. Zero is accepted — a legitimate
+    "render the header only" request.
+    """
+    try:
+        value = int(s)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected an integer, got {s!r}") from exc
+    if value < 0:
+        raise argparse.ArgumentTypeError(f"must be >= 0, got {value}")
+    return value
+
+
 #: Handler table. Unit 2+ reassign these to real implementations.
 _HANDLERS: dict[str, Callable[[Namespace], int]] = {
     "audit": _stubs.audit_stub,
@@ -162,10 +180,10 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     audit.add_argument(
         "--trend-n",
-        type=int,
+        type=_nonneg_int,
         default=20,
         metavar="N",
-        help="Number of rows to show for --trend. Default: 20. Meaningful only with --trend.",
+        help="Number of rows to show for --trend. Default: 20. Must be >= 0. Meaningful only with --trend.",
     )
     audit.add_argument(
         "--history",
@@ -239,24 +257,39 @@ def main(argv: list[str] | None = None) -> int:
     if args.subcommand != "audit":
         parser.error(f"unknown subcommand: {args.subcommand!r}")
 
+    mode = _resolve_mode(args)
+
+    # ``--format csv`` is only meaningful for ``--trend`` (the history
+    # file itself is CSV). Silently falling back to markdown for every
+    # other mode hid user typos; reject it at the CLI boundary so the
+    # user sees the mismatch instead of wondering why the flag did
+    # nothing.
+    if getattr(args, "format", None) == "csv" and mode != "trend":
+        parser.error("--format csv is only supported with --trend")
+
+    # ``--commander`` filters a per-commander audit; it is meaningless
+    # for ``--trend`` (which renders raw history rows without a
+    # commander concept). Fail loudly instead of silently ignoring.
+    if getattr(args, "commander", None) is not None and mode == "trend":
+        parser.error("--commander is not supported with --trend")
+
     # ``--format`` is stored as ``None`` when not passed so we can
     # apply mode-specific defaults: ``--trend`` defaults to CSV (the
     # history file is already CSV), every other mode defaults to ``md``
     # (matches the legacy behaviour). Users still get ``md`` / ``json``
     # / ``csv`` explicit overrides.
     if getattr(args, "format", None) is None:
-        args.format = "csv" if getattr(args, "trend", None) is not None else "md"
+        args.format = "csv" if mode == "trend" else "md"
 
     # ``--trend-n`` only makes sense with ``--trend``. A lone
     # ``--trend-n`` is harmless — warn on stderr rather than erroring so
     # the user sees the flag had no effect.
-    if getattr(args, "trend", None) is None and getattr(args, "trend_n", 20) != 20:
+    if mode != "trend" and getattr(args, "trend_n", 20) != 20:
         print(
             "bench.py audit: warning: --trend-n has no effect without --trend.",
             file=sys.stderr,
         )
 
-    mode = _resolve_mode(args)
     handler = _HANDLERS[mode]
     return handler(args)
 

--- a/src/mtg_synergy_graph/bench/fixture.py
+++ b/src/mtg_synergy_graph/bench/fixture.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import sys
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -35,13 +36,13 @@ from typing import Any
 
 from mtg_synergy_graph.bench.hidden_gems import hidden_gem_hit_rate_for_commander
 from mtg_synergy_graph.bench.tensor import TensorWriter, compute_config_hash
+from mtg_synergy_graph.edhrec_helpers import fetch_high_synergy_top_n
 from mtg_synergy_graph.universal_scorer import (
     TensorRow,
     TensorSink,
     UniversalScore,
     score_all_universal,
 )
-from mtg_synergy_graph.validate import commander_to_slug
 
 #: Current fixture schema version. Bumped when the JSON layout changes
 #: in a non-backward-compatible way. Load refuses to read a newer
@@ -257,19 +258,24 @@ def _edhrec_top_30(
     the metric toward 1.0 on that commander and desensitizing the
     warning threshold.
 
-    Mirrors the SQL shape in ``validate.py:_run_one`` but widens the
-    window from 10 to 30.
+    Delegates to :func:`mtg_synergy_graph.edhrec_helpers.fetch_high_synergy_top_n`
+    for the shared SQL shape + section-name constant.
+
+    A corrupt/missing EDHREC DB or a dropped table surfaces as
+    ``sqlite3.DatabaseError`` (``sqlite3.OperationalError`` is a
+    subclass). We degrade to a stderr warning + ``None`` for the
+    affected commander so ``build_fixture`` can still process the
+    rest of the golden set — losing gem data for one commander must
+    not abort the whole audit.
     """
-    slug = commander_to_slug(commander)
-    rows = edhrec_conn.execute(
-        "SELECT card_name FROM edhrec_card_synergy "
-        "WHERE commander_slug = ? AND section = 'High Synergy Cards' "
-        "ORDER BY synergy DESC LIMIT 30",
-        (slug,),
-    ).fetchall()
-    if not rows:
+    try:
+        return fetch_high_synergy_top_n(edhrec_conn, commander, limit=30)
+    except sqlite3.DatabaseError as exc:
+        print(
+            f"bench.py audit: warning: edhrec query failed for commander {commander!r}: {exc}",
+            file=sys.stderr,
+        )
         return None
-    return {r[0] for r in rows}
 
 
 def build_fixture(

--- a/src/mtg_synergy_graph/bench/fixture.py
+++ b/src/mtg_synergy_graph/bench/fixture.py
@@ -248,32 +248,27 @@ def _edhrec_top_30(
 ) -> set[str] | None:
     """Fetch EDHREC's top-30 ``High Synergy Cards`` for a commander.
 
-    Returns ``None`` when the commander has NO rows in
-    ``edhrec_card_synergy`` at all (treated as "no EDHREC data →
-    skip" downstream). Returns an empty set when the commander has
-    rows but none in the ``High Synergy Cards`` section — in that
-    case the metric is still computed (every one of our top-30 is a
-    candidate hidden gem, subject to plausibility).
+    Returns ``None`` when the commander has no rows in the
+    ``'High Synergy Cards'`` section of ``edhrec_card_synergy``
+    (either because no rows exist for the commander at all, or because
+    rows exist only in other sections). Both cases are treated as "no
+    reference data → skip" downstream — returning an empty set instead
+    would make every one of our top-30 "hidden," spuriously inflating
+    the metric toward 1.0 on that commander and desensitizing the
+    warning threshold.
 
     Mirrors the SQL shape in ``validate.py:_run_one`` but widens the
     window from 10 to 30.
     """
     slug = commander_to_slug(commander)
-    # First check: does this commander have ANY EDHREC rows? If not,
-    # the caller treats this as "skip."
-    any_row = edhrec_conn.execute(
-        "SELECT 1 FROM edhrec_card_synergy WHERE commander_slug = ? LIMIT 1",
-        (slug,),
-    ).fetchone()
-    if any_row is None:
-        return None
-
     rows = edhrec_conn.execute(
         "SELECT card_name FROM edhrec_card_synergy "
         "WHERE commander_slug = ? AND section = 'High Synergy Cards' "
         "ORDER BY synergy DESC LIMIT 30",
         (slug,),
     ).fetchall()
+    if not rows:
+        return None
     return {r[0] for r in rows}
 
 

--- a/src/mtg_synergy_graph/bench/fixture.py
+++ b/src/mtg_synergy_graph/bench/fixture.py
@@ -33,6 +33,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from mtg_synergy_graph.bench.hidden_gems import hidden_gem_hit_rate_for_commander
 from mtg_synergy_graph.bench.tensor import TensorWriter, compute_config_hash
 from mtg_synergy_graph.universal_scorer import (
     TensorRow,
@@ -40,6 +41,7 @@ from mtg_synergy_graph.universal_scorer import (
     UniversalScore,
     score_all_universal,
 )
+from mtg_synergy_graph.validate import commander_to_slug
 
 #: Current fixture schema version. Bumped when the JSON layout changes
 #: in a non-backward-compatible way. Load refuses to read a newer
@@ -210,29 +212,69 @@ def score_commander(
     commander: str,
     tensor_sink: TensorSink | None = None,
     top_n: int = TOP_N_PINNED,
+    *,
+    capture_rows: bool = False,
 ) -> tuple[dict[str, float], list[TensorRow]]:
     """Score one commander, returning (top-N scores, tensor_rows).
 
     When a downstream ``tensor_sink`` is wired (typically a
     ``TensorWriter`` during ``--repin``) the returned row list is
-    empty — the sink is the single persistence path and the local
-    list would be redundant memory pressure on a ~5k-row per-commander
-    result. Tests that exercise the return list call without a sink.
+    empty by default — the sink is the single persistence path and the
+    local list would be redundant memory pressure on a ~5k-row per-
+    commander result. Tests that exercise the return list call without
+    a sink.
+
+    Set ``capture_rows=True`` to force local capture even when a sink
+    is provided. The dual-sink path is used by ``build_fixture`` when
+    it needs rows in memory for the hidden-gem metric while also
+    forwarding them to the tensor writer.
     """
     rows: list[TensorRow] = []
-    capture_locally = tensor_sink is None
+    capture_locally = tensor_sink is None or capture_rows
 
     def sink(row: TensorRow) -> None:
         if capture_locally:
             rows.append(row)
-        else:
-            # tensor_sink is not None — pyright narrows on the outer
-            # closure capture.
-            assert tensor_sink is not None
+        if tensor_sink is not None:
             tensor_sink(row)
 
     scores = score_all_universal(conn, [commander], tensor_sink=sink)
     return _top_n_scores(scores, top_n), rows
+
+
+def _edhrec_top_30(
+    edhrec_conn: sqlite3.Connection,
+    commander: str,
+) -> set[str] | None:
+    """Fetch EDHREC's top-30 ``High Synergy Cards`` for a commander.
+
+    Returns ``None`` when the commander has NO rows in
+    ``edhrec_card_synergy`` at all (treated as "no EDHREC data →
+    skip" downstream). Returns an empty set when the commander has
+    rows but none in the ``High Synergy Cards`` section — in that
+    case the metric is still computed (every one of our top-30 is a
+    candidate hidden gem, subject to plausibility).
+
+    Mirrors the SQL shape in ``validate.py:_run_one`` but widens the
+    window from 10 to 30.
+    """
+    slug = commander_to_slug(commander)
+    # First check: does this commander have ANY EDHREC rows? If not,
+    # the caller treats this as "skip."
+    any_row = edhrec_conn.execute(
+        "SELECT 1 FROM edhrec_card_synergy WHERE commander_slug = ? LIMIT 1",
+        (slug,),
+    ).fetchone()
+    if any_row is None:
+        return None
+
+    rows = edhrec_conn.execute(
+        "SELECT card_name FROM edhrec_card_synergy "
+        "WHERE commander_slug = ? AND section = 'High Synergy Cards' "
+        "ORDER BY synergy DESC LIMIT 30",
+        (slug,),
+    ).fetchall()
+    return {r[0] for r in rows}
 
 
 def build_fixture(
@@ -240,6 +282,7 @@ def build_fixture(
     commanders: list[str],
     existing: PinnedFixture | None = None,
     tensor_writer: TensorWriter | None = None,
+    edhrec_conn: sqlite3.Connection | None = None,
 ) -> PinnedFixture:
     """Score all commanders and produce a fresh fixture.
 
@@ -248,19 +291,41 @@ def build_fixture(
     Unit 6's ``--rule`` / ``--inspect`` / ``--collinearity`` queries
     have data to read afterward. ``--expect-identity`` omits the writer
     so it does not mutate DB state while auditing.
+
+    When ``edhrec_conn`` is provided, per-commander
+    ``hidden_gem_hit_rate`` + ``hidden_cards`` are computed at fixture
+    build time (Unit 2 of plan 003) and stored in
+    ``FixtureEntry.legacy`` under those two keys. Commanders with no
+    EDHREC rows have the keys ABSENT (not ``None``), so Unit 3's
+    aggregator filters on key presence. Callers without an
+    ``edhrec_conn`` get the old behavior — no gem fields written.
     """
     existing_by_cmdr = {e.commander: e for e in existing.entries} if existing is not None else {}
 
     entries: list[FixtureEntry] = []
     sink = tensor_writer.sink if tensor_writer is not None else None
+    capture_rows = edhrec_conn is not None
     for cmdr in commanders:
-        top_scores, _rows = score_commander(conn, cmdr, tensor_sink=sink)
-        legacy = existing_by_cmdr.get(cmdr)
+        top_scores, rows = score_commander(conn, cmdr, tensor_sink=sink, capture_rows=capture_rows)
+        legacy_source = existing_by_cmdr.get(cmdr)
+        legacy: dict[str, Any] = dict(legacy_source.legacy) if legacy_source is not None else {}
+
+        if edhrec_conn is not None:
+            edhrec_top_30 = _edhrec_top_30(edhrec_conn, cmdr)
+            # Our top-30 by score desc (ties broken by name) — take
+            # the leading slice of the already-sorted ``top_scores`` dict.
+            our_top_30 = list(top_scores.keys())[:30]
+            contributions = [(row.candidate, row.rule_id, row.contribution) for row in rows]
+            entry = hidden_gem_hit_rate_for_commander(cmdr, our_top_30, edhrec_top_30, contributions)
+            if entry is not None:
+                legacy["hidden_gem_hit_rate"] = entry.rate
+                legacy["hidden_cards"] = list(entry.hidden_cards)
+
         entries.append(
             FixtureEntry(
                 commander=cmdr,
                 scores=top_scores,
-                legacy=dict(legacy.legacy) if legacy is not None else {},
+                legacy=legacy,
             )
         )
 

--- a/src/mtg_synergy_graph/bench/handlers.py
+++ b/src/mtg_synergy_graph/bench/handlers.py
@@ -30,7 +30,7 @@ from mtg_synergy_graph.bench.fixture import (
     PinnedFixture,
     build_fixture,
 )
-from mtg_synergy_graph.bench.history import HistoryRow
+from mtg_synergy_graph.bench.history import CSV_FIELDS, HistoryRow
 from mtg_synergy_graph.bench.rule_ops import (
     inspect_rule,
     summarize_rule_contributions,
@@ -636,11 +636,15 @@ def handle_inspect_gems(args: argparse.Namespace) -> int:
         rows = [r for r in rows if r.commander == commander_filter]
     rows = _sort_deltas(rows)
 
+    # Compute the aggregate across the FULL matching set before
+    # truncation. If we truncated first, ``--limit 5`` would render an
+    # aggregate reflecting only the 5 most extreme movers, hiding the
+    # true direction of the change.
+    aggregate = _aggregate_rate_delta(rows)
+
     limit = getattr(args, "limit", 100)
     if limit is not None and limit >= 0:
         rows = rows[:limit]
-
-    aggregate = _aggregate_rate_delta(rows)
 
     fmt = getattr(args, "format", "md")
     if fmt == "json":
@@ -674,19 +678,6 @@ def handle_inspect_gems(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 
 
-_TREND_HEADER: tuple[str, ...] = (
-    "timestamp",
-    "commit_sha",
-    "config_hash",
-    "aggregate_score_delta",
-    "hidden_gem_hit_rate",
-    "hidden_gem_hit_rate_delta",
-    "commanders_compared",
-    "commanders_with_edhrec",
-    "verdict",
-)
-
-
 def _row_to_cells(row: HistoryRow) -> tuple[str, ...]:
     """Render one ``HistoryRow`` as string cells in the trend column order."""
 
@@ -712,7 +703,7 @@ def _render_trend_csv(rows: list[HistoryRow]) -> str:
 
     buf = _io.StringIO()
     writer = _csv.writer(buf)
-    writer.writerow(_TREND_HEADER)
+    writer.writerow(CSV_FIELDS)
     for row in rows:
         writer.writerow(_row_to_cells(row))
     return buf.getvalue()
@@ -720,8 +711,8 @@ def _render_trend_csv(rows: list[HistoryRow]) -> str:
 
 def _render_trend_md(rows: list[HistoryRow]) -> str:
     lines: list[str] = []
-    lines.append("| " + " | ".join(_TREND_HEADER) + " |")
-    lines.append("|" + "|".join(["---"] * len(_TREND_HEADER)) + "|")
+    lines.append("| " + " | ".join(CSV_FIELDS) + " |")
+    lines.append("|" + "|".join(["---"] * len(CSV_FIELDS)) + "|")
     for row in rows:
         cells = _row_to_cells(row)
         lines.append("| " + " | ".join(cells) + " |")

--- a/src/mtg_synergy_graph/bench/handlers.py
+++ b/src/mtg_synergy_graph/bench/handlers.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from mtg_synergy_graph.bench import history as bench_history
 from mtg_synergy_graph.bench.collinearity import (
     CollinearityReport,
     compute_collinearity,
@@ -29,6 +30,7 @@ from mtg_synergy_graph.bench.fixture import (
     PinnedFixture,
     build_fixture,
 )
+from mtg_synergy_graph.bench.history import HistoryRow
 from mtg_synergy_graph.bench.rule_ops import (
     inspect_rule,
     summarize_rule_contributions,
@@ -664,6 +666,137 @@ def handle_inspect_gems(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
 
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Unit 5 (hidden-gem plan): --trend hidden_gems
+# ---------------------------------------------------------------------------
+
+
+_TREND_HEADER: tuple[str, ...] = (
+    "timestamp",
+    "commit_sha",
+    "config_hash",
+    "aggregate_score_delta",
+    "hidden_gem_hit_rate",
+    "hidden_gem_hit_rate_delta",
+    "commanders_compared",
+    "commanders_with_edhrec",
+    "verdict",
+)
+
+
+def _row_to_cells(row: HistoryRow) -> tuple[str, ...]:
+    """Render one ``HistoryRow`` as string cells in the trend column order."""
+
+    def _f(value: float | None) -> str:
+        return "" if value is None else f"{value:.6f}"
+
+    return (
+        row.timestamp,
+        row.commit_sha,
+        row.config_hash,
+        _f(row.aggregate_score_delta),
+        _f(row.hidden_gem_hit_rate),
+        _f(row.hidden_gem_hit_rate_delta),
+        str(row.commanders_compared),
+        str(row.commanders_with_edhrec),
+        row.verdict,
+    )
+
+
+def _render_trend_csv(rows: list[HistoryRow]) -> str:
+    import csv as _csv
+    import io as _io
+
+    buf = _io.StringIO()
+    writer = _csv.writer(buf)
+    writer.writerow(_TREND_HEADER)
+    for row in rows:
+        writer.writerow(_row_to_cells(row))
+    return buf.getvalue()
+
+
+def _render_trend_md(rows: list[HistoryRow]) -> str:
+    lines: list[str] = []
+    lines.append("| " + " | ".join(_TREND_HEADER) + " |")
+    lines.append("|" + "|".join(["---"] * len(_TREND_HEADER)) + "|")
+    for row in rows:
+        cells = _row_to_cells(row)
+        lines.append("| " + " | ".join(cells) + " |")
+    return "\n".join(lines) + "\n"
+
+
+def _render_trend_json(rows: list[HistoryRow]) -> str:
+    payload = [
+        {
+            "timestamp": r.timestamp,
+            "commit_sha": r.commit_sha,
+            "config_hash": r.config_hash,
+            "aggregate_score_delta": r.aggregate_score_delta,
+            "hidden_gem_hit_rate": r.hidden_gem_hit_rate,
+            "hidden_gem_hit_rate_delta": r.hidden_gem_hit_rate_delta,
+            "commanders_compared": r.commanders_compared,
+            "commanders_with_edhrec": r.commanders_with_edhrec,
+            "verdict": r.verdict,
+        }
+        for r in rows
+    ]
+    return _json.dumps(payload, indent=2, ensure_ascii=False)
+
+
+def handle_trend_hidden_gems(args: argparse.Namespace) -> int:
+    """Handle ``bench.py audit --trend hidden_gems``.
+
+    Reads the last ``args.trend_n`` rows (default 20) from the append-only
+    ``.audit/history.csv`` log and renders them as CSV (default),
+    Markdown, or JSON. Missing history is not an error — prints an
+    actionable stderr message and exits 0.
+
+    Exit codes:
+    * ``0`` — normal (including fresh-checkout / no history).
+    """
+    history_path = Path(getattr(args, "history", ".audit/history.csv"))
+    trend_n = int(getattr(args, "trend_n", 20))
+
+    # Missing file: advisory stderr, empty stdout, success exit. A fresh
+    # checkout without ``bench.py audit`` runs is a normal state, not an
+    # error.
+    if not history_path.exists():
+        print(
+            "no history yet — run `bench.py audit` first",
+            file=sys.stderr,
+        )
+        return 0
+
+    rows = bench_history.read_last(trend_n, path=history_path) if trend_n > 0 else []
+
+    # Per the plan, CSV is the natural default for ``--trend`` — the
+    # history file itself is CSV. We honour an explicit ``--format csv``
+    # as well as the audit-wide default of ``md`` (which is meaningless
+    # here because we're reading raw rows, not rendering an audit
+    # report). ``--format md`` and ``--format json`` are explicit
+    # opt-ins for pretty-printed / structured output.
+    fmt = getattr(args, "format", "md")
+    if fmt == "json":
+        rendered = _render_trend_json(rows)
+    elif fmt == "md":
+        rendered = _render_trend_md(rows)
+    else:
+        rendered = _render_trend_csv(rows)
+
+    output_target = getattr(args, "output", None)
+    if output_target is None or output_target == "-":
+        print(rendered, end="" if rendered.endswith("\n") else "\n")
+    else:
+        output_path = Path(output_target)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(rendered, encoding="utf-8")
+        print(
+            f"bench.py audit --trend: report written to {output_path}",
+            file=sys.stderr,
+        )
     return 0
 
 

--- a/src/mtg_synergy_graph/bench/handlers.py
+++ b/src/mtg_synergy_graph/bench/handlers.py
@@ -12,15 +12,19 @@ formats a human-readable or JSON report. The functions here are what
 from __future__ import annotations
 
 import argparse
+import json as _json
 import sqlite3
 import sys
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from mtg_synergy_graph.bench.collinearity import (
     CollinearityReport,
     compute_collinearity,
 )
 from mtg_synergy_graph.bench.fixture import (
+    FixtureEntry,
     IdentityReport,
     PinnedFixture,
     build_fixture,
@@ -369,6 +373,297 @@ def handle_unknowns(args: argparse.Namespace) -> int:
     print("-" * 71)
     for r in rows:
         print(f"{r['subkind'][:40]:<40} {r['distinct_cards']:>15} {int(r['rank_weight']):>14}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Unit 4 (hidden-gem plan): --inspect-gems
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HiddenGemDelta:
+    """One commander's hidden-gem delta: rate change + lost/gained sets.
+
+    Immutable record rendered into either a markdown table row or a
+    JSON object. Sorting key is ``abs(rate_delta)`` descending with
+    ``None`` entries pushed to the end; commander name is the stable
+    tiebreaker so identical magnitudes render reproducibly.
+    """
+
+    commander: str
+    pinned_rate: float | None
+    live_rate: float | None
+    rate_delta: float | None
+    lost: tuple[str, ...]
+    gained: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "commander": self.commander,
+            "pinned_rate": self.pinned_rate,
+            "live_rate": self.live_rate,
+            "rate_delta": self.rate_delta,
+            "lost": list(self.lost),
+            "gained": list(self.gained),
+        }
+
+
+def _gem_rate(entry: FixtureEntry) -> float | None:
+    """Extract ``hidden_gem_hit_rate`` from ``legacy``, returning None
+    when absent or non-numeric."""
+    value = entry.legacy.get("hidden_gem_hit_rate")
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        return float(value)
+    return None
+
+
+def _gem_cards(entry: FixtureEntry) -> frozenset[str]:
+    """Extract the ``hidden_cards`` list from ``legacy`` as a frozenset."""
+    raw = entry.legacy.get("hidden_cards")
+    if not isinstance(raw, list):
+        return frozenset()
+    return frozenset(str(c) for c in raw)
+
+
+def _has_gem_data(fixture: PinnedFixture) -> bool:
+    """True iff any entry in the fixture carries ``hidden_gem_hit_rate``
+    or a non-empty ``hidden_cards`` list."""
+    for entry in fixture.entries:
+        if _gem_rate(entry) is not None:
+            return True
+        if _gem_cards(entry):
+            return True
+    return False
+
+
+def _build_deltas(
+    pinned: PinnedFixture,
+    live: PinnedFixture,
+) -> tuple[list[HiddenGemDelta], int]:
+    """Diff pinned vs live, returning (rows, skipped_count).
+
+    Skipped = commanders present in pinned but absent from live. Rows
+    cover the intersection of commanders in both fixtures.
+    """
+    live_by_cmdr = {e.commander: e for e in live.entries}
+    rows: list[HiddenGemDelta] = []
+    skipped = 0
+
+    for pinned_entry in pinned.entries:
+        live_entry = live_by_cmdr.get(pinned_entry.commander)
+        if live_entry is None:
+            skipped += 1
+            continue
+
+        pinned_cards = _gem_cards(pinned_entry)
+        live_cards = _gem_cards(live_entry)
+        pinned_rate = _gem_rate(pinned_entry)
+        live_rate = _gem_rate(live_entry)
+
+        rate_delta: float | None = (
+            live_rate - pinned_rate if pinned_rate is not None and live_rate is not None else None
+        )
+
+        rows.append(
+            HiddenGemDelta(
+                commander=pinned_entry.commander,
+                pinned_rate=pinned_rate,
+                live_rate=live_rate,
+                rate_delta=rate_delta,
+                lost=tuple(sorted(pinned_cards - live_cards)),
+                gained=tuple(sorted(live_cards - pinned_cards)),
+            )
+        )
+
+    return rows, skipped
+
+
+def _sort_deltas(rows: list[HiddenGemDelta]) -> list[HiddenGemDelta]:
+    """Sort rows by ``|rate_delta|`` desc with None last, name as
+    tiebreaker."""
+
+    def key(row: HiddenGemDelta) -> tuple[int, float, str]:
+        if row.rate_delta is None:
+            return (1, 0.0, row.commander)
+        return (0, -abs(row.rate_delta), row.commander)
+
+    return sorted(rows, key=key)
+
+
+def _format_delta_count(rate_delta: float | None) -> str:
+    """Render Δ as rounded-integer count out of 30 (more intuitive than
+    a float since the metric is a ratio of cards in a 30-card window)."""
+    if rate_delta is None:
+        return "—"
+    count = round(rate_delta * 30)
+    # Normalize -0 to 0 so the rendered output doesn't flap on tiny
+    # floating-point noise near zero.
+    if count == 0:
+        return "0"
+    return f"{count:+d}"
+
+
+def _format_card_list(names: tuple[str, ...]) -> str:
+    """Render a tuple of card names as a compact, comma-separated cell."""
+    if not names:
+        return "—"
+    preview = ", ".join(names[:3])
+    if len(names) > 3:
+        preview += f" … +{len(names) - 3} more"
+    return preview
+
+
+def _render_gems_markdown(
+    rows: list[HiddenGemDelta],
+    aggregate_rate_delta: float | None,
+    skipped_count: int,
+) -> str:
+    lines: list[str] = []
+    lines.append("# bench.py audit --inspect-gems")
+    lines.append("")
+    if aggregate_rate_delta is None:
+        lines.append("**Aggregate Δ:** `—`")
+    else:
+        lines.append(f"**Aggregate Δ:** `{aggregate_rate_delta:+.4f}`")
+    lines.append(f"**Commanders:** {len(rows)}")
+    if skipped_count:
+        lines.append(f"**Skipped (missing from live):** {skipped_count}")
+    lines.append("")
+    lines.append("| commander | Δ | lost gems | gained gems |")
+    lines.append("|-----------|--:|-----------|-------------|")
+    for row in rows:
+        lines.append(
+            f"| {row.commander} | {_format_delta_count(row.rate_delta)} "
+            f"| {_format_card_list(row.lost)} | {_format_card_list(row.gained)} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _render_gems_json(
+    rows: list[HiddenGemDelta],
+    aggregate_rate_delta: float | None,
+    skipped_count: int,
+) -> str:
+    payload = {
+        "aggregate_rate_delta": aggregate_rate_delta,
+        "n_commanders": len(rows),
+        "skipped_from_live": skipped_count,
+        "rows": [row.to_dict() for row in rows],
+    }
+    return _json.dumps(payload, indent=2, ensure_ascii=False)
+
+
+def _aggregate_rate_delta(rows: list[HiddenGemDelta]) -> float | None:
+    deltas = [r.rate_delta for r in rows if r.rate_delta is not None]
+    if not deltas:
+        return None
+    return sum(deltas) / len(deltas)
+
+
+def handle_inspect_gems(args: argparse.Namespace) -> int:
+    """Handle ``bench.py audit --inspect-gems``.
+
+    Per-commander diff of hidden-gem sets between pinned and live.
+    Reads the pinned fixture, re-scores the same commander list using
+    the current DB + EDHREC DB via ``build_fixture``, and emits a table
+    (markdown or JSON) of per-commander ``(Δ, lost_gems, gained_gems)``
+    sorted by ``|rate_delta|`` desc.
+
+    Exit codes:
+    * ``0`` — normal (even when there is no baseline gem data to compare).
+    * ``2`` — missing fixture, missing EDHREC DB, or ``--commander NAME``
+      does not match any fixture entry.
+    """
+    fixture_path = Path(args.fixture)
+    if not fixture_path.exists():
+        print(
+            f"error: pinned fixture {fixture_path} not found. Run `bench.py audit --repin --yes` to create one.",
+            file=sys.stderr,
+        )
+        return 2
+
+    pinned = PinnedFixture.load(fixture_path)
+
+    # --commander filter: reject unknown names before doing any work.
+    commander_filter: str | None = getattr(args, "commander", None)
+    if commander_filter is not None and not any(e.commander == commander_filter for e in pinned.entries):
+        print(
+            f"error: commander {commander_filter!r} not in fixture {fixture_path}. "
+            "Check spelling or run `bench.py audit --repin --yes` to refresh.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Short-circuit when the pinned fixture carries no gem data — no
+    # useful diff is possible. Predates Unit 2 plumbing of edhrec_conn
+    # into handle_repin; once that lands, pins will carry gem data by
+    # default and this branch becomes a rare edge case.
+    if not _has_gem_data(pinned):
+        print("no baseline gems to compare", file=sys.stderr)
+        return 0
+
+    # EDHREC DB is mandatory for a live gem rebuild. Missing here is a
+    # usage error, not an empty-diff condition.
+    edhrec_db_path = getattr(args, "edhrec_db", None)
+    if edhrec_db_path is None or not Path(edhrec_db_path).exists():
+        print(
+            f"error: EDHREC DB {edhrec_db_path!r} not found. Pass --edhrec-db PATH or import the EDHREC data first.",
+            file=sys.stderr,
+        )
+        return 2
+
+    commanders = [e.commander for e in pinned.entries]
+    conn = open_db(args.db)
+    edhrec_conn = sqlite3.connect(edhrec_db_path)
+    edhrec_conn.row_factory = sqlite3.Row
+    try:
+        live = build_fixture(
+            conn,
+            commanders,
+            existing=pinned,
+            tensor_writer=None,
+            edhrec_conn=edhrec_conn,
+        )
+    finally:
+        edhrec_conn.close()
+        conn.close()
+
+    rows, skipped_count = _build_deltas(pinned, live)
+    if commander_filter is not None:
+        rows = [r for r in rows if r.commander == commander_filter]
+    rows = _sort_deltas(rows)
+
+    limit = getattr(args, "limit", 100)
+    if limit is not None and limit >= 0:
+        rows = rows[:limit]
+
+    aggregate = _aggregate_rate_delta(rows)
+
+    fmt = getattr(args, "format", "md")
+    if fmt == "json":
+        rendered = _render_gems_json(rows, aggregate, skipped_count)
+    else:
+        rendered = _render_gems_markdown(rows, aggregate, skipped_count)
+
+    output_target = getattr(args, "output", None)
+    if output_target is None or output_target == "-":
+        print(rendered)
+    else:
+        output_path = Path(output_target)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(rendered, encoding="utf-8")
+        print(
+            f"bench.py audit --inspect-gems: report written to {output_path}",
+            file=sys.stderr,
+        )
+
+    if skipped_count:
+        print(
+            f"skipped {skipped_count} commander(s) missing from live",
+            file=sys.stderr,
+        )
+
     return 0
 
 

--- a/src/mtg_synergy_graph/bench/handlers.py
+++ b/src/mtg_synergy_graph/bench/handlers.py
@@ -209,6 +209,58 @@ def _print_identity_report(report: IdentityReport, fixture_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _emit_rendered(
+    rendered: str,
+    args: argparse.Namespace,
+    *,
+    label: str,
+) -> None:
+    """Shared stdout-or-file writer for ``--rule`` / ``--inspect`` /
+    ``--collinearity``. Mirrors ``handle_audit`` / ``handle_inspect_gems``:
+    write to ``--output PATH`` with stderr confirmation, or print to
+    stdout when ``--output`` is unset / ``-``."""
+    output_target = getattr(args, "output", None)
+    if output_target is None or output_target == "-":
+        print(rendered)
+        return
+    output_path = Path(output_target)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        rendered if rendered.endswith("\n") else rendered + "\n",
+        encoding="utf-8",
+    )
+    print(
+        f"bench.py audit --{label}: report written to {output_path}",
+        file=sys.stderr,
+    )
+
+
+def _render_rule_markdown(summary: Any) -> str:
+    lines: list[str] = []
+    lines.append(f"# bench.py audit --rule {summary.rule_id}")
+    lines.append(f"config_hash: {summary.config_hash[:12]}...")
+    lines.append(f"commanders_affected: {summary.commanders_affected}")
+    lines.append(f"candidates_affected: {summary.candidates_affected}")
+    lines.append(f"aggregate_contribution (raw / pre-dampening): {summary.aggregate_contribution:+.4f}")
+    lines.append("")
+    lines.append("Top commanders by |aggregate contribution|:")
+    for cmdr, contrib in summary.per_commander:
+        lines.append(f"  {cmdr}: {contrib:+.4f}")
+    return "\n".join(lines)
+
+
+def _render_rule_json(summary: Any) -> str:
+    payload = {
+        "rule_id": summary.rule_id,
+        "config_hash": summary.config_hash,
+        "commanders_affected": summary.commanders_affected,
+        "candidates_affected": summary.candidates_affected,
+        "aggregate_contribution": summary.aggregate_contribution,
+        "top_commanders": [{"commander": cmdr, "contribution": contrib} for cmdr, contrib in summary.per_commander],
+    }
+    return _json.dumps(payload, indent=2, ensure_ascii=False)
+
+
 def handle_rule(args: argparse.Namespace) -> int:
     """Handle ``bench.py audit --rule RULE_ID`` — per-rule raw-contribution summary.
 
@@ -216,6 +268,10 @@ def handle_rule(args: argparse.Namespace) -> int:
     **Not** an ablation / score-delta estimate — the underlying
     per-(cmdr, cand) values in the tensor are pre-dampening. See
     ``bench/rule_ops.py`` module docstring for why.
+
+    Supports ``--format json`` for programmatic consumers and
+    ``--output PATH`` to redirect output to a file with a stderr
+    confirmation.
     """
     conn = open_db(args.db)
     try:
@@ -232,20 +288,55 @@ def handle_rule(args: argparse.Namespace) -> int:
         )
         return 1
 
-    print(f"# bench.py audit --rule {summary.rule_id}")
-    print(f"config_hash: {summary.config_hash[:12]}...")
-    print(f"commanders_affected: {summary.commanders_affected}")
-    print(f"candidates_affected: {summary.candidates_affected}")
-    print(f"aggregate_contribution (raw / pre-dampening): {summary.aggregate_contribution:+.4f}")
-    print()
-    print("Top commanders by |aggregate contribution|:")
-    for cmdr, contrib in summary.per_commander:
-        print(f"  {cmdr}: {contrib:+.4f}")
+    fmt = getattr(args, "format", "md")
+    rendered = _render_rule_json(summary) if fmt == "json" else _render_rule_markdown(summary)
+    _emit_rendered(rendered, args, label="rule")
     return 0
 
 
+def _render_inspect_markdown(rows: list[Any], rule_id: str, commander: str | None, limit: int) -> str:
+    lines: list[str] = []
+    lines.append(f"# bench.py audit --inspect {rule_id}")
+    if commander:
+        lines.append(f"commander filter: {commander}")
+    lines.append(f"rows: {len(rows)} (limit: {limit})")
+    lines.append("")
+    lines.append(f"{'commander':<40} {'candidate':<40} {'contrib':>10} {'idf':>8} {'cnt':>4}")
+    for row in rows:
+        lines.append(
+            f"{row.commander[:40]:<40} {row.candidate[:40]:<40} "
+            f"{row.contribution:>+10.4f} {row.idf_weight:>8.4f} {row.raw_count:>4d}"
+        )
+    return "\n".join(lines)
+
+
+def _render_inspect_json(rows: list[Any], rule_id: str, commander: str | None, limit: int) -> str:
+    payload = {
+        "rule_id": rule_id,
+        "commander_filter": commander,
+        "limit": limit,
+        "n_rows": len(rows),
+        "rows": [
+            {
+                "commander": row.commander,
+                "candidate": row.candidate,
+                "contribution": row.contribution,
+                "idf_weight": row.idf_weight,
+                "raw_count": row.raw_count,
+            }
+            for row in rows
+        ],
+    }
+    return _json.dumps(payload, indent=2, ensure_ascii=False)
+
+
 def handle_inspect(args: argparse.Namespace) -> int:
-    """Handle ``bench.py audit --inspect RULE_ID`` — per-(cmdr, cand) rows."""
+    """Handle ``bench.py audit --inspect RULE_ID`` — per-(cmdr, cand) rows.
+
+    Supports ``--format json`` for programmatic consumers and
+    ``--output PATH`` to redirect output to a file with a stderr
+    confirmation.
+    """
     conn = open_db(args.db)
     try:
         rows = inspect_rule(conn, args.inspect, limit=args.limit, commander=args.commander)
@@ -260,29 +351,76 @@ def handle_inspect(args: argparse.Namespace) -> int:
         )
         return 1
 
-    print(f"# bench.py audit --inspect {args.inspect}")
-    if args.commander:
-        print(f"commander filter: {args.commander}")
-    print(f"rows: {len(rows)} (limit: {args.limit})")
-    print()
-    print(f"{'commander':<40} {'candidate':<40} {'contrib':>10} {'idf':>8} {'cnt':>4}")
-    for row in rows:
-        print(
-            f"{row.commander[:40]:<40} {row.candidate[:40]:<40} "
-            f"{row.contribution:>+10.4f} {row.idf_weight:>8.4f} {row.raw_count:>4d}"
-        )
+    fmt = getattr(args, "format", "md")
+    if fmt == "json":
+        rendered = _render_inspect_json(rows, args.inspect, args.commander, args.limit)
+    else:
+        rendered = _render_inspect_markdown(rows, args.inspect, args.commander, args.limit)
+    _emit_rendered(rendered, args, label="inspect")
     return 0
 
 
+def _render_collinearity_markdown(report: CollinearityReport) -> str:
+    lines: list[str] = []
+    lines.append("# bench.py audit --collinearity")
+    lines.append(f"config_hash: {report.config_hash[:12]}...")
+    lines.append(f"rules_examined: {report.rules_examined}")
+    if report.rules_dropped:
+        lines.append(
+            f"rules dropped (zero variance): {len(report.rules_dropped)} — "
+            f"{', '.join(report.rules_dropped[:5])}" + (", …" if len(report.rules_dropped) > 5 else "")
+        )
+    if not report.pairs_flagged:
+        lines.append("")
+        lines.append("No collinear pairs detected (VIF > 5 AND |r| > 0.8).")
+        return "\n".join(lines)
+
+    lines.append("")
+    lines.append(f"{'rule_a':<30} {'rule_b':<30} {'r':>7} {'VIF_a':>8} {'VIF_b':>8}")
+    for pair in report.pairs_flagged[:30]:
+        lines.append(
+            f"{pair.rule_a[:30]:<30} {pair.rule_b[:30]:<30} "
+            f"{pair.pearson_r:>+7.3f} {pair.vif_a:>8.2f} {pair.vif_b:>8.2f}"
+        )
+    return "\n".join(lines)
+
+
+def _render_collinearity_json(report: CollinearityReport) -> str:
+    payload = {
+        "config_hash": report.config_hash,
+        "rules_examined": report.rules_examined,
+        "rules_dropped": list(report.rules_dropped),
+        "vif_per_rule": dict(report.vif_per_rule),
+        "pairs_flagged": [
+            {
+                "rule_a": pair.rule_a,
+                "rule_b": pair.rule_b,
+                "pearson_r": pair.pearson_r,
+                "vif_a": pair.vif_a,
+                "vif_b": pair.vif_b,
+            }
+            for pair in report.pairs_flagged
+        ],
+    }
+    return _json.dumps(payload, indent=2, ensure_ascii=False)
+
+
 def handle_collinearity(args: argparse.Namespace) -> int:
-    """Handle ``bench.py audit --collinearity`` — pairwise VIF + Pearson."""
+    """Handle ``bench.py audit --collinearity`` — pairwise VIF + Pearson.
+
+    Supports ``--format json`` for programmatic consumers and
+    ``--output PATH`` to redirect output to a file with a stderr
+    confirmation.
+    """
     conn = open_db(args.db)
     try:
         report = compute_collinearity(conn)
     finally:
         conn.close()
 
-    _print_collinearity_report(report)
+    fmt = getattr(args, "format", "md")
+    rendered = _render_collinearity_json(report) if fmt == "json" else _render_collinearity_markdown(report)
+    _emit_rendered(rendered, args, label="collinearity")
     return 0
 
 
@@ -804,26 +942,3 @@ def handle_trend_hidden_gems(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
     return 0
-
-
-def _print_collinearity_report(report: CollinearityReport) -> None:
-    print("# bench.py audit --collinearity")
-    print(f"config_hash: {report.config_hash[:12]}...")
-    print(f"rules_examined: {report.rules_examined}")
-    if report.rules_dropped:
-        print(
-            f"rules dropped (zero variance): {len(report.rules_dropped)} — "
-            f"{', '.join(report.rules_dropped[:5])}" + (", …" if len(report.rules_dropped) > 5 else "")
-        )
-    if not report.pairs_flagged:
-        print()
-        print("No collinear pairs detected (VIF > 5 AND |r| > 0.8).")
-        return
-
-    print()
-    print(f"{'rule_a':<30} {'rule_b':<30} {'r':>7} {'VIF_a':>8} {'VIF_b':>8}")
-    for pair in report.pairs_flagged[:30]:
-        print(
-            f"{pair.rule_a[:30]:<30} {pair.rule_b[:30]:<30} "
-            f"{pair.pearson_r:>+7.3f} {pair.vif_a:>8.2f} {pair.vif_b:>8.2f}"
-        )

--- a/src/mtg_synergy_graph/bench/handlers.py
+++ b/src/mtg_synergy_graph/bench/handlers.py
@@ -30,7 +30,7 @@ from mtg_synergy_graph.bench.fixture import (
     PinnedFixture,
     build_fixture,
 )
-from mtg_synergy_graph.bench.history import CSV_FIELDS, HistoryRow
+from mtg_synergy_graph.bench.history import CSV_FIELDS, HistoryRow, fmt_float
 from mtg_synergy_graph.bench.rule_ops import (
     inspect_rule,
     summarize_rule_contributions,
@@ -617,18 +617,33 @@ def handle_inspect_gems(args: argparse.Namespace) -> int:
 
     commanders = [e.commander for e in pinned.entries]
     conn = open_db(args.db)
-    edhrec_conn = sqlite3.connect(edhrec_db_path)
-    edhrec_conn.row_factory = sqlite3.Row
     try:
-        live = build_fixture(
-            conn,
-            commanders,
-            existing=pinned,
-            tensor_writer=None,
-            edhrec_conn=edhrec_conn,
-        )
+        edhrec_conn = sqlite3.connect(edhrec_db_path)
+        edhrec_conn.row_factory = sqlite3.Row
+        try:
+            live = build_fixture(
+                conn,
+                commanders,
+                existing=pinned,
+                tensor_writer=None,
+                edhrec_conn=edhrec_conn,
+            )
+        except sqlite3.DatabaseError as exc:
+            # Corrupt or schema-less EDHREC DB surfaces as a
+            # DatabaseError (OperationalError is a subclass). Map to
+            # the same "missing/unusable DB" exit code + actionable
+            # hint as the non-existent-path branch above so the user
+            # sees a consistent error surface.
+            print(
+                f"error: EDHREC DB {edhrec_db_path!r} is unusable: {exc}. "
+                "Pass --edhrec-db PATH to a valid EDHREC synergy DB, "
+                "or re-import the EDHREC data.",
+                file=sys.stderr,
+            )
+            return 2
+        finally:
+            edhrec_conn.close()
     finally:
-        edhrec_conn.close()
         conn.close()
 
     rows, skipped_count = _build_deltas(pinned, live)
@@ -679,18 +694,18 @@ def handle_inspect_gems(args: argparse.Namespace) -> int:
 
 
 def _row_to_cells(row: HistoryRow) -> tuple[str, ...]:
-    """Render one ``HistoryRow`` as string cells in the trend column order."""
+    """Render one ``HistoryRow`` as string cells in the trend column order.
 
-    def _f(value: float | None) -> str:
-        return "" if value is None else f"{value:.6f}"
-
+    Uses ``history.fmt_float`` so the trend renderer and the history
+    writer stay in lockstep on precision + ``None``-handling.
+    """
     return (
         row.timestamp,
         row.commit_sha,
         row.config_hash,
-        _f(row.aggregate_score_delta),
-        _f(row.hidden_gem_hit_rate),
-        _f(row.hidden_gem_hit_rate_delta),
+        fmt_float(row.aggregate_score_delta),
+        fmt_float(row.hidden_gem_hit_rate),
+        fmt_float(row.hidden_gem_hit_rate_delta),
         str(row.commanders_compared),
         str(row.commanders_with_edhrec),
         row.verdict,

--- a/src/mtg_synergy_graph/bench/hidden_gems.py
+++ b/src/mtg_synergy_graph/bench/hidden_gems.py
@@ -29,14 +29,14 @@ from types import MappingProxyType
 
 #: Warning threshold for aggregate delta regressions (FR4). If the
 #: delta between live and pinned aggregate ``hidden_gem_hit_rate`` drops
-#: below ``-_HIDDEN_GEM_WARN_THRESHOLD``, the audit prints a stderr
+#: below ``-HIDDEN_GEM_WARN_THRESHOLD``, the audit prints a stderr
 #: warning. The commit is NOT gated on this at MVP — see plan 003 FR6
 #: escalation criteria: promotion to a commit-gate requires (1) the
 #: metric to be tracked for ≥20 commits, (2) human correlation
 #: confirming metric drops track subjectively-bad changes, and (3) a
 #: false-positive rate below 10% on recent accepted commits. Promotion
 #: is itself a separate ce-brainstorm + ce-plan cycle.
-_HIDDEN_GEM_WARN_THRESHOLD = 0.02
+HIDDEN_GEM_WARN_THRESHOLD = 0.02
 
 
 @dataclass(frozen=True)
@@ -98,8 +98,54 @@ def _aggregate_contributions(
     return dict(n_rules), dict(totals)
 
 
+def _plausibility_from_maps(
+    cand: str,
+    n_rules_map: Mapping[str, int],
+    totals_map: Mapping[str, float],
+    median: float,
+) -> bool:
+    """FR2 plausibility gate against pre-aggregated maps + median.
+
+    Internal helper so batched callers can aggregate contributions +
+    compute the median once across the whole candidate cohort, then
+    evaluate plausibility for each candidate in O(1) per call.
+
+    ``median`` is expected to be the median of strictly-positive totals
+    across the commander's cohort; callers pass ``0.0`` when the cohort
+    has no positive totals (the median-OR leg then short-circuits to
+    False, falling back to the N_rules leg only).
+    """
+    n_rules_cand = n_rules_map.get(cand, 0)
+    if n_rules_cand >= 2:
+        return True
+
+    total_cand = totals_map.get(cand, 0.0)
+    if total_cand <= 0:
+        return False
+
+    if median <= 0:
+        # Degenerate: the cohort has no positive totals OR the median
+        # collapses to zero. The median-OR leg is vacuous; fall back to
+        # the N_rules leg only (which already failed).
+        return False
+
+    return total_cand > median
+
+
+def _cohort_median(totals_map: Mapping[str, float]) -> float:
+    """Return the median of strictly-positive totals, or ``0.0`` if none.
+
+    Zero-median fallback is documented in ``plausibility``: an all-zero
+    cohort should reject every candidate via the N_rules leg only.
+    """
+    positive_totals = [v for v in totals_map.values() if v > 0]
+    if not positive_totals:
+        return 0.0
+    return statistics.median(positive_totals)
+
+
 def plausibility(
-    cmdr: str,
+    _cmdr: str,
     cand: str,
     contributions: Iterable[tuple[str, str, float]],
 ) -> bool:
@@ -115,36 +161,21 @@ def plausibility(
     non-zero candidate regardless of specificity. We short-circuit to
     the N_rules leg only in that case.
 
-    ``cmdr`` is accepted for API symmetry with future extensions
+    ``_cmdr`` is accepted for API symmetry with future extensions
     (embedding-based plausibility tightening — see plan 003 "Deferred
     to Separate Tasks") but not used by the pure-mechanical gate.
+
+    **Performance note:** this function is ``O(rows)`` per call — it
+    aggregates contributions and computes the cohort median fresh every
+    invocation. Use :func:`hidden_gem_hit_rate_for_commander` (or the
+    internal :func:`_plausibility_from_maps`) when evaluating many
+    candidates against the same commander; that path amortizes the
+    aggregation to ``O(rows)`` across the whole cohort instead of
+    ``O(rows × candidates)``.
     """
-    # ``cmdr`` is reserved for future per-commander tuning (FR6
-    # escalation path); silence unused-argument without per-line noqa.
-    del cmdr
     n_rules_map, totals_map = _aggregate_contributions(contributions)
-    n_rules_cand = n_rules_map.get(cand, 0)
-
-    if n_rules_cand >= 2:
-        return True
-
-    total_cand = totals_map.get(cand, 0.0)
-    if total_cand <= 0:
-        return False
-
-    # Median is computed across candidates with any positive total.
-    # Empty or all-zero cohort → median fallback rejects everything.
-    positive_totals = [v for v in totals_map.values() if v > 0]
-    if not positive_totals:
-        return False
-
-    median = statistics.median(positive_totals)
-    if median <= 0:
-        # Degenerate: the median of the positive set somehow collapses
-        # to zero. Fall back to N_rules leg only.
-        return False
-
-    return total_cand > median
+    median = _cohort_median(totals_map)
+    return _plausibility_from_maps(cand, n_rules_map, totals_map, median)
 
 
 def hidden_gem_hit_rate_for_commander(
@@ -170,13 +201,18 @@ def hidden_gem_hit_rate_for_commander(
     if edhrec_top_30 is None:
         return None
 
-    # Materialize once so we can iterate twice (plausibility check).
+    # Aggregate contributions + compute the cohort median ONCE so the
+    # per-candidate plausibility check is O(1). Prior versions called
+    # ``plausibility`` (which re-aggregates internally) once per hidden
+    # candidate — O(H × rows) for H hidden candidates. This is now O(rows).
     rows = list(contributions)
+    n_rules_map, totals_map = _aggregate_contributions(rows)
+    median = _cohort_median(totals_map)
 
     our_set = set(our_top_30)
     hidden = our_set - edhrec_top_30
 
-    plausible_hidden = sorted(c for c in hidden if plausibility(commander, c, rows))
+    plausible_hidden = sorted(c for c in hidden if _plausibility_from_maps(c, n_rules_map, totals_map, median))
 
     rate = len(plausible_hidden) / 30
     return HiddenGemEntry(

--- a/src/mtg_synergy_graph/bench/hidden_gems.py
+++ b/src/mtg_synergy_graph/bench/hidden_gems.py
@@ -1,0 +1,199 @@
+"""Hidden-gem metric core (Unit 1 of plan 003).
+
+Pure-function substrate for the ``hidden_gem_hit_rate`` axis of
+``bench.py audit``. Takes pre-shaped tensor rows and computes:
+
+* ``plausibility(cmdr, cand, contributions)`` — the FR2 mechanical
+  plausibility gate (``N_rules_firing >= 2`` OR
+  ``total_contribution > median``, strict inequality, zero-median
+  fallback to the N_rules leg).
+* ``hidden_gem_hit_rate_for_commander(our_top_30, edhrec_top_30,
+  contributions)`` — fraction of our top-30 that (a) EDHREC's top-30
+  did not list and (b) passes the plausibility gate. Returns ``None``
+  when ``edhrec_top_30 is None`` (no EDHREC data → skip).
+* ``aggregate_hidden_gem_hit_rate(entries)`` — mean over commanders
+  with entries; records skipped commanders.
+
+The module is DB-agnostic: callers (Unit 2) shape sqlite rows from
+``rule_contributions`` into ``(candidate, rule_id, contribution)``
+tuples and pass them in. No sqlite import here.
+"""
+
+from __future__ import annotations
+
+import statistics
+from collections import defaultdict
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+
+#: Warning threshold for aggregate delta regressions (FR4). If the
+#: delta between live and pinned aggregate ``hidden_gem_hit_rate`` drops
+#: below ``-_HIDDEN_GEM_WARN_THRESHOLD``, the audit prints a stderr
+#: warning. The commit is NOT gated on this at MVP — see plan 003 FR6
+#: escalation criteria: promotion to a commit-gate requires (1) the
+#: metric to be tracked for ≥20 commits, (2) human correlation
+#: confirming metric drops track subjectively-bad changes, and (3) a
+#: false-positive rate below 10% on recent accepted commits. Promotion
+#: is itself a separate ce-brainstorm + ce-plan cycle.
+_HIDDEN_GEM_WARN_THRESHOLD = 0.02
+
+
+@dataclass(frozen=True)
+class HiddenGemEntry:
+    """One commander's hidden-gem metric value + the specific cards."""
+
+    commander: str
+    rate: float
+    hidden_cards: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class HiddenGemReport:
+    """Aggregate hidden-gem metric across commanders.
+
+    ``aggregate`` is None when no commander had EDHREC data (everyone
+    was skipped). ``skipped_commanders`` carries the names of
+    commanders whose per-commander computation returned ``None``
+    (``edhrec_top_30 is None``).
+    """
+
+    aggregate: float | None
+    per_commander: dict[str, HiddenGemEntry]
+    skipped_commanders: tuple[str, ...]
+
+
+def _aggregate_contributions(
+    contributions: Iterable[tuple[str, str, float]],
+) -> tuple[dict[str, int], dict[str, float]]:
+    """Fold tensor rows into per-candidate (n_rules_firing, total).
+
+    Only contributions strictly greater than zero count — a rule that
+    reduces the score shouldn't make the card "more plausible."
+    """
+    n_rules: dict[str, int] = defaultdict(int)
+    totals: dict[str, float] = defaultdict(float)
+    for candidate, _rule_id, contribution in contributions:
+        if contribution > 0:
+            n_rules[candidate] += 1
+            totals[candidate] += contribution
+    return dict(n_rules), dict(totals)
+
+
+def plausibility(
+    cmdr: str,
+    cand: str,
+    contributions: Iterable[tuple[str, str, float]],
+) -> bool:
+    """FR2 mechanical plausibility gate for one ``(cmdr, cand)``.
+
+    Returns True iff
+    ``N_rules_firing(cmdr, cand) >= 2`` OR
+    ``total_contribution(cmdr, cand) > median_contribution(cmdr)``
+    (strict inequality).
+
+    When the per-commander median is 0 (all candidate totals are 0),
+    the median-OR leg is vacuous — strict ``> 0`` would flag every
+    non-zero candidate regardless of specificity. We short-circuit to
+    the N_rules leg only in that case.
+
+    ``cmdr`` is accepted for API symmetry with future extensions
+    (embedding-based plausibility tightening — see plan 003 "Deferred
+    to Separate Tasks") but not used by the pure-mechanical gate.
+    """
+    # ``cmdr`` is reserved for future per-commander tuning (FR6
+    # escalation path); silence unused-argument without per-line noqa.
+    del cmdr
+    n_rules_map, totals_map = _aggregate_contributions(contributions)
+    n_rules_cand = n_rules_map.get(cand, 0)
+
+    if n_rules_cand >= 2:
+        return True
+
+    total_cand = totals_map.get(cand, 0.0)
+    if total_cand <= 0:
+        return False
+
+    # Median is computed across candidates with any positive total.
+    # Empty or all-zero cohort → median fallback rejects everything.
+    positive_totals = [v for v in totals_map.values() if v > 0]
+    if not positive_totals:
+        return False
+
+    median = statistics.median(positive_totals)
+    if median <= 0:
+        # Degenerate: the median of the positive set somehow collapses
+        # to zero. Fall back to N_rules leg only.
+        return False
+
+    return total_cand > median
+
+
+def hidden_gem_hit_rate_for_commander(
+    commander: str,
+    our_top_30: Sequence[str],
+    edhrec_top_30: set[str] | None,
+    contributions: Iterable[tuple[str, str, float]],
+) -> HiddenGemEntry | None:
+    """FR1 per-commander metric.
+
+    Returns None when ``edhrec_top_30 is None`` — "no EDHREC data,
+    skip." Aggregator treats these as skipped commanders, not as
+    zero-rate contributors.
+
+    Input ordering of ``our_top_30`` does not affect the output. The
+    function rejects duplicates with ``ValueError("our_top_30 must be
+    unique")`` since duplicates would double-count against the 30-card
+    denominator.
+    """
+    if len(set(our_top_30)) != len(our_top_30):
+        raise ValueError("our_top_30 must be unique")
+
+    if edhrec_top_30 is None:
+        return None
+
+    # Materialize once so we can iterate twice (plausibility check).
+    rows = list(contributions)
+
+    our_set = set(our_top_30)
+    hidden = our_set - edhrec_top_30
+
+    plausible_hidden = sorted(c for c in hidden if plausibility(commander, c, rows))
+
+    rate = len(plausible_hidden) / 30
+    return HiddenGemEntry(
+        commander=commander,
+        rate=rate,
+        hidden_cards=tuple(plausible_hidden),
+    )
+
+
+def aggregate_hidden_gem_hit_rate(
+    entries: Iterable[tuple[str, HiddenGemEntry | None]],
+) -> HiddenGemReport:
+    """Combine per-commander entries into aggregate report.
+
+    Each input tuple is ``(commander_name, entry_or_None)``. ``None``
+    entries move the commander into ``skipped_commanders``; real
+    entries contribute their ``rate`` to the arithmetic-mean
+    ``aggregate``. Empty input and all-None input both produce
+    ``aggregate = None``.
+    """
+    per_commander: dict[str, HiddenGemEntry] = {}
+    skipped: list[str] = []
+
+    for name, entry in entries:
+        if entry is None:
+            skipped.append(name)
+        else:
+            per_commander[name] = entry
+
+    if not per_commander:
+        aggregate: float | None = None
+    else:
+        aggregate = sum(e.rate for e in per_commander.values()) / len(per_commander)
+
+    return HiddenGemReport(
+        aggregate=aggregate,
+        per_commander=per_commander,
+        skipped_commanders=tuple(skipped),
+    )

--- a/src/mtg_synergy_graph/bench/hidden_gems.py
+++ b/src/mtg_synergy_graph/bench/hidden_gems.py
@@ -23,8 +23,9 @@ from __future__ import annotations
 
 import statistics
 from collections import defaultdict
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
+from types import MappingProxyType
 
 #: Warning threshold for aggregate delta regressions (FR4). If the
 #: delta between live and pinned aggregate ``hidden_gem_hit_rate`` drops
@@ -55,11 +56,29 @@ class HiddenGemReport:
     was skipped). ``skipped_commanders`` carries the names of
     commanders whose per-commander computation returned ``None``
     (``edhrec_top_30 is None``).
+
+    ``per_commander`` is exposed as a ``Mapping`` and wrapped in a
+    ``MappingProxyType`` at construction so the ``frozen=True``
+    contract isn't silently violated by callers mutating the dict in
+    place. Equality comparisons against plain ``dict`` instances still
+    work (``MappingProxyType`` compares equal to a dict with the same
+    items).
     """
 
     aggregate: float | None
-    per_commander: dict[str, HiddenGemEntry]
+    per_commander: Mapping[str, HiddenGemEntry]
     skipped_commanders: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        # Freeze the mapping so callers can't mutate ``per_commander``
+        # even though the dataclass itself is frozen. We rebuild from a
+        # dict so the proxy wraps an independent, caller-unreachable
+        # backing dict.
+        object.__setattr__(
+            self,
+            "per_commander",
+            MappingProxyType(dict(self.per_commander)),
+        )
 
 
 def _aggregate_contributions(

--- a/src/mtg_synergy_graph/bench/history.py
+++ b/src/mtg_synergy_graph/bench/history.py
@@ -42,7 +42,7 @@ from mtg_synergy_graph.bench.report import AuditReport
 
 #: CSV column order. Must match ``HistoryRow`` field order. Touch both
 #: together or the round-trip tests will catch the drift.
-_CSV_FIELDS: tuple[str, ...] = (
+CSV_FIELDS: tuple[str, ...] = (
     "timestamp",
     "commit_sha",
     "config_hash",
@@ -103,11 +103,16 @@ def append_run(
         with csv_path.open("a", encoding="utf-8", newline="") as fh:
             writer = csv.writer(fh)
             if write_header:
-                writer.writerow(_CSV_FIELDS)
+                writer.writerow(CSV_FIELDS)
             writer.writerow(_row_from_report(report))
-    except OSError as exc:
+    except (OSError, csv.Error) as exc:
+        # csv.Error covers NUL bytes / non-encodable characters in the
+        # rendered cells; OSError covers disk failures, permission
+        # errors, etc. Either way, the history write must never turn a
+        # PASS audit into a failure — we degrade to a stderr warning
+        # that includes the exception class for triage.
         print(
-            f"bench.py audit: warning: failed to append history row to {csv_path}: {exc}",
+            f"bench.py audit: warning: failed to append history row to {csv_path}: {exc.__class__.__name__}: {exc}",
             file=sys.stderr,
         )
 
@@ -167,9 +172,9 @@ def read_last(n: int, path: str | Path = _DEFAULT_PATH) -> list[HistoryRow]:
                 header = next(reader)
             except StopIteration:
                 return []
-            if tuple(header) != _CSV_FIELDS:
+            if tuple(header) != CSV_FIELDS:
                 print(
-                    f"bench.py audit: warning: {csv_path} header mismatch; expected {_CSV_FIELDS}, got {tuple(header)}",
+                    f"bench.py audit: warning: {csv_path} header mismatch; expected {CSV_FIELDS}, got {tuple(header)}",
                     file=sys.stderr,
                 )
                 return []
@@ -191,10 +196,10 @@ def read_last(n: int, path: str | Path = _DEFAULT_PATH) -> list[HistoryRow]:
 
 def _parse_row(raw: list[str], *, lineno: int, path: Path) -> HistoryRow | None:
     """Convert one raw CSV row to a ``HistoryRow``; skip + warn on error."""
-    if len(raw) != len(_CSV_FIELDS):
+    if len(raw) != len(CSV_FIELDS):
         print(
             f"bench.py audit: warning: skipping malformed row {lineno} in "
-            f"{path}: expected {len(_CSV_FIELDS)} fields, got {len(raw)}",
+            f"{path}: expected {len(CSV_FIELDS)} fields, got {len(raw)}",
             file=sys.stderr,
         )
         return None
@@ -258,6 +263,7 @@ def _commit_sha() -> str:
 
 
 __all__ = [
+    "CSV_FIELDS",
     "HistoryRow",
     "append_run",
     "read_last",

--- a/src/mtg_synergy_graph/bench/history.py
+++ b/src/mtg_synergy_graph/bench/history.py
@@ -95,12 +95,31 @@ def append_run(
     the file does not exist or is empty. Any exception during write
     degrades to a stderr warning — a history write failure must never
     abort the primary audit output.
+
+    The header-write check uses the file descriptor's post-open
+    position rather than a separate ``Path.stat()`` call so two
+    concurrent audits can't race between "is the file empty?" and
+    "open for append and write header." Opening in append mode
+    positions the FD at end-of-file; ``tell() == 0`` iff the file
+    was empty (or newly created). On the rare platform where
+    append-mode ``tell`` is unreliable we fall back to ``os.fstat``.
     """
     csv_path = Path(path)
     try:
         csv_path.parent.mkdir(parents=True, exist_ok=True)
-        write_header = (not csv_path.exists()) or csv_path.stat().st_size == 0
         with csv_path.open("a", encoding="utf-8", newline="") as fh:
+            # Append-mode open positions at EOF; a zero offset means
+            # the file was empty (or just created). This replaces the
+            # prior ``path.exists() + path.stat().st_size`` check which
+            # raced with concurrent writers. If ``tell()`` returns <0
+            # on some platform (unspecified), we fall back to ``fstat``
+            # on the same FD — still atomic relative to this writer.
+            pos = fh.tell()
+            if pos < 0:
+                import os as _os
+
+                pos = _os.fstat(fh.fileno()).st_size
+            write_header = pos == 0
             writer = csv.writer(fh)
             if write_header:
                 writer.writerow(CSV_FIELDS)
@@ -124,22 +143,27 @@ def _row_from_report(report: AuditReport) -> list[str]:
         timestamp,
         _commit_sha(),
         report.live_config_hash,
-        _fmt_float(report.aggregate_score_delta),
-        _fmt_float(report.aggregate_hidden_gem_hit_rate),
-        _fmt_float(report.hidden_gem_hit_rate_delta),
+        fmt_float(report.aggregate_score_delta),
+        fmt_float(report.aggregate_hidden_gem_hit_rate),
+        fmt_float(report.hidden_gem_hit_rate_delta),
         str(report.commanders_compared),
         str(report.commanders_with_edhrec),
         report.verdict.value,
     ]
 
 
-def _fmt_float(value: float | None) -> str:
+def fmt_float(value: float | None) -> str:
     """Render a float with fixed precision; ``None`` → empty string.
 
     Six decimals is enough to preserve NDCG-level deltas on playback;
     we never need more precision for a trend chart. Empty string
     (not ``"None"``, not ``"null"``) keeps the CSV compact and numeric-
     parser friendly downstream.
+
+    Public (no leading underscore) so ``bench.handlers._row_to_cells``
+    can re-use the same renderer for the ``--trend`` markdown/CSV
+    table — keeping both call sites in lockstep on precision +
+    ``None``-handling semantics.
     """
     if value is None:
         return ""
@@ -165,6 +189,8 @@ def read_last(n: int, path: str | Path = _DEFAULT_PATH) -> list[HistoryRow]:
         return []
 
     rows: list[HistoryRow] = []
+    total_rows = 0
+    skipped_count = 0
     try:
         with csv_path.open(encoding="utf-8", newline="") as fh:
             reader = csv.reader(fh)
@@ -179,8 +205,11 @@ def read_last(n: int, path: str | Path = _DEFAULT_PATH) -> list[HistoryRow]:
                 )
                 return []
             for lineno, raw in enumerate(reader, start=2):
+                total_rows += 1
                 parsed = _parse_row(raw, lineno=lineno, path=csv_path)
-                if parsed is not None:
+                if parsed is None:
+                    skipped_count += 1
+                else:
                     rows.append(parsed)
     except OSError as exc:
         print(
@@ -188,6 +217,16 @@ def read_last(n: int, path: str | Path = _DEFAULT_PATH) -> list[HistoryRow]:
             file=sys.stderr,
         )
         return []
+
+    # Per-row warnings above are load-bearing for debugging a single
+    # bad append; this aggregate tells an operator at a glance that
+    # the history file has drift worth investigating. Emitted once,
+    # after the loop.
+    if skipped_count > 0:
+        print(
+            f"bench.py audit: warning: skipped {skipped_count} of {total_rows} malformed row(s) in {csv_path}",
+            file=sys.stderr,
+        )
 
     if n >= len(rows):
         return rows
@@ -266,5 +305,6 @@ __all__ = [
     "CSV_FIELDS",
     "HistoryRow",
     "append_run",
+    "fmt_float",
     "read_last",
 ]

--- a/src/mtg_synergy_graph/bench/history.py
+++ b/src/mtg_synergy_graph/bench/history.py
@@ -1,0 +1,264 @@
+"""Append-only ``.audit/history.csv`` log of ``bench.py audit`` runs.
+
+Each successful ``bench.py audit`` run adds one row so an operator (or
+``bench.py audit --trend hidden_gems``) can review longitudinal trends
+in the hidden-gem metric alongside the existing aggregate score delta
+and verdict.
+
+Design invariants
+-----------------
+* **Append-only.** Never rewritten; the header is emitted once on first
+  write and preserved on every subsequent append.
+* **No third-party deps.** Uses the stdlib ``csv`` module so the file
+  stays git-diffable / human-readable.
+* **Never crashes the audit.** I/O failures degrade to a stderr warning;
+  the caller (:mod:`bench.audit`) wraps ``append_run`` in try/except
+  belt-and-suspenders in case a future refactor tightens this.
+* **Gitignored via ``.audit/``.** Matches the existing pre-commit hook
+  convention — see ``.gitignore`` at repo root.
+
+CSV schema (9 columns, header written once)::
+
+    timestamp,commit_sha,config_hash,aggregate_score_delta,
+    hidden_gem_hit_rate,hidden_gem_hit_rate_delta,
+    commanders_compared,commanders_with_edhrec,verdict
+
+Empty string is used as the sentinel for missing numeric data (e.g. a
+``None`` ``hidden_gem_hit_rate`` before Unit 2 pins gem fields). The
+``csv`` module parses empty strings as the empty string on read; the
+``HistoryRow`` constructor promotes them back to ``None`` / defaults.
+"""
+
+from __future__ import annotations
+
+import csv
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from mtg_synergy_graph.bench.report import AuditReport
+
+#: CSV column order. Must match ``HistoryRow`` field order. Touch both
+#: together or the round-trip tests will catch the drift.
+_CSV_FIELDS: tuple[str, ...] = (
+    "timestamp",
+    "commit_sha",
+    "config_hash",
+    "aggregate_score_delta",
+    "hidden_gem_hit_rate",
+    "hidden_gem_hit_rate_delta",
+    "commanders_compared",
+    "commanders_with_edhrec",
+    "verdict",
+)
+
+_DEFAULT_PATH = Path(".audit/history.csv")
+
+
+@dataclass(frozen=True)
+class HistoryRow:
+    """One row of ``.audit/history.csv``, typed and immutable.
+
+    Float fields are ``None`` when the CSV column is empty (e.g. an old
+    run predating the gem metric). Integer fields default to ``0`` when
+    blank rather than ``None`` — ``commanders_compared`` and
+    ``commanders_with_edhrec`` are always computed from non-None counts
+    by :class:`AuditReport`, so a blank here only happens on malformed
+    input that ``read_last`` already skips.
+    """
+
+    timestamp: str
+    commit_sha: str
+    config_hash: str
+    aggregate_score_delta: float | None
+    hidden_gem_hit_rate: float | None
+    hidden_gem_hit_rate_delta: float | None
+    commanders_compared: int
+    commanders_with_edhrec: int
+    verdict: str
+
+
+# ---------------------------------------------------------------------------
+# Writer
+# ---------------------------------------------------------------------------
+
+
+def append_run(
+    report: AuditReport,
+    path: str | Path = _DEFAULT_PATH,
+) -> None:
+    """Append one row summarizing ``report`` to the history CSV.
+
+    Creates the parent directory (``.audit/``) and emits the header if
+    the file does not exist or is empty. Any exception during write
+    degrades to a stderr warning — a history write failure must never
+    abort the primary audit output.
+    """
+    csv_path = Path(path)
+    try:
+        csv_path.parent.mkdir(parents=True, exist_ok=True)
+        write_header = (not csv_path.exists()) or csv_path.stat().st_size == 0
+        with csv_path.open("a", encoding="utf-8", newline="") as fh:
+            writer = csv.writer(fh)
+            if write_header:
+                writer.writerow(_CSV_FIELDS)
+            writer.writerow(_row_from_report(report))
+    except OSError as exc:
+        print(
+            f"bench.py audit: warning: failed to append history row to {csv_path}: {exc}",
+            file=sys.stderr,
+        )
+
+
+def _row_from_report(report: AuditReport) -> list[str]:
+    """Render the ``AuditReport`` into the CSV's 9 string cells."""
+    timestamp = datetime.now(UTC).isoformat(timespec="seconds")
+    return [
+        timestamp,
+        _commit_sha(),
+        report.live_config_hash,
+        _fmt_float(report.aggregate_score_delta),
+        _fmt_float(report.aggregate_hidden_gem_hit_rate),
+        _fmt_float(report.hidden_gem_hit_rate_delta),
+        str(report.commanders_compared),
+        str(report.commanders_with_edhrec),
+        report.verdict.value,
+    ]
+
+
+def _fmt_float(value: float | None) -> str:
+    """Render a float with fixed precision; ``None`` → empty string.
+
+    Six decimals is enough to preserve NDCG-level deltas on playback;
+    we never need more precision for a trend chart. Empty string
+    (not ``"None"``, not ``"null"``) keeps the CSV compact and numeric-
+    parser friendly downstream.
+    """
+    if value is None:
+        return ""
+    return f"{value:.6f}"
+
+
+# ---------------------------------------------------------------------------
+# Reader
+# ---------------------------------------------------------------------------
+
+
+def read_last(n: int, path: str | Path = _DEFAULT_PATH) -> list[HistoryRow]:
+    """Return the last ``n`` rows of ``path`` (chronological order).
+
+    Returns ``[]`` when the file does not exist. Skips malformed rows
+    (wrong field count, unparseable numbers) with a stderr warning so
+    a single bad append can't break the whole trend command.
+    """
+    csv_path = Path(path)
+    if not csv_path.exists():
+        return []
+    if n <= 0:
+        return []
+
+    rows: list[HistoryRow] = []
+    try:
+        with csv_path.open(encoding="utf-8", newline="") as fh:
+            reader = csv.reader(fh)
+            try:
+                header = next(reader)
+            except StopIteration:
+                return []
+            if tuple(header) != _CSV_FIELDS:
+                print(
+                    f"bench.py audit: warning: {csv_path} header mismatch; expected {_CSV_FIELDS}, got {tuple(header)}",
+                    file=sys.stderr,
+                )
+                return []
+            for lineno, raw in enumerate(reader, start=2):
+                parsed = _parse_row(raw, lineno=lineno, path=csv_path)
+                if parsed is not None:
+                    rows.append(parsed)
+    except OSError as exc:
+        print(
+            f"bench.py audit: warning: failed to read history from {csv_path}: {exc}",
+            file=sys.stderr,
+        )
+        return []
+
+    if n >= len(rows):
+        return rows
+    return rows[-n:]
+
+
+def _parse_row(raw: list[str], *, lineno: int, path: Path) -> HistoryRow | None:
+    """Convert one raw CSV row to a ``HistoryRow``; skip + warn on error."""
+    if len(raw) != len(_CSV_FIELDS):
+        print(
+            f"bench.py audit: warning: skipping malformed row {lineno} in "
+            f"{path}: expected {len(_CSV_FIELDS)} fields, got {len(raw)}",
+            file=sys.stderr,
+        )
+        return None
+    try:
+        return HistoryRow(
+            timestamp=raw[0],
+            commit_sha=raw[1],
+            config_hash=raw[2],
+            aggregate_score_delta=_parse_float(raw[3]),
+            hidden_gem_hit_rate=_parse_float(raw[4]),
+            hidden_gem_hit_rate_delta=_parse_float(raw[5]),
+            commanders_compared=_parse_int(raw[6]),
+            commanders_with_edhrec=_parse_int(raw[7]),
+            verdict=raw[8],
+        )
+    except ValueError as exc:
+        print(
+            f"bench.py audit: warning: skipping bad row {lineno} in {path}: {exc}",
+            file=sys.stderr,
+        )
+        return None
+
+
+def _parse_float(value: str) -> float | None:
+    if value == "":
+        return None
+    return float(value)
+
+
+def _parse_int(value: str) -> int:
+    if value == "":
+        return 0
+    return int(value)
+
+
+# ---------------------------------------------------------------------------
+# Git
+# ---------------------------------------------------------------------------
+
+
+def _commit_sha() -> str:
+    """Return ``git rev-parse HEAD`` or an empty string.
+
+    Empty string covers three failure modes: git binary missing
+    (``FileNotFoundError``), not inside a git checkout (``CalledProcess
+    Error``), and any other unexpected subprocess error. The CSV row
+    shape stays stable either way — trend consumers see ``""`` as the
+    "no git" sentinel.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],  # noqa: S607 — git is on PATH in every dev/CI env we ship
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+        return ""
+    return result.stdout.strip()
+
+
+__all__ = [
+    "HistoryRow",
+    "append_run",
+    "read_last",
+]

--- a/src/mtg_synergy_graph/bench/hook_entry.py
+++ b/src/mtg_synergy_graph/bench/hook_entry.py
@@ -14,7 +14,10 @@ Environment:
 * ``BENCH_DB``     — override the DB path (default: ``synergy.db``).
 * ``BENCH_FIXTURE``— override the fixture path (default:
                     ``tests/fixtures/golden_set_run.json``).
-* ``BENCH_FORMAT`` — ``md`` (default) or ``json``.
+* ``BENCH_FORMAT`` — ``md`` (default), ``json``, or ``csv``. ``csv`` is
+                    only meaningful for ``bench.py audit --trend``; the
+                    hook skips the ``.audit/last.*`` write when csv is
+                    selected and emits a stderr warning.
 """
 
 from __future__ import annotations
@@ -59,12 +62,22 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     # Write the report to .audit/last.{md,json} for consumption by the
-    # developer after the commit.
-    audit_dir = Path(".audit")
-    audit_dir.mkdir(exist_ok=True)
-    suffix = "json" if fmt == "json" else "md"
-    rendered = report.to_json() if fmt == "json" else report.to_markdown()
-    (audit_dir / f"last.{suffix}").write_text(rendered, encoding="utf-8")
+    # developer after the commit. ``csv`` is meaningful only for
+    # ``bench.py audit --trend`` — for the hook there is no sensible CSV
+    # rendering of a one-shot audit report, so we skip the write and
+    # warn instead of silently falling back to markdown.
+    if fmt == "csv":
+        print(
+            "bench-audit: warning: BENCH_FORMAT=csv is meaningful only for "
+            "`bench.py audit --trend`; skipping .audit/last.* write for this hook run.",
+            file=sys.stderr,
+        )
+    else:
+        audit_dir = Path(".audit")
+        audit_dir.mkdir(exist_ok=True)
+        suffix = "json" if fmt == "json" else "md"
+        rendered = report.to_json() if fmt == "json" else report.to_markdown()
+        (audit_dir / f"last.{suffix}").write_text(rendered, encoding="utf-8")
 
     # Emit a single summary line per policy — HARMFUL prints a banner.
     tag = "PASS" if report.is_identical else report.verdict.value

--- a/src/mtg_synergy_graph/bench/report.py
+++ b/src/mtg_synergy_graph/bench/report.py
@@ -10,12 +10,15 @@ from __future__ import annotations
 
 import json
 from dataclasses import asdict, dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from mtg_synergy_graph.bench.fixture import (
     IdentityReport,
     PinnedFixture,
 )
+
+if TYPE_CHECKING:
+    from mtg_synergy_graph.bench.fixture import FixtureEntry
 from mtg_synergy_graph.bench.hidden_gems import _HIDDEN_GEM_WARN_THRESHOLD
 from mtg_synergy_graph.bench.histogram import (
     Bucket,
@@ -185,7 +188,7 @@ def build_report(
     )
 
 
-def _commander_delta(pinned: Any, live: Any) -> CommanderDelta:  # FixtureEntry; annotated Any to avoid circular import
+def _commander_delta(pinned: FixtureEntry, live: FixtureEntry | None) -> CommanderDelta:
     pinned_scores = pinned.scores
     live_scores = live.scores if live is not None else {}
 
@@ -213,8 +216,8 @@ def _commander_delta(pinned: Any, live: Any) -> CommanderDelta:  # FixtureEntry;
 
 
 def _build_rule_deltas(
-    pinned_by_cmdr: dict[str, Any],
-    live_by_cmdr: dict[str, Any],
+    pinned_by_cmdr: dict[str, FixtureEntry],
+    live_by_cmdr: dict[str, FixtureEntry],
 ) -> list[RuleDelta]:
     """Per-rule rollup lives in SQLite now (see ``bench.rule_ops``).
 

--- a/src/mtg_synergy_graph/bench/report.py
+++ b/src/mtg_synergy_graph/bench/report.py
@@ -16,6 +16,7 @@ from mtg_synergy_graph.bench.fixture import (
     IdentityReport,
     PinnedFixture,
 )
+from mtg_synergy_graph.bench.hidden_gems import _HIDDEN_GEM_WARN_THRESHOLD
 from mtg_synergy_graph.bench.histogram import (
     Bucket,
     Histogram,
@@ -80,6 +81,20 @@ class AuditReport:
     verdict: Verdict = Verdict.TRIVIAL
     per_commander: list[CommanderDelta] = field(default_factory=list)
     per_rule: list[RuleDelta] = field(default_factory=list)
+    #: Aggregate ``hidden_gem_hit_rate`` over live entries whose
+    #: ``legacy`` dict carries the key (i.e., the commander had EDHREC
+    #: data at fixture-build time). ``None`` when no entry has the key.
+    aggregate_hidden_gem_hit_rate: float | None = None
+    #: Same aggregate, computed against the pinned fixture. ``None`` on
+    #: an old pin that predates the metric.
+    pinned_hidden_gem_hit_rate: float | None = None
+    #: ``live - pinned`` when both aggregates are non-None, else None.
+    hidden_gem_hit_rate_delta: float | None = None
+    #: True iff delta dropped strictly below ``-_HIDDEN_GEM_WARN_THRESHOLD``
+    #: (FR4). Informational only — does not affect exit code.
+    hidden_gem_warning: bool = False
+    #: Count of entries contributing to the live aggregate.
+    commanders_with_edhrec: int = 0
 
     @property
     def is_identical(self) -> bool:
@@ -99,6 +114,27 @@ class AuditReport:
 # ---------------------------------------------------------------------------
 # Aggregation
 # ---------------------------------------------------------------------------
+
+
+def _aggregate_hidden_gem_from_fixture(
+    fixture: PinnedFixture,
+) -> tuple[float | None, int]:
+    """Compute the arithmetic-mean ``hidden_gem_hit_rate`` across entries.
+
+    Only entries whose ``legacy`` dict carries the
+    ``"hidden_gem_hit_rate"`` key contribute — missing-key entries are
+    skipped (old fixtures or commanders without EDHREC data). Returns
+    ``(None, 0)`` when no entry has the key so callers can distinguish
+    "zero rate" from "no data."
+    """
+    rates: list[float] = []
+    for entry in fixture.entries:
+        rate = entry.legacy.get("hidden_gem_hit_rate")
+        if isinstance(rate, int | float):
+            rates.append(float(rate))
+    if not rates:
+        return None, 0
+    return sum(rates) / len(rates), len(rates)
 
 
 def build_report(
@@ -122,6 +158,14 @@ def build_report(
     histogram = compute_histogram(pinned, live)
     verdict = rollup_to_verdict(histogram, aggregate_score_delta)
 
+    live_gem_mean, live_gem_count = _aggregate_hidden_gem_from_fixture(live)
+    pinned_gem_mean, _ = _aggregate_hidden_gem_from_fixture(pinned)
+    if live_gem_mean is not None and pinned_gem_mean is not None:
+        gem_delta: float | None = live_gem_mean - pinned_gem_mean
+    else:
+        gem_delta = None
+    gem_warning = gem_delta is not None and gem_delta < -_HIDDEN_GEM_WARN_THRESHOLD
+
     return AuditReport(
         fixture_path=fixture_path,
         pinned_config_hash=pinned.config_hash,
@@ -133,6 +177,11 @@ def build_report(
         verdict=verdict,
         per_commander=sorted(per_commander, key=lambda d: abs(d.score_delta_sum), reverse=True),
         per_rule=sorted(per_rule, key=lambda d: abs(d.contribution_delta_sum), reverse=True),
+        aggregate_hidden_gem_hit_rate=live_gem_mean,
+        pinned_hidden_gem_hit_rate=pinned_gem_mean,
+        hidden_gem_hit_rate_delta=gem_delta,
+        hidden_gem_warning=gem_warning,
+        commanders_with_edhrec=live_gem_count,
     )
 
 
@@ -196,7 +245,30 @@ def _as_json_dict(report: AuditReport) -> dict[str, Any]:
         "per_commander": [cd.to_dict() for cd in report.per_commander[:50]],
         "per_rule": [rd.to_dict() for rd in report.per_rule[:50]],
         "missing_commanders": report.identity_report.missing_commanders,
+        "aggregate_hidden_gem_hit_rate": report.aggregate_hidden_gem_hit_rate,
+        "hidden_gem_hit_rate_delta": report.hidden_gem_hit_rate_delta,
+        "hidden_gem_warning": report.hidden_gem_warning,
+        "commanders_with_edhrec": report.commanders_with_edhrec,
     }
+
+
+def _format_hidden_gem_line(report: AuditReport) -> str:
+    """Format the ``**hidden_gem_hit_rate:**`` markdown backtick content.
+
+    Shapes:
+    * ``0.1467 (Δ -0.0034, 97 cmdrs with EDHREC)`` when both aggregates exist.
+    * ``0.1467 (Δ —, 97 cmdrs with EDHREC)`` when one side lacks gem data.
+    * ``— (no commanders with EDHREC data)`` when neither side has data.
+    """
+    aggregate = report.aggregate_hidden_gem_hit_rate
+    if aggregate is None:
+        # No live data — fall through to em-dash sentinel.
+        if report.pinned_hidden_gem_hit_rate is None:
+            return "— (no commanders with EDHREC data)"
+        return f"— (pinned {report.pinned_hidden_gem_hit_rate:.4f}, no live data)"
+
+    delta_str = "—" if report.hidden_gem_hit_rate_delta is None else f"{report.hidden_gem_hit_rate_delta:+.4f}"
+    return f"{aggregate:.4f} (Δ {delta_str}, {report.commanders_with_edhrec} cmdrs with EDHREC)"
 
 
 def _render_markdown(report: AuditReport) -> str:
@@ -213,6 +285,7 @@ def _render_markdown(report: AuditReport) -> str:
         f"{'== live' if report.config_hash_matches else f'!= `{report.live_config_hash[:12]}...`'}"
     )
     lines.append(f"**Aggregate score Δ:** `{report.aggregate_score_delta:+.6f}`")
+    lines.append(f"**hidden_gem_hit_rate:** `{_format_hidden_gem_line(report)}`")
     lines.append(f"**Commanders compared:** {report.commanders_compared}")
     lines.append("")
 

--- a/src/mtg_synergy_graph/bench/report.py
+++ b/src/mtg_synergy_graph/bench/report.py
@@ -19,7 +19,7 @@ from mtg_synergy_graph.bench.fixture import (
 
 if TYPE_CHECKING:
     from mtg_synergy_graph.bench.fixture import FixtureEntry
-from mtg_synergy_graph.bench.hidden_gems import _HIDDEN_GEM_WARN_THRESHOLD
+from mtg_synergy_graph.bench.hidden_gems import HIDDEN_GEM_WARN_THRESHOLD
 from mtg_synergy_graph.bench.histogram import (
     Bucket,
     Histogram,
@@ -93,7 +93,7 @@ class AuditReport:
     pinned_hidden_gem_hit_rate: float | None = None
     #: ``live - pinned`` when both aggregates are non-None, else None.
     hidden_gem_hit_rate_delta: float | None = None
-    #: True iff delta dropped strictly below ``-_HIDDEN_GEM_WARN_THRESHOLD``
+    #: True iff delta dropped strictly below ``-HIDDEN_GEM_WARN_THRESHOLD``
     #: (FR4). Informational only — does not affect exit code.
     hidden_gem_warning: bool = False
     #: Count of entries contributing to the live aggregate.
@@ -167,7 +167,7 @@ def build_report(
         gem_delta: float | None = live_gem_mean - pinned_gem_mean
     else:
         gem_delta = None
-    gem_warning = gem_delta is not None and gem_delta < -_HIDDEN_GEM_WARN_THRESHOLD
+    gem_warning = gem_delta is not None and gem_delta < -HIDDEN_GEM_WARN_THRESHOLD
 
     return AuditReport(
         fixture_path=fixture_path,

--- a/src/mtg_synergy_graph/edhrec_helpers.py
+++ b/src/mtg_synergy_graph/edhrec_helpers.py
@@ -1,0 +1,89 @@
+"""Shared helpers for querying the EDHREC synergy SQLite DB.
+
+The ``edhrec_card_synergy`` table's ``section = 'High Synergy Cards'``
+query shape is used by at least two callers — ``bench.fixture`` (for
+the hidden-gem metric) and ``validate._run_one`` (for the golden-set
+tracker). Centralising the section string + query SQL here keeps the
+two call sites in sync and removes the risk of one drifting off the
+other when EDHREC renames a section.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+#: Section name as it appears verbatim in ``edhrec_card_synergy``.
+#: Changing this literal requires updating the EDHREC importer at the
+#: same time — the value is pinned to what the upstream EDHREC scraper
+#: emits.
+HIGH_SYNERGY_SECTION = "High Synergy Cards"
+
+
+def _query_high_synergy(
+    edhrec_conn: sqlite3.Connection,
+    commander_name: str,
+    limit: int,
+) -> list[str]:
+    """Internal: return ordered card names (desc synergy) or empty list."""
+    # Local import to avoid a module-level cycle — ``validate`` now
+    # imports from this module for the shared-helper fix. Moving
+    # ``commander_to_slug`` itself would invalidate tests that import
+    # it from ``validate``.
+    from mtg_synergy_graph.validate import commander_to_slug
+
+    slug = commander_to_slug(commander_name)
+    rows = edhrec_conn.execute(
+        "SELECT card_name FROM edhrec_card_synergy "
+        "WHERE commander_slug = ? AND section = ? "
+        "ORDER BY synergy DESC LIMIT ?",
+        (slug, HIGH_SYNERGY_SECTION, limit),
+    ).fetchall()
+    # Rows come as sqlite3.Row or plain tuple; the first column is
+    # always ``card_name``. Index by position to handle both.
+    return [r[0] for r in rows]
+
+
+def fetch_high_synergy_top_n(
+    edhrec_conn: sqlite3.Connection,
+    commander_name: str,
+    *,
+    limit: int = 30,
+) -> set[str] | None:
+    """Return the top ``limit`` High Synergy Cards for a commander.
+
+    Returns ``None`` when the commander has no rows in the
+    ``'High Synergy Cards'`` section (either because no rows exist for
+    the commander at all, or because rows exist only in other
+    sections). ``None`` is the "no reference data → skip" sentinel
+    used by downstream callers; an empty set would conflate "no data"
+    with "commander has zero high-synergy entries."
+
+    ``limit`` defaults to 30 so the hidden-gem caller can use the bare
+    helper; callers that want a smaller window override.
+    """
+    names = _query_high_synergy(edhrec_conn, commander_name, limit)
+    if not names:
+        return None
+    return set(names)
+
+
+def fetch_high_synergy_top_n_ordered(
+    edhrec_conn: sqlite3.Connection,
+    commander_name: str,
+    *,
+    limit: int = 10,
+) -> tuple[str, ...]:
+    """Return the top ``limit`` High Synergy Cards as an ordered tuple.
+
+    Preserves synergy-descending order. Returns an empty tuple when
+    the commander has no rows. Used by callers that need rank order
+    (e.g. ``validate._run_one`` for its ``edhrec_top10`` field).
+    """
+    return tuple(_query_high_synergy(edhrec_conn, commander_name, limit))
+
+
+__all__ = [
+    "HIGH_SYNERGY_SECTION",
+    "fetch_high_synergy_top_n",
+    "fetch_high_synergy_top_n_ordered",
+]

--- a/src/mtg_synergy_graph/validate.py
+++ b/src/mtg_synergy_graph/validate.py
@@ -240,14 +240,12 @@ def _run_one(
         hi_syn_hits = len(top30 & hi_syn)
         on_page_hits = len(top30 & all_on_page)
 
-        # Top-5 hi-syn by synergy score (for reference)
-        hi_syn_rows = edhrec_conn.execute(
-            "SELECT card_name, synergy FROM edhrec_card_synergy "
-            "WHERE commander_slug = ? AND section = 'High Synergy Cards' "
-            "ORDER BY synergy DESC LIMIT 10",
-            (slug,),
-        ).fetchall()
-        edhrec_top10 = tuple(r["card_name"] for r in hi_syn_rows)
+        # Top-10 hi-syn by synergy score (for reference). Shared SQL
+        # shape lives in ``edhrec_helpers`` so the bench fixture and
+        # this tracker can't drift on the section-name literal.
+        from mtg_synergy_graph.edhrec_helpers import fetch_high_synergy_top_n_ordered
+
+        edhrec_top10 = fetch_high_synergy_top_n_ordered(edhrec_conn, commander[0], limit=10)
 
     return GoldenSetEntry(
         commander=" + ".join(commander),

--- a/tests/bench/test_audit_integration.py
+++ b/tests/bench/test_audit_integration.py
@@ -1,0 +1,233 @@
+"""Integration tests for ``bench.py audit`` wiring of ``edhrec_db``.
+
+Guards against structural-drift regressions on the hidden-gem metric:
+
+* ``run_audit`` must open the EDHREC DB when one is configured and
+  pass it through to ``build_fixture`` so the live aggregate gets
+  populated. Without this, the FR3 ``gem_Δ`` summary line is always
+  ``—`` and FR4's warning cannot fire.
+* When the configured EDHREC DB path does not exist, the audit must
+  degrade gracefully: print a stderr warning, continue, and surface
+  ``gem_Δ=—`` without crashing.
+
+Uses synthetic in-memory DBs so tests run in milliseconds and do not
+depend on ``data/synergy.db`` + ``data/tags.db``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from mtg_synergy_graph.bench.audit import handle_audit
+from mtg_synergy_graph.bench.fixture import build_fixture
+from mtg_synergy_graph.db import open_db
+
+# ---------------------------------------------------------------------------
+# Synthetic DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_synergy_db(conn: sqlite3.Connection) -> None:
+    """Minimal DB with one commander + several candidates that produce
+    enough tensor rows that the plausibility gate has real data to
+    work with on hidden candidates."""
+    conn.execute(
+        "INSERT INTO cards (name, card_types, subtypes, cmc, color_identity, edhrec_rank, legal_commander) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("Test Commander", "Creature", "", 4, "R", 1000, 1),
+    )
+    for cand, rank in [
+        ("Token Maker", 500),
+        ("Flicker Guy", 600),
+        ("Hidden A", 700),
+        ("Hidden B", 800),
+        ("Hidden C", 900),
+    ]:
+        conn.execute(
+            "INSERT INTO cards (name, card_types, subtypes, cmc, color_identity, edhrec_rank, legal_commander) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (cand, "Creature", "", 3, "R", rank, 1),
+        )
+    # Commander: ETB trigger on creatures you control.
+    conn.execute(
+        "INSERT INTO card_ports (card_name, port_type, event_class, valid_filter, raw_line) VALUES (?, ?, ?, ?, ?)",
+        ("Test Commander", "trigger", "ChangesZone", "Creature.YouCtrl", "{ETB}"),
+    )
+    # Candidates with matching effects — produce tensor rows.
+    conn.execute(
+        "INSERT INTO card_ports (card_name, port_type, event_class, valid_filter, raw_line) VALUES (?, ?, ?, ?, ?)",
+        ("Token Maker", "effect", "Token", "Creature.Token", "{make}"),
+    )
+    conn.execute(
+        "INSERT INTO card_ports (card_name, port_type, event_class, valid_filter, raw_line) VALUES (?, ?, ?, ?, ?)",
+        ("Flicker Guy", "effect", "ChangesZone", "Creature.YouCtrl", "{flicker}"),
+    )
+    conn.execute(
+        "INSERT INTO card_ports (card_name, port_type, event_class, valid_filter, raw_line) VALUES (?, ?, ?, ?, ?)",
+        ("Hidden A", "effect", "Token", "Creature.Token", "{make}"),
+    )
+    conn.execute(
+        "INSERT INTO card_ports (card_name, port_type, event_class, valid_filter, raw_line) VALUES (?, ?, ?, ?, ?)",
+        ("Hidden B", "effect", "Token", "Creature.Token", "{make}"),
+    )
+    conn.execute(
+        "INSERT INTO card_ports (card_name, port_type, event_class, valid_filter, raw_line) VALUES (?, ?, ?, ?, ?)",
+        ("Hidden C", "effect", "ChangesZone", "Creature.YouCtrl", "{flicker}"),
+    )
+    conn.commit()
+
+
+def _make_edhrec_db(path: Path) -> None:
+    """Synthetic EDHREC DB listing Token Maker + Flicker Guy as the
+    High Synergy Cards for our test commander. Everything else (Hidden
+    A/B/C) is absent and thus a hidden-gem candidate.
+    """
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            "CREATE TABLE edhrec_card_synergy (commander_slug TEXT, card_name TEXT, section TEXT, synergy REAL)"
+        )
+        conn.executemany(
+            "INSERT INTO edhrec_card_synergy (commander_slug, card_name, section, synergy) VALUES (?, ?, ?, ?)",
+            [
+                ("test-commander", "Token Maker", "High Synergy Cards", 0.5),
+                ("test-commander", "Flicker Guy", "High Synergy Cards", 0.4),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _args(
+    *,
+    db: Path,
+    fixture: Path,
+    edhrec_db: Path | None,
+    history: Path,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        db=str(db),
+        fixture=str(fixture),
+        edhrec_db=str(edhrec_db) if edhrec_db is not None else None,
+        history=str(history),
+        format="md",
+        output="-",
+    )
+
+
+@pytest.fixture()
+def seeded_setup(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    """Create the synergy DB, the EDHREC DB, and pin a fresh fixture.
+
+    Returns ``(synergy_db, edhrec_db, fixture_path, history_path)``.
+    The fixture carries live hidden-gem data so the audit has a
+    non-None pinned aggregate to delta against.
+    """
+    synergy_db = tmp_path / "synergy.db"
+    edhrec_db = tmp_path / "tags.db"
+    fixture_path = tmp_path / "fixture.json"
+    history_path = tmp_path / "history.csv"
+
+    # 1) Seed synergy DB.
+    conn = open_db(synergy_db)
+    try:
+        _seed_synergy_db(conn)
+    finally:
+        conn.close()
+
+    # 2) Create EDHREC DB with rows.
+    _make_edhrec_db(edhrec_db)
+
+    # 3) Pin a fresh fixture using the EDHREC DB so pinned entry gets
+    #    hidden-gem fields.
+    conn = open_db(synergy_db)
+    edhrec_conn = sqlite3.connect(edhrec_db)
+    edhrec_conn.row_factory = sqlite3.Row
+    try:
+        fixture = build_fixture(
+            conn,
+            ["Test Commander"],
+            edhrec_conn=edhrec_conn,
+        )
+    finally:
+        edhrec_conn.close()
+        conn.close()
+    fixture.write(fixture_path)
+
+    return synergy_db, edhrec_db, fixture_path, history_path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_run_audit_with_edhrec_db_populates_gem_delta(
+    seeded_setup: tuple[Path, Path, Path, Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``handle_audit`` with ``edhrec_db`` → live aggregate populated and
+    the summary line renders a numeric ``gem_Δ=+N.NNNN`` (not ``—``).
+    """
+    synergy_db, edhrec_db, fixture_path, history_path = seeded_setup
+
+    args = _args(
+        db=synergy_db,
+        fixture=fixture_path,
+        edhrec_db=edhrec_db,
+        history=history_path,
+    )
+    rc = handle_audit(args)
+    # Identity-clean (pin was built on the same tree) ⇒ exit 0.
+    assert rc == 0
+
+    err = capsys.readouterr().err
+    # The summary should have a *numeric* gem delta, not the em-dash
+    # sentinel. Accept +N.NNNN or -N.NNNN (both signs are valid for
+    # "we have data").
+    assert "gem_Δ=—" not in err
+    assert "gem_Δ=" in err
+    # The numeric form uses a signed 4-decimal format.
+    # Extract the substring after "gem_Δ=" — ensure the next 7 chars
+    # start with a sign.
+    gem_idx = err.index("gem_Δ=")
+    fragment = err[gem_idx + len("gem_Δ=") : gem_idx + len("gem_Δ=") + 7]
+    assert fragment[0] in "+-", f"expected signed number after gem_Δ=, got {fragment!r}"
+
+
+def test_run_audit_nonexistent_edhrec_db_warns_and_degrades(
+    seeded_setup: tuple[Path, Path, Path, Path],
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """If the configured ``edhrec_db`` path does not exist, the audit
+    must NOT fail — it degrades to "no gem data on the live side"
+    (gem_Δ=—) and emits a stderr warning about the missing DB.
+    """
+    synergy_db, _real_edhrec_db, fixture_path, history_path = seeded_setup
+
+    missing_edhrec = tmp_path / "does-not-exist.db"
+    assert not missing_edhrec.exists()
+
+    args = _args(
+        db=synergy_db,
+        fixture=fixture_path,
+        edhrec_db=missing_edhrec,
+        history=history_path,
+    )
+    rc = handle_audit(args)
+    # Audit still succeeds (identical scores; gem fields degrade
+    # silently).
+    assert rc == 0
+
+    err = capsys.readouterr().err
+    # Warning about the missing EDHREC DB went to stderr.
+    assert "not found" in err
+    assert "hidden_gem_hit_rate will be unavailable" in err
+    # Live has no gem data, so the delta is None → em-dash sentinel.
+    assert "gem_Δ=—" in err

--- a/tests/bench/test_audit_main.py
+++ b/tests/bench/test_audit_main.py
@@ -343,3 +343,53 @@ def test_run_audit_returns_report_on_clean_fixture(tmp_path: Path, seeded_db_pat
     report = run_audit(seeded_db_path, fixture_path)
     assert report.is_identical
     assert report.aggregate_score_delta == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _write_default_output error handling (P2 fix #24)
+# ---------------------------------------------------------------------------
+
+
+def test_write_default_output_os_error_does_not_fail_audit(
+    tmp_path: Path,
+    seeded_db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A read-only ``.audit/`` (OSError on mkdir/write) must not turn a
+    PASS audit into a failure. Handler emits a stderr warning and
+    returns 0.
+
+    Simulated via monkeypatching ``Path.mkdir`` to raise OSError.
+    """
+    fixture_path = tmp_path / "baseline.json"
+    _prepin(seeded_db_path, fixture_path, ["Test Commander"])
+
+    # Sabotage mkdir so _write_default_output's mkdir call raises.
+    original_mkdir = Path.mkdir
+
+    def _boom(self: Path, *args: object, **kwargs: object) -> None:
+        # Only trigger on the ``.audit`` default-dir call, not on
+        # output-path parent dirs.
+        if self.name == ".audit":
+            raise PermissionError("read-only audit dir")
+        original_mkdir(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "mkdir", _boom)
+
+    # Run without --output so _write_default_output is the code path.
+    exit_code = bench_cli.main(
+        [
+            "audit",
+            "--db",
+            str(seeded_db_path),
+            "--fixture",
+            str(fixture_path),
+        ]
+    )
+    # Audit itself is clean → exit 0.
+    assert exit_code == 0
+    cap = capsys.readouterr()
+    # Warning surfaced to stderr (prefixed "bench.py audit: warning").
+    assert "could not write" in cap.err.lower()
+    assert ".audit" in cap.err

--- a/tests/bench/test_audit_warning.py
+++ b/tests/bench/test_audit_warning.py
@@ -1,0 +1,247 @@
+"""FR4 stderr warning behavior in ``handle_audit`` (Unit 3 of plan 003).
+
+Mocks ``run_audit`` to return a pre-built ``AuditReport`` so we can
+test the warning-print code path without touching a real DB / fixture.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+import mtg_synergy_graph.bench.audit as audit_module
+from mtg_synergy_graph.bench.audit import handle_audit
+from mtg_synergy_graph.bench.fixture import IdentityReport
+from mtg_synergy_graph.bench.histogram import Histogram, Verdict
+from mtg_synergy_graph.bench.report import AuditReport
+
+
+def _make_report(
+    *,
+    delta: float | None,
+    aggregate_live: float | None,
+    aggregate_pinned: float | None,
+    warning: bool,
+    is_identical: bool = True,
+) -> AuditReport:
+    """Build a synthetic ``AuditReport`` with preset hidden-gem fields."""
+    identity = IdentityReport()  # empty = identical
+    if not is_identical:
+        identity.missing_commanders = ["X"]
+    return AuditReport(
+        fixture_path="baseline.json",
+        pinned_config_hash="abc",
+        live_config_hash="abc",
+        aggregate_score_delta=0.0,
+        commanders_compared=100,
+        identity_report=identity,
+        histogram=Histogram(samples={}),
+        verdict=Verdict.TRIVIAL,
+        aggregate_hidden_gem_hit_rate=aggregate_live,
+        pinned_hidden_gem_hit_rate=aggregate_pinned,
+        hidden_gem_hit_rate_delta=delta,
+        hidden_gem_warning=warning,
+        commanders_with_edhrec=97 if aggregate_live is not None else 0,
+    )
+
+
+def _write_dummy_fixture(fixture_path: Path) -> None:
+    """Write a minimal fixture file with one entry so ``handle_audit``
+    passes its existence + non-empty checks.
+    """
+    fixture_path.write_text(
+        '{"schema_version": 1, "config_hash": "abc", "created_at": "t", '
+        '"entries": [{"commander": "X", "scores": {"Y": 1.0}}]}'
+    )
+
+
+def _args_for(fixture_path: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        fixture=str(fixture_path),
+        db="ignored.db",
+        format="md",
+        output=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Warning path
+# ---------------------------------------------------------------------------
+
+
+def test_warning_prints_to_stderr_when_delta_below_threshold(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """delta = -0.025 → stderr contains the FR4 warning line."""
+    fixture_path = tmp_path / "baseline.json"
+    _write_dummy_fixture(fixture_path)
+
+    report = _make_report(
+        delta=-0.025,
+        aggregate_live=0.113,
+        aggregate_pinned=0.138,
+        warning=True,
+    )
+    monkeypatch.setattr(audit_module, "run_audit", lambda _db, _fx: report)
+
+    import os
+
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        exit_code = handle_audit(_args_for(fixture_path))
+    finally:
+        os.chdir(old_cwd)
+
+    captured = capsys.readouterr()
+    assert exit_code == 0  # identical report → exit 0
+    # Warning body
+    assert "hidden_gem_hit_rate dropped" in captured.err
+    assert "--inspect-gems" in captured.err
+    # Summary still appears
+    assert "gem_Δ" in captured.err
+    assert "WARN" in captured.err
+
+
+def test_warning_format_uses_abs_delta_and_3_decimals(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Delta shown as absolute value with 3 decimals; pinned + live too."""
+    fixture_path = tmp_path / "baseline.json"
+    _write_dummy_fixture(fixture_path)
+
+    report = _make_report(
+        delta=-0.034,
+        aggregate_live=0.113,
+        aggregate_pinned=0.147,
+        warning=True,
+    )
+    monkeypatch.setattr(audit_module, "run_audit", lambda _db, _fx: report)
+
+    import os
+
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        handle_audit(_args_for(fixture_path))
+    finally:
+        os.chdir(old_cwd)
+
+    captured = capsys.readouterr()
+    # abs(delta) = 0.034
+    assert "0.034" in captured.err
+    # Pinned (0.147) and live (0.113) to 3 decimals
+    assert "0.147" in captured.err
+    assert "0.113" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# No-warning path
+# ---------------------------------------------------------------------------
+
+
+def test_no_warning_when_delta_zero(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """delta = 0 → stderr has summary but no warning line."""
+    fixture_path = tmp_path / "baseline.json"
+    _write_dummy_fixture(fixture_path)
+
+    report = _make_report(
+        delta=0.0,
+        aggregate_live=0.15,
+        aggregate_pinned=0.15,
+        warning=False,
+    )
+    monkeypatch.setattr(audit_module, "run_audit", lambda _db, _fx: report)
+
+    import os
+
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        handle_audit(_args_for(fixture_path))
+    finally:
+        os.chdir(old_cwd)
+
+    captured = capsys.readouterr()
+    assert "hidden_gem_hit_rate dropped" not in captured.err
+    assert "--inspect-gems" not in captured.err
+    # Summary still carries gem_Δ marker
+    assert "gem_Δ" in captured.err
+    assert "WARN" not in captured.err
+
+
+def test_no_warning_when_aggregate_none(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No EDHREC data → warning never fires, summary uses em-dash."""
+    fixture_path = tmp_path / "baseline.json"
+    _write_dummy_fixture(fixture_path)
+
+    report = _make_report(
+        delta=None,
+        aggregate_live=None,
+        aggregate_pinned=None,
+        warning=False,
+    )
+    monkeypatch.setattr(audit_module, "run_audit", lambda _db, _fx: report)
+
+    import os
+
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        handle_audit(_args_for(fixture_path))
+    finally:
+        os.chdir(old_cwd)
+
+    captured = capsys.readouterr()
+    assert "hidden_gem_hit_rate dropped" not in captured.err
+    assert "gem_Δ=—" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — warning printed exactly once per run
+# ---------------------------------------------------------------------------
+
+
+def test_warning_printed_exactly_once_per_run(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two sinks (markdown file + stdout print) must not duplicate warning."""
+    fixture_path = tmp_path / "baseline.json"
+    _write_dummy_fixture(fixture_path)
+
+    report = _make_report(
+        delta=-0.050,
+        aggregate_live=0.100,
+        aggregate_pinned=0.150,
+        warning=True,
+    )
+    monkeypatch.setattr(audit_module, "run_audit", lambda _db, _fx: report)
+
+    import os
+
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        handle_audit(_args_for(fixture_path))
+    finally:
+        os.chdir(old_cwd)
+
+    captured = capsys.readouterr()
+    # Count the warning-header occurrences in stderr.
+    assert captured.err.count("hidden_gem_hit_rate dropped") == 1

--- a/tests/bench/test_audit_warning.py
+++ b/tests/bench/test_audit_warning.py
@@ -86,7 +86,7 @@ def test_warning_prints_to_stderr_when_delta_below_threshold(
         aggregate_pinned=0.138,
         warning=True,
     )
-    monkeypatch.setattr(audit_module, "run_audit", lambda _db, _fx: report)
+    monkeypatch.setattr(audit_module, "run_audit", lambda _db, _fx, edhrec_db=None: report)
 
     import os
 
@@ -122,7 +122,7 @@ def test_warning_format_uses_abs_delta_and_3_decimals(
         aggregate_pinned=0.147,
         warning=True,
     )
-    monkeypatch.setattr(audit_module, "run_audit", lambda _db, _fx: report)
+    monkeypatch.setattr(audit_module, "run_audit", lambda _db, _fx, edhrec_db=None: report)
 
     import os
 
@@ -161,7 +161,7 @@ def test_no_warning_when_delta_zero(
         aggregate_pinned=0.15,
         warning=False,
     )
-    monkeypatch.setattr(audit_module, "run_audit", lambda _db, _fx: report)
+    monkeypatch.setattr(audit_module, "run_audit", lambda _db, _fx, edhrec_db=None: report)
 
     import os
 
@@ -195,7 +195,7 @@ def test_no_warning_when_aggregate_none(
         aggregate_pinned=None,
         warning=False,
     )
-    monkeypatch.setattr(audit_module, "run_audit", lambda _db, _fx: report)
+    monkeypatch.setattr(audit_module, "run_audit", lambda _db, _fx, edhrec_db=None: report)
 
     import os
 
@@ -231,7 +231,7 @@ def test_warning_printed_exactly_once_per_run(
         aggregate_pinned=0.150,
         warning=True,
     )
-    monkeypatch.setattr(audit_module, "run_audit", lambda _db, _fx: report)
+    monkeypatch.setattr(audit_module, "run_audit", lambda _db, _fx, edhrec_db=None: report)
 
     import os
 

--- a/tests/bench/test_fixture_hidden_gems.py
+++ b/tests/bench/test_fixture_hidden_gems.py
@@ -401,3 +401,44 @@ def test_hidden_cards_with_commas_survive_json(
     hidden_cards = loaded.entries[0].legacy.get("hidden_cards", [])
     for name in hidden_cards:
         assert isinstance(name, str)
+
+
+# ---------------------------------------------------------------------------
+# Corrupt EDHREC DB error handling (P2 fix #10)
+# ---------------------------------------------------------------------------
+
+
+def test_build_fixture_skips_commander_on_corrupt_edhrec_query(
+    seeded_db: sqlite3.Connection,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Corrupt/missing edhrec table → stderr warning + commander skipped.
+
+    The build continues for other commanders instead of aborting the
+    whole audit when a single commander's EDHREC lookup raises
+    ``sqlite3.DatabaseError`` (e.g. missing ``edhrec_card_synergy``
+    table or corrupt rows).
+    """
+    # Create an EDHREC DB without the expected table so the query
+    # raises OperationalError (a subclass of DatabaseError).
+    bad_edhrec_path = tmp_path / "bad_edhrec.db"
+    conn = sqlite3.connect(bad_edhrec_path)
+    conn.row_factory = sqlite3.Row
+    # Intentionally DO NOT create edhrec_card_synergy.
+    conn.commit()
+
+    try:
+        fresh = build_fixture(seeded_db, ["Test Commander"], edhrec_conn=conn)
+    finally:
+        conn.close()
+
+    # Commander row is still in the fixture; gem keys absent.
+    assert len(fresh.entries) == 1
+    entry = fresh.entries[0]
+    assert "hidden_gem_hit_rate" not in entry.legacy
+    assert "hidden_cards" not in entry.legacy
+    # Stderr carries the warning.
+    err = capsys.readouterr().err
+    assert "edhrec query failed" in err.lower()
+    assert "test commander" in err.lower()

--- a/tests/bench/test_fixture_hidden_gems.py
+++ b/tests/bench/test_fixture_hidden_gems.py
@@ -1,0 +1,401 @@
+"""Fixture integration of hidden-gem metric (Unit 2 of plan 003).
+
+Tests that ``build_fixture(..., edhrec_conn=...)`` computes per-commander
+``hidden_gem_hit_rate`` + ``hidden_cards`` at fixture-build time and
+persists them into ``FixtureEntry.legacy``. Backwards-compat: callers
+without an ``edhrec_conn`` get the old behavior (no gem keys in
+``legacy``).
+
+Uses synthetic in-memory DBs (synergy + EDHREC) so tests are fast and
+independent of ``data/synergy.db`` + ``data/edhrec.db``.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from mtg_synergy_graph.bench.fixture import (
+    FixtureEntry,
+    PinnedFixture,
+    build_fixture,
+)
+from mtg_synergy_graph.db import open_db
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _seed_synergy_db(conn: sqlite3.Connection) -> None:
+    """Minimal synergy DB with one commander + a handful of candidates.
+
+    The scoring pass runs for real, producing tensor rows we can use.
+    """
+    conn.execute(
+        "INSERT INTO cards (name, card_types, subtypes, cmc, color_identity, edhrec_rank, legal_commander) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("Test Commander", "Creature", "", 4, "R", 1000, 1),
+    )
+    conn.execute(
+        "INSERT INTO cards (name, card_types, subtypes, cmc, color_identity, edhrec_rank, legal_commander) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("Token Maker", "Creature", "", 3, "R", 500, 1),
+    )
+    conn.execute(
+        "INSERT INTO cards (name, card_types, subtypes, cmc, color_identity, edhrec_rank, legal_commander) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("Flicker Guy", "Creature", "", 3, "R", 600, 1),
+    )
+    conn.execute(
+        "INSERT INTO card_ports (card_name, port_type, event_class, valid_filter, raw_line) VALUES (?, ?, ?, ?, ?)",
+        ("Test Commander", "trigger", "ChangesZone", "Creature.YouCtrl", "{ETB}"),
+    )
+    conn.execute(
+        "INSERT INTO card_ports (card_name, port_type, event_class, valid_filter, raw_line) VALUES (?, ?, ?, ?, ?)",
+        ("Token Maker", "effect", "Token", "Creature.Token", "{make}"),
+    )
+    conn.execute(
+        "INSERT INTO card_ports (card_name, port_type, event_class, valid_filter, raw_line) VALUES (?, ?, ?, ?, ?)",
+        ("Flicker Guy", "effect", "ChangesZone", "Creature.YouCtrl", "{flicker}"),
+    )
+    conn.commit()
+
+
+def _make_edhrec_db(
+    path: Path,
+    rows: list[tuple[str, str, str, float]],
+) -> sqlite3.Connection:
+    """Build a synthetic EDHREC DB.
+
+    ``rows`` is an iterable of
+    ``(commander_slug, card_name, section, synergy)``.
+    """
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE edhrec_card_synergy (commander_slug TEXT, card_name TEXT, section TEXT, synergy REAL)")
+    conn.executemany(
+        "INSERT INTO edhrec_card_synergy (commander_slug, card_name, section, synergy) VALUES (?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+    return conn
+
+
+@pytest.fixture()
+def seeded_db(tmp_path: Path) -> sqlite3.Connection:
+    conn = open_db(tmp_path / "synergy.db")
+    _seed_synergy_db(conn)
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Happy / backwards-compat paths
+# ---------------------------------------------------------------------------
+
+
+def test_build_fixture_without_edhrec_conn_omits_gem_keys(
+    seeded_db: sqlite3.Connection,
+) -> None:
+    """Backwards compat: no edhrec_conn → legacy dict has no gem keys."""
+    fresh = build_fixture(seeded_db, ["Test Commander"])
+    assert len(fresh.entries) == 1
+    entry = fresh.entries[0]
+    assert "hidden_gem_hit_rate" not in entry.legacy
+    assert "hidden_cards" not in entry.legacy
+
+
+def test_build_fixture_with_edhrec_conn_populates_gem_keys(
+    seeded_db: sqlite3.Connection,
+    tmp_path: Path,
+) -> None:
+    """Happy path: with EDHREC data, legacy gets rate + hidden_cards."""
+    # EDHREC has Token Maker (section: High Synergy Cards). Flicker Guy
+    # is NOT in EDHREC top-30, so it's a candidate hidden gem (whether
+    # it passes plausibility depends on how many rules fire).
+    edhrec = _make_edhrec_db(
+        tmp_path / "edhrec.db",
+        [("test-commander", "Token Maker", "High Synergy Cards", 0.5)],
+    )
+    try:
+        fresh = build_fixture(seeded_db, ["Test Commander"], edhrec_conn=edhrec)
+    finally:
+        edhrec.close()
+
+    assert len(fresh.entries) == 1
+    entry = fresh.entries[0]
+    assert "hidden_gem_hit_rate" in entry.legacy
+    assert "hidden_cards" in entry.legacy
+    rate = entry.legacy["hidden_gem_hit_rate"]
+    assert isinstance(rate, float)
+    assert 0.0 <= rate <= 1.0
+    # hidden_cards is JSON-friendly (list, not tuple).
+    assert isinstance(entry.legacy["hidden_cards"], list)
+
+
+def test_build_fixture_edhrec_conn_none_is_same_as_no_conn(
+    seeded_db: sqlite3.Connection,
+) -> None:
+    """``edhrec_conn=None`` is explicit backwards-compat; no gem keys."""
+    fresh = build_fixture(seeded_db, ["Test Commander"], edhrec_conn=None)
+    entry = fresh.entries[0]
+    assert "hidden_gem_hit_rate" not in entry.legacy
+    assert "hidden_cards" not in entry.legacy
+
+
+# ---------------------------------------------------------------------------
+# Skip cases (commander with no EDHREC data)
+# ---------------------------------------------------------------------------
+
+
+def test_commander_with_no_edhrec_rows_gets_no_gem_keys(
+    seeded_db: sqlite3.Connection,
+    tmp_path: Path,
+) -> None:
+    """Commander with zero rows in edhrec_card_synergy → keys absent."""
+    # EDHREC DB exists but has no rows for Test Commander.
+    edhrec = _make_edhrec_db(
+        tmp_path / "edhrec.db",
+        [("other-commander", "Some Card", "High Synergy Cards", 0.9)],
+    )
+    try:
+        fresh = build_fixture(seeded_db, ["Test Commander"], edhrec_conn=edhrec)
+    finally:
+        edhrec.close()
+
+    entry = fresh.entries[0]
+    # edhrec_top_30 is None (no rows at all for this commander's slug)
+    # — hidden_gem_hit_rate_for_commander returns None — gem keys
+    # should be absent.
+    assert "hidden_gem_hit_rate" not in entry.legacy
+    assert "hidden_cards" not in entry.legacy
+
+
+def test_commander_with_empty_high_synergy_section_still_computes(
+    seeded_db: sqlite3.Connection,
+    tmp_path: Path,
+) -> None:
+    """Rows exist under another section but 0 'High Synergy Cards' rows.
+
+    EDHREC top-30 is an empty set (not None) → every one of our top-30
+    is "hidden"; plausibility gate filters. The metric is computed (it
+    is NOT a skip).
+    """
+    edhrec = _make_edhrec_db(
+        tmp_path / "edhrec.db",
+        [("test-commander", "Random Card", "Top Cards", 0.1)],
+    )
+    try:
+        fresh = build_fixture(seeded_db, ["Test Commander"], edhrec_conn=edhrec)
+    finally:
+        edhrec.close()
+
+    entry = fresh.entries[0]
+    # There ARE rows for this slug, just not in the High Synergy section.
+    # So edhrec_top_30 is the empty set, and the metric IS computed.
+    assert "hidden_gem_hit_rate" in entry.legacy
+    assert "hidden_cards" in entry.legacy
+
+
+# ---------------------------------------------------------------------------
+# Round-trip + determinism
+# ---------------------------------------------------------------------------
+
+
+def test_gem_fields_round_trip_through_json(
+    seeded_db: sqlite3.Connection,
+    tmp_path: Path,
+) -> None:
+    """Fixture with gem fields serializes and reloads with values intact."""
+    edhrec = _make_edhrec_db(
+        tmp_path / "edhrec.db",
+        [("test-commander", "Token Maker", "High Synergy Cards", 0.5)],
+    )
+    try:
+        fresh = build_fixture(seeded_db, ["Test Commander"], edhrec_conn=edhrec)
+    finally:
+        edhrec.close()
+
+    fixture_path = tmp_path / "fixture.json"
+    fresh.write(fixture_path)
+    loaded = PinnedFixture.load(fixture_path)
+
+    assert len(loaded.entries) == 1
+    e = loaded.entries[0]
+    original = fresh.entries[0]
+    assert e.legacy["hidden_gem_hit_rate"] == original.legacy["hidden_gem_hit_rate"]
+    assert e.legacy["hidden_cards"] == original.legacy["hidden_cards"]
+
+
+def test_gem_fields_present_in_raw_json(
+    seeded_db: sqlite3.Connection,
+    tmp_path: Path,
+) -> None:
+    """The gem keys survive the JSON write (via the legacy pass-through)."""
+    edhrec = _make_edhrec_db(
+        tmp_path / "edhrec.db",
+        [("test-commander", "Token Maker", "High Synergy Cards", 0.5)],
+    )
+    try:
+        fresh = build_fixture(seeded_db, ["Test Commander"], edhrec_conn=edhrec)
+    finally:
+        edhrec.close()
+
+    fixture_path = tmp_path / "fixture.json"
+    fresh.write(fixture_path)
+    raw = json.loads(fixture_path.read_text())
+    entry_raw = raw["entries"][0]
+    assert "hidden_gem_hit_rate" in entry_raw
+    assert "hidden_cards" in entry_raw
+
+
+def test_build_fixture_hidden_gem_determinism(
+    seeded_db: sqlite3.Connection,
+    tmp_path: Path,
+) -> None:
+    """Two identical build_fixture calls produce byte-identical rates."""
+    edhrec = _make_edhrec_db(
+        tmp_path / "edhrec.db",
+        [("test-commander", "Token Maker", "High Synergy Cards", 0.5)],
+    )
+    try:
+        first = build_fixture(seeded_db, ["Test Commander"], edhrec_conn=edhrec)
+        second = build_fixture(seeded_db, ["Test Commander"], edhrec_conn=edhrec)
+    finally:
+        edhrec.close()
+
+    rate_a = first.entries[0].legacy.get("hidden_gem_hit_rate")
+    rate_b = second.entries[0].legacy.get("hidden_gem_hit_rate")
+    assert rate_a is not None
+    assert rate_a == rate_b  # bitwise float equality
+    assert first.entries[0].legacy.get("hidden_cards") == second.entries[0].legacy.get("hidden_cards")
+
+
+# ---------------------------------------------------------------------------
+# Interaction with tensor_writer
+# ---------------------------------------------------------------------------
+
+
+def test_gem_fields_computed_even_when_tensor_writer_is_provided(
+    seeded_db: sqlite3.Connection,
+    tmp_path: Path,
+) -> None:
+    """Dual-sink plumbing: writer AND local row capture both work.
+
+    The metric needs rows in memory, while --repin wants rows persisted
+    to SQLite. This test guards against "provided a writer ⇒ lost the
+    metric" regressions.
+    """
+    from mtg_synergy_graph.bench.tensor import TensorWriter
+
+    edhrec = _make_edhrec_db(
+        tmp_path / "edhrec.db",
+        [("test-commander", "Token Maker", "High Synergy Cards", 0.5)],
+    )
+    try:
+        with TensorWriter(seeded_db) as writer:
+            fresh = build_fixture(
+                seeded_db,
+                ["Test Commander"],
+                tensor_writer=writer,
+                edhrec_conn=edhrec,
+            )
+    finally:
+        edhrec.close()
+
+    entry = fresh.entries[0]
+    assert "hidden_gem_hit_rate" in entry.legacy
+    assert "hidden_cards" in entry.legacy
+
+    # And the tensor still reached SQLite.
+    row_count = seeded_db.execute("SELECT COUNT(*) FROM rule_contributions").fetchone()[0]
+    assert row_count > 0
+
+
+# ---------------------------------------------------------------------------
+# Legacy preservation alongside new keys
+# ---------------------------------------------------------------------------
+
+
+def test_existing_legacy_fields_preserved_with_gem_keys_added(
+    seeded_db: sqlite3.Connection,
+    tmp_path: Path,
+) -> None:
+    """`build_fixture` adds gem keys without clobbering other legacy fields."""
+    existing = PinnedFixture(
+        config_hash="old",
+        created_at="t",
+        entries=[
+            FixtureEntry(
+                commander="Test Commander",
+                legacy={"hi_syn_hits": 3, "ndcg30": 0.5, "top10": ["X"]},
+            )
+        ],
+    )
+    edhrec = _make_edhrec_db(
+        tmp_path / "edhrec.db",
+        [("test-commander", "Token Maker", "High Synergy Cards", 0.5)],
+    )
+    try:
+        fresh = build_fixture(
+            seeded_db,
+            ["Test Commander"],
+            existing=existing,
+            edhrec_conn=edhrec,
+        )
+    finally:
+        edhrec.close()
+
+    entry = fresh.entries[0]
+    # Old legacy fields preserved.
+    assert entry.legacy["hi_syn_hits"] == 3
+    assert entry.legacy["ndcg30"] == 0.5
+    assert entry.legacy["top10"] == ["X"]
+    # New gem fields added.
+    assert "hidden_gem_hit_rate" in entry.legacy
+    assert "hidden_cards" in entry.legacy
+
+
+# ---------------------------------------------------------------------------
+# Unicode / punctuation in card names
+# ---------------------------------------------------------------------------
+
+
+def test_hidden_cards_with_commas_survive_json(
+    seeded_db: sqlite3.Connection,
+    tmp_path: Path,
+) -> None:
+    """Card names with commas (common in MTG) round-trip through JSON."""
+    # Insert a candidate whose name has a comma; make it hidden by not
+    # listing it in EDHREC. Its plausibility depends on tensor rows.
+    seeded_db.execute(
+        "INSERT INTO cards (name, card_types, subtypes, cmc, color_identity, edhrec_rank, legal_commander) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("Korvold, Fae-Cursed King", "Creature", "Dragon", 5, "BRG", 50, 1),
+    )
+    seeded_db.execute(
+        "INSERT INTO card_ports (card_name, port_type, event_class, valid_filter, raw_line) VALUES (?, ?, ?, ?, ?)",
+        ("Korvold, Fae-Cursed King", "trigger", "Sacrificed", "Permanent.YouCtrl", "{sac}"),
+    )
+    seeded_db.commit()
+
+    edhrec = _make_edhrec_db(
+        tmp_path / "edhrec.db",
+        [("test-commander", "Token Maker", "High Synergy Cards", 0.5)],
+    )
+    try:
+        fresh = build_fixture(seeded_db, ["Test Commander"], edhrec_conn=edhrec)
+    finally:
+        edhrec.close()
+
+    fixture_path = tmp_path / "fixture.json"
+    fresh.write(fixture_path)
+    loaded = PinnedFixture.load(fixture_path)
+    # hidden_cards is a plain list of card names — reloading preserves
+    # any unicode / comma content verbatim (JSON handles this natively).
+    hidden_cards = loaded.entries[0].legacy.get("hidden_cards", [])
+    for name in hidden_cards:
+        assert isinstance(name, str)

--- a/tests/bench/test_fixture_hidden_gems.py
+++ b/tests/bench/test_fixture_hidden_gems.py
@@ -174,15 +174,17 @@ def test_commander_with_no_edhrec_rows_gets_no_gem_keys(
     assert "hidden_cards" not in entry.legacy
 
 
-def test_commander_with_empty_high_synergy_section_still_computes(
+def test_commander_with_empty_high_synergy_section_is_skipped(
     seeded_db: sqlite3.Connection,
     tmp_path: Path,
 ) -> None:
     """Rows exist under another section but 0 'High Synergy Cards' rows.
 
-    EDHREC top-30 is an empty set (not None) → every one of our top-30
-    is "hidden"; plausibility gate filters. The metric is computed (it
-    is NOT a skip).
+    Treated as "no reference data → skip": ``_edhrec_top_30`` returns
+    ``None``, so ``hidden_gem_hit_rate_for_commander`` returns ``None``,
+    and the legacy dict carries no gem keys. Returning an empty set
+    instead would inflate the metric toward 1.0 (every top-30 card
+    becomes "hidden"), desensitizing the warning threshold.
     """
     edhrec = _make_edhrec_db(
         tmp_path / "edhrec.db",
@@ -194,10 +196,10 @@ def test_commander_with_empty_high_synergy_section_still_computes(
         edhrec.close()
 
     entry = fresh.entries[0]
-    # There ARE rows for this slug, just not in the High Synergy section.
-    # So edhrec_top_30 is the empty set, and the metric IS computed.
-    assert "hidden_gem_hit_rate" in entry.legacy
-    assert "hidden_cards" in entry.legacy
+    # Empty 'High Synergy Cards' section is equivalent to no EDHREC
+    # data for our purposes — the commander is skipped.
+    assert "hidden_gem_hit_rate" not in entry.legacy
+    assert "hidden_cards" not in entry.legacy
 
 
 # ---------------------------------------------------------------------------

--- a/tests/bench/test_handle_inspect_gems.py
+++ b/tests/bench/test_handle_inspect_gems.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -414,8 +415,18 @@ def test_limit_zero_yields_empty_table(
     rc = handle_inspect_gems(_args(fixture_path, synergy, edhrec_db=str(edhrec), limit=0))
     assert rc == 0
     out = capsys.readouterr().out
-    # No data row — commander name must not appear below the header.
-    assert "A" not in out.split("|-----------|--:|")[-1] if "|-----------|--:|" in out else True
+    # Full table separator row must be present (render still emits the
+    # header + separator even with --limit 0).
+    separator = "|-----------|--:|-----------|-------------|"
+    assert separator in out
+    # No data rows follow the separator — everything after it should
+    # be whitespace. Previously the test was
+    # ``assert 'A' not in out.split(sep)[-1] if sep in out else True``
+    # which was vacuously true when the separator wasn't present (the
+    # exact bug P2 fix #23 targeted); this rewrite asserts behavior
+    # directly.
+    after_separator = out.split(separator, 1)[1].strip()
+    assert after_separator == ""
 
 
 # ---------------------------------------------------------------------------
@@ -466,6 +477,56 @@ def test_edhrec_db_missing_exits_2(
     assert rc == 2
     err = capsys.readouterr().err
     assert "edhrec" in err.lower()
+
+
+def test_edhrec_db_unusable_surfaces_actionable_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Corrupt / schema-less EDHREC DB → exit 2 with actionable stderr.
+
+    Simulates the "sqlite3.DatabaseError from build_fixture" path: a
+    real file exists at the path but build_fixture raises when it
+    tries to query it. Should surface as exit 2 with the
+    "Pass --edhrec-db PATH..." guidance (the same surface as a missing
+    path), not an unhandled traceback.
+    """
+    synergy = tmp_path / "synergy.db"
+    synergy.touch()
+    edhrec = tmp_path / "tags.db"
+    # Create a real SQLite DB so the path exists and is openable,
+    # but without the expected table — the helper raises
+    # OperationalError (subclass of DatabaseError).
+    conn = sqlite3.connect(edhrec)
+    conn.commit()
+    conn.close()
+
+    pinned = _make_fixture(
+        [
+            FixtureEntry(
+                commander="A",
+                legacy={"hidden_gem_hit_rate": 0.1, "hidden_cards": ["X"]},
+            ),
+        ]
+    )
+    fixture_path = tmp_path / "baseline.json"
+    _write_fixture(fixture_path, pinned)
+
+    # Monkeypatch build_fixture to raise DatabaseError directly — this
+    # is the error surface we need to handle.
+    def _raise(conn, commanders, existing=None, tensor_writer=None, edhrec_conn=None):  # type: ignore[no-untyped-def]
+        import sqlite3 as _sql
+
+        raise _sql.OperationalError("no such table: edhrec_card_synergy")
+
+    monkeypatch.setattr(handlers, "build_fixture", _raise)
+
+    rc = handle_inspect_gems(_args(fixture_path, synergy, edhrec_db=str(edhrec)))
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "edhrec" in err.lower()
+    assert "unusable" in err.lower() or "pass --edhrec-db" in err.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/bench/test_handle_inspect_gems.py
+++ b/tests/bench/test_handle_inspect_gems.py
@@ -1,0 +1,727 @@
+"""``bench.py audit --inspect-gems`` handler tests (Unit 4 of plan 003).
+
+Per-commander diff of hidden-gem sets between pinned and live. Tests
+use synthetic in-memory ``PinnedFixture`` instances and monkeypatch
+``build_fixture`` in the handler module so the tests run in ~milliseconds
+and avoid touching the real ``data/synergy.db`` + ``data/tags.db``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from mtg_synergy_graph.bench import handlers
+from mtg_synergy_graph.bench.fixture import (
+    FixtureEntry,
+    PinnedFixture,
+)
+from mtg_synergy_graph.bench.handlers import handle_inspect_gems
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _args(
+    fixture: Path,
+    db: Path | str = "data/synergy.db",
+    *,
+    edhrec_db: str | None = "data/tags.db",
+    commander: str | None = None,
+    fmt: str = "md",
+    output: str | None = None,
+    limit: int = 100,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        db=str(db),
+        edhrec_db=edhrec_db,
+        fixture=str(fixture),
+        commander=commander,
+        format=fmt,
+        output=output,
+        limit=limit,
+    )
+
+
+def _write_fixture(path: Path, fixture: PinnedFixture) -> None:
+    fixture.write(path)
+
+
+def _make_fixture(entries: list[FixtureEntry], *, config_hash: str = "x") -> PinnedFixture:
+    return PinnedFixture(config_hash=config_hash, created_at="t", entries=entries)
+
+
+@pytest.fixture()
+def _stub_dbs(tmp_path: Path) -> tuple[Path, Path]:
+    """Create empty stub DB files so existence checks pass. The real
+    ``build_fixture`` is monkeypatched per test so these contents are
+    never read."""
+    synergy = tmp_path / "synergy.db"
+    synergy.touch()
+    edhrec = tmp_path / "tags.db"
+    edhrec.touch()
+    return synergy, edhrec
+
+
+def _patch_build_fixture(monkeypatch: pytest.MonkeyPatch, live: PinnedFixture) -> None:
+    """Replace ``build_fixture`` in the handler module with a stub that
+    returns the given live fixture regardless of input."""
+
+    def _stub(conn, commanders, existing=None, tensor_writer=None, edhrec_conn=None):  # type: ignore[no-untyped-def]
+        return live
+
+    monkeypatch.setattr(handlers, "build_fixture", _stub)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_renders_delta_rows_sorted_by_magnitude(
+    tmp_path: Path,
+    _stub_dbs: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Two commanders, each with lost/gained gems — output lists them in
+    |Δ| desc order and names lost/gained cards."""
+    synergy, edhrec = _stub_dbs
+
+    pinned = _make_fixture(
+        [
+            FixtureEntry(
+                commander="Animar",
+                legacy={
+                    "hidden_gem_hit_rate": 0.20,
+                    "hidden_cards": ["Spellbinder", "Morophon"],
+                },
+            ),
+            FixtureEntry(
+                commander="Yuriko",
+                legacy={
+                    "hidden_gem_hit_rate": 0.10,
+                    "hidden_cards": ["Agent of Treachery"],
+                },
+            ),
+        ]
+    )
+    fixture_path = tmp_path / "baseline.json"
+    _write_fixture(fixture_path, pinned)
+
+    live = _make_fixture(
+        [
+            FixtureEntry(
+                commander="Animar",
+                legacy={
+                    # Dropped by |Δ|=0.10 (3/30 to 0/30 ≈ -0.10 — use ~0.1333)
+                    "hidden_gem_hit_rate": 0.10,
+                    # Lost Morophon; no gains.
+                    "hidden_cards": ["Spellbinder"],
+                },
+            ),
+            FixtureEntry(
+                commander="Yuriko",
+                legacy={
+                    "hidden_gem_hit_rate": 0.13,  # small positive Δ
+                    "hidden_cards": ["Agent of Treachery", "Curtains' Call"],
+                },
+            ),
+        ]
+    )
+    _patch_build_fixture(monkeypatch, live)
+
+    rc = handle_inspect_gems(_args(fixture_path, synergy, edhrec_db=str(edhrec)))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "bench.py audit --inspect-gems" in out
+    # Both commanders appear.
+    assert "Animar" in out
+    assert "Yuriko" in out
+    # Animar should sort first (|Δ|=0.10 > |Δ|=0.03).
+    animar_pos = out.index("Animar")
+    yuriko_pos = out.index("Yuriko")
+    assert animar_pos < yuriko_pos
+    # Lost/gained names rendered.
+    assert "Morophon" in out
+    assert "Curtains' Call" in out
+
+
+def test_rate_delta_rendered_as_integer_count_out_of_30(
+    tmp_path: Path,
+    _stub_dbs: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Δ column shows ``round(rate_delta * 30)`` — more intuitive than a
+    float since the metric is a count out of 30."""
+    synergy, edhrec = _stub_dbs
+    pinned = _make_fixture(
+        [
+            FixtureEntry(
+                commander="CmdrA",
+                legacy={
+                    "hidden_gem_hit_rate": 2.0 / 30.0,
+                    "hidden_cards": ["X", "Y"],
+                },
+            ),
+        ]
+    )
+    fixture_path = tmp_path / "baseline.json"
+    _write_fixture(fixture_path, pinned)
+
+    live = _make_fixture(
+        [
+            FixtureEntry(
+                commander="CmdrA",
+                legacy={
+                    "hidden_gem_hit_rate": 0.0,
+                    "hidden_cards": [],
+                },
+            ),
+        ]
+    )
+    _patch_build_fixture(monkeypatch, live)
+
+    rc = handle_inspect_gems(_args(fixture_path, synergy, edhrec_db=str(edhrec)))
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Δ=-2 (lost 2 gems out of 30)
+    assert "-2" in out
+
+
+# ---------------------------------------------------------------------------
+# Edge: no baseline gem data
+# ---------------------------------------------------------------------------
+
+
+def test_empty_pinned_no_baseline_message(
+    tmp_path: Path,
+    _stub_dbs: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Pinned has no ``hidden_gem_hit_rate`` anywhere → handler emits
+    ``no baseline gems to compare`` and exits 0."""
+    synergy, edhrec = _stub_dbs
+    pinned = _make_fixture(
+        [
+            FixtureEntry(commander="A", legacy={"ndcg30": 0.5}),
+            FixtureEntry(commander="B", legacy={}),
+        ]
+    )
+    fixture_path = tmp_path / "baseline.json"
+    _write_fixture(fixture_path, pinned)
+
+    live = _make_fixture(
+        [
+            FixtureEntry(commander="A", legacy={}),
+            FixtureEntry(commander="B", legacy={}),
+        ]
+    )
+    _patch_build_fixture(monkeypatch, live)
+
+    rc = handle_inspect_gems(_args(fixture_path, synergy, edhrec_db=str(edhrec)))
+    assert rc == 0
+    combined = capsys.readouterr()
+    assert "no baseline gems to compare" in (combined.out + combined.err).lower()
+
+
+# ---------------------------------------------------------------------------
+# Edge: --commander filter
+# ---------------------------------------------------------------------------
+
+
+def test_commander_filter_selects_one_row(
+    tmp_path: Path,
+    _stub_dbs: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--commander NAME`` filters to one row."""
+    synergy, edhrec = _stub_dbs
+    pinned = _make_fixture(
+        [
+            FixtureEntry(
+                commander="KeepMe",
+                legacy={"hidden_gem_hit_rate": 0.20, "hidden_cards": ["A", "B"]},
+            ),
+            FixtureEntry(
+                commander="DropMe",
+                legacy={"hidden_gem_hit_rate": 0.30, "hidden_cards": ["C", "D"]},
+            ),
+        ]
+    )
+    fixture_path = tmp_path / "baseline.json"
+    _write_fixture(fixture_path, pinned)
+
+    live = _make_fixture(
+        [
+            FixtureEntry(
+                commander="KeepMe",
+                legacy={"hidden_gem_hit_rate": 0.10, "hidden_cards": ["A"]},
+            ),
+            FixtureEntry(
+                commander="DropMe",
+                legacy={"hidden_gem_hit_rate": 0.05, "hidden_cards": []},
+            ),
+        ]
+    )
+    _patch_build_fixture(monkeypatch, live)
+
+    rc = handle_inspect_gems(_args(fixture_path, synergy, edhrec_db=str(edhrec), commander="KeepMe"))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "KeepMe" in out
+    assert "DropMe" not in out
+
+
+def test_commander_not_in_fixture_exits_2(
+    tmp_path: Path,
+    _stub_dbs: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--commander NameNotInFixture`` → exit 2, actionable stderr."""
+    synergy, edhrec = _stub_dbs
+    pinned = _make_fixture(
+        [
+            FixtureEntry(
+                commander="RealCommander",
+                legacy={"hidden_gem_hit_rate": 0.1, "hidden_cards": ["X"]},
+            ),
+        ]
+    )
+    fixture_path = tmp_path / "baseline.json"
+    _write_fixture(fixture_path, pinned)
+
+    live = _make_fixture(
+        [
+            FixtureEntry(
+                commander="RealCommander",
+                legacy={"hidden_gem_hit_rate": 0.1, "hidden_cards": ["X"]},
+            ),
+        ]
+    )
+    _patch_build_fixture(monkeypatch, live)
+
+    rc = handle_inspect_gems(
+        _args(fixture_path, synergy, edhrec_db=str(edhrec), commander="Ghost Commander"),
+    )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "not in fixture" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Edge: --limit
+# ---------------------------------------------------------------------------
+
+
+def test_limit_zero_yields_empty_table(
+    tmp_path: Path,
+    _stub_dbs: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--limit 0`` → table header only, exit 0."""
+    synergy, edhrec = _stub_dbs
+    pinned = _make_fixture(
+        [
+            FixtureEntry(
+                commander="A",
+                legacy={"hidden_gem_hit_rate": 0.1, "hidden_cards": ["X"]},
+            ),
+        ]
+    )
+    fixture_path = tmp_path / "baseline.json"
+    _write_fixture(fixture_path, pinned)
+
+    live = _make_fixture(
+        [
+            FixtureEntry(commander="A", legacy={"hidden_gem_hit_rate": 0.0, "hidden_cards": []}),
+        ]
+    )
+    _patch_build_fixture(monkeypatch, live)
+
+    rc = handle_inspect_gems(_args(fixture_path, synergy, edhrec_db=str(edhrec), limit=0))
+    assert rc == 0
+    out = capsys.readouterr().out
+    # No data row — commander name must not appear below the header.
+    assert "A" not in out.split("|-----------|--:|")[-1] if "|-----------|--:|" in out else True
+
+
+# ---------------------------------------------------------------------------
+# Error: missing fixture
+# ---------------------------------------------------------------------------
+
+
+def test_fixture_missing_exits_2(
+    tmp_path: Path,
+    _stub_dbs: tuple[Path, Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Fixture file doesn't exist → exit 2, message consistent with handle_audit."""
+    synergy, edhrec = _stub_dbs
+    rc = handle_inspect_gems(_args(tmp_path / "does-not-exist.json", synergy, edhrec_db=str(edhrec)))
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "not found" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Error: missing EDHREC DB
+# ---------------------------------------------------------------------------
+
+
+def test_edhrec_db_missing_exits_2(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Fixture exists but edhrec DB missing → exit 2."""
+    synergy = tmp_path / "synergy.db"
+    synergy.touch()
+
+    pinned = _make_fixture(
+        [
+            FixtureEntry(
+                commander="A",
+                legacy={"hidden_gem_hit_rate": 0.1, "hidden_cards": ["X"]},
+            ),
+        ]
+    )
+    fixture_path = tmp_path / "baseline.json"
+    _write_fixture(fixture_path, pinned)
+
+    rc = handle_inspect_gems(
+        _args(fixture_path, synergy, edhrec_db=str(tmp_path / "missing.db")),
+    )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "edhrec" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# CLI dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_cli_dispatch_routes_to_handle_inspect_gems(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``main(["audit", "--inspect-gems", ...])`` routes via register()."""
+    import mtg_synergy_graph.bench  # ensure handlers register  # noqa: F401
+    from mtg_synergy_graph.bench.cli import main
+
+    synergy = tmp_path / "synergy.db"
+    synergy.touch()
+    edhrec = tmp_path / "tags.db"
+    edhrec.touch()
+
+    pinned = _make_fixture(
+        [
+            FixtureEntry(
+                commander="A",
+                legacy={"hidden_gem_hit_rate": 0.1, "hidden_cards": ["X"]},
+            ),
+        ]
+    )
+    fixture_path = tmp_path / "baseline.json"
+    _write_fixture(fixture_path, pinned)
+
+    # Monkeypatch so CLI routing is exercised but we don't need a real DB.
+    live = _make_fixture(
+        [
+            FixtureEntry(
+                commander="A",
+                legacy={"hidden_gem_hit_rate": 0.0, "hidden_cards": []},
+            ),
+        ]
+    )
+    _patch_build_fixture(monkeypatch, live)
+
+    rc = main(
+        [
+            "audit",
+            "--inspect-gems",
+            "--db",
+            str(synergy),
+            "--edhrec-db",
+            str(edhrec),
+            "--fixture",
+            str(fixture_path),
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "bench.py audit --inspect-gems" in out
+
+
+def test_inspect_gems_mutually_exclusive_with_other_modes() -> None:
+    """``--inspect-gems`` is in the mode mutex group → combining with
+    ``--expect-identity`` raises SystemExit from argparse."""
+    from mtg_synergy_graph.bench.cli import main
+
+    with pytest.raises(SystemExit):
+        main(["audit", "--inspect-gems", "--expect-identity"])
+
+
+# ---------------------------------------------------------------------------
+# --format json
+# ---------------------------------------------------------------------------
+
+
+def test_json_format_valid_and_contains_aggregate(
+    tmp_path: Path,
+    _stub_dbs: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--format json`` emits parseable JSON with ``rows`` + aggregate."""
+    synergy, edhrec = _stub_dbs
+    pinned = _make_fixture(
+        [
+            FixtureEntry(
+                commander="A",
+                legacy={"hidden_gem_hit_rate": 0.2, "hidden_cards": ["X", "Y"]},
+            ),
+        ]
+    )
+    fixture_path = tmp_path / "baseline.json"
+    _write_fixture(fixture_path, pinned)
+
+    live = _make_fixture(
+        [
+            FixtureEntry(
+                commander="A",
+                legacy={"hidden_gem_hit_rate": 0.1, "hidden_cards": ["X"]},
+            ),
+        ]
+    )
+    _patch_build_fixture(monkeypatch, live)
+
+    rc = handle_inspect_gems(_args(fixture_path, synergy, edhrec_db=str(edhrec), fmt="json"))
+    assert rc == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert "aggregate_rate_delta" in payload
+    assert "n_commanders" in payload
+    assert "rows" in payload
+    assert isinstance(payload["rows"], list)
+    assert payload["rows"][0]["commander"] == "A"
+    assert "Y" in payload["rows"][0]["lost"]
+
+
+# ---------------------------------------------------------------------------
+# --output PATH
+# ---------------------------------------------------------------------------
+
+
+def test_output_writes_to_file_with_stderr_confirmation(
+    tmp_path: Path,
+    _stub_dbs: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--output PATH`` writes rendered content to file; stderr carries
+    the confirmation; stdout is empty."""
+    synergy, edhrec = _stub_dbs
+    pinned = _make_fixture(
+        [
+            FixtureEntry(
+                commander="A",
+                legacy={"hidden_gem_hit_rate": 0.2, "hidden_cards": ["X", "Y"]},
+            ),
+        ]
+    )
+    fixture_path = tmp_path / "baseline.json"
+    _write_fixture(fixture_path, pinned)
+
+    live = _make_fixture(
+        [
+            FixtureEntry(
+                commander="A",
+                legacy={"hidden_gem_hit_rate": 0.1, "hidden_cards": ["X"]},
+            ),
+        ]
+    )
+    _patch_build_fixture(monkeypatch, live)
+
+    out_path = tmp_path / "gems.md"
+    rc = handle_inspect_gems(
+        _args(fixture_path, synergy, edhrec_db=str(edhrec), output=str(out_path)),
+    )
+    assert rc == 0
+    assert out_path.exists()
+    content = out_path.read_text(encoding="utf-8")
+    assert "bench.py audit --inspect-gems" in content
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert str(out_path) in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Edge: commander in pinned but not live
+# ---------------------------------------------------------------------------
+
+
+def test_commander_missing_from_live_skipped(
+    tmp_path: Path,
+    _stub_dbs: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Commander in pinned but missing from live → skipped with stderr note."""
+    synergy, edhrec = _stub_dbs
+    pinned = _make_fixture(
+        [
+            FixtureEntry(
+                commander="A",
+                legacy={"hidden_gem_hit_rate": 0.1, "hidden_cards": ["X"]},
+            ),
+            FixtureEntry(
+                commander="B",
+                legacy={"hidden_gem_hit_rate": 0.2, "hidden_cards": ["Y"]},
+            ),
+        ]
+    )
+    fixture_path = tmp_path / "baseline.json"
+    _write_fixture(fixture_path, pinned)
+
+    live = _make_fixture(
+        [
+            # Only A; B is missing.
+            FixtureEntry(
+                commander="A",
+                legacy={"hidden_gem_hit_rate": 0.05, "hidden_cards": []},
+            ),
+        ]
+    )
+    _patch_build_fixture(monkeypatch, live)
+
+    rc = handle_inspect_gems(_args(fixture_path, synergy, edhrec_db=str(edhrec)))
+    assert rc == 0
+    captured = capsys.readouterr()
+    out = captured.out
+    err = captured.err
+    # A is present; B is skipped.
+    assert "A" in out
+    assert "skipped 1" in err.lower() or "missing from live" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Edge: rate_delta = None sorted last
+# ---------------------------------------------------------------------------
+
+
+def test_none_rate_delta_sorts_last(
+    tmp_path: Path,
+    _stub_dbs: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Commanders with missing legacy rate on one side sort to the end."""
+    synergy, edhrec = _stub_dbs
+    pinned = _make_fixture(
+        [
+            FixtureEntry(
+                commander="HasBoth",
+                legacy={"hidden_gem_hit_rate": 0.2, "hidden_cards": ["X"]},
+            ),
+            FixtureEntry(
+                commander="PinnedOnly",
+                legacy={"hidden_gem_hit_rate": 0.5, "hidden_cards": ["Z"]},
+            ),
+        ]
+    )
+    fixture_path = tmp_path / "baseline.json"
+    _write_fixture(fixture_path, pinned)
+
+    live = _make_fixture(
+        [
+            FixtureEntry(
+                commander="HasBoth",
+                legacy={"hidden_gem_hit_rate": 0.1, "hidden_cards": []},
+            ),
+            # No rate or hidden_cards on the live side for PinnedOnly.
+            FixtureEntry(commander="PinnedOnly", legacy={}),
+        ]
+    )
+    _patch_build_fixture(monkeypatch, live)
+
+    rc = handle_inspect_gems(_args(fixture_path, synergy, edhrec_db=str(edhrec)))
+    assert rc == 0
+    out = capsys.readouterr().out
+    # HasBoth rendered first; PinnedOnly last.
+    has_both_pos = out.index("HasBoth")
+    pinned_only_pos = out.index("PinnedOnly")
+    assert has_both_pos < pinned_only_pos
+    # Δ column shows "—" for the None row — look for it on the PinnedOnly line.
+    for line in out.splitlines():
+        if "PinnedOnly" in line:
+            assert "—" in line
+            break
+    else:
+        raise AssertionError("PinnedOnly row not found in output")
+
+
+# ---------------------------------------------------------------------------
+# Edge: commas in names
+# ---------------------------------------------------------------------------
+
+
+def test_names_with_commas_render_correctly(
+    tmp_path: Path,
+    _stub_dbs: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Card + commander names with commas don't break markdown cells."""
+    synergy, edhrec = _stub_dbs
+    cmdr_name = "Korvold, Fae-Cursed King"
+    gem_lost = "Curtains' Call"
+    pinned = _make_fixture(
+        [
+            FixtureEntry(
+                commander=cmdr_name,
+                legacy={
+                    "hidden_gem_hit_rate": 0.2,
+                    "hidden_cards": [gem_lost, "Citizen, Angel"],
+                },
+            ),
+        ]
+    )
+    fixture_path = tmp_path / "baseline.json"
+    _write_fixture(fixture_path, pinned)
+
+    live = _make_fixture(
+        [
+            FixtureEntry(
+                commander=cmdr_name,
+                legacy={"hidden_gem_hit_rate": 0.1, "hidden_cards": []},
+            ),
+        ]
+    )
+    _patch_build_fixture(monkeypatch, live)
+
+    rc = handle_inspect_gems(_args(fixture_path, synergy, edhrec_db=str(edhrec)))
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Full commander name present, not split.
+    assert cmdr_name in out
+    # Gem name with apostrophe preserved.
+    assert gem_lost in out
+
+    # JSON format preserves commas cleanly.
+    rc = handle_inspect_gems(_args(fixture_path, synergy, edhrec_db=str(edhrec), fmt="json"))
+    assert rc == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["rows"][0]["commander"] == cmdr_name
+    assert gem_lost in payload["rows"][0]["lost"]

--- a/tests/bench/test_handle_inspect_gems.py
+++ b/tests/bench/test_handle_inspect_gems.py
@@ -322,6 +322,69 @@ def test_commander_not_in_fixture_exits_2(
 # ---------------------------------------------------------------------------
 
 
+def test_aggregate_computed_over_full_set_not_truncated_by_limit(
+    tmp_path: Path,
+    _stub_dbs: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--limit`` truncates the rendered table but MUST NOT shrink the
+    input to the aggregate-Δ calculation.
+
+    With 10 commanders whose rate_deltas span a wide range, rendering
+    ``--limit 3`` should still report the aggregate over all 10. If
+    the aggregate is computed post-limit, only the three extreme
+    movers drive it — hiding whether the broader set moved positively
+    or negatively.
+    """
+    synergy, edhrec = _stub_dbs
+
+    # Build 10 commanders with known deltas. Pinned rate is constant so
+    # the delta on each equals live - pinned.
+    #   - 7 commanders drop by 0.01 (well below the extreme)
+    #   - 3 commanders drop by 0.30 (the extreme movers)
+    # Aggregate over all 10: (7 * -0.01 + 3 * -0.30) / 10 = -0.097
+    # Aggregate over top 3 (|Δ|=0.30 each): -0.30
+    pinned_entries: list[FixtureEntry] = []
+    live_entries: list[FixtureEntry] = []
+    for idx in range(10):
+        pinned_rate = 0.5
+        # Δ = -0.30 for the 3 extreme movers, -0.01 for the rest.
+        live_rate = 0.20 if idx < 3 else 0.49
+        name = f"Cmdr{idx:02d}"
+        pinned_entries.append(
+            FixtureEntry(
+                commander=name,
+                legacy={"hidden_gem_hit_rate": pinned_rate, "hidden_cards": ["P"]},
+            )
+        )
+        live_entries.append(
+            FixtureEntry(
+                commander=name,
+                legacy={"hidden_gem_hit_rate": live_rate, "hidden_cards": ["L"]},
+            )
+        )
+
+    pinned = _make_fixture(pinned_entries)
+    fixture_path = tmp_path / "baseline.json"
+    _write_fixture(fixture_path, pinned)
+
+    live = _make_fixture(live_entries)
+    _patch_build_fixture(monkeypatch, live)
+
+    rc = handle_inspect_gems(_args(fixture_path, synergy, edhrec_db=str(edhrec), limit=3))
+    assert rc == 0
+    out = capsys.readouterr().out
+
+    # Aggregate over all 10 = -0.0970. Over the truncated top-3 it
+    # would be -0.3000. Accept either sign formatting but require the
+    # 10-row aggregate, not the 3-row one.
+    assert "-0.0970" in out, (
+        f"Aggregate should reflect all 10 commanders, not just the top-3 by magnitude. Output was:\n{out}"
+    )
+    assert "-0.3000" not in out
+
+
 def test_limit_zero_yields_empty_table(
     tmp_path: Path,
     _stub_dbs: tuple[Path, Path],

--- a/tests/bench/test_handle_trend_hidden_gems.py
+++ b/tests/bench/test_handle_trend_hidden_gems.py
@@ -255,6 +255,116 @@ def test_trend_rejects_unknown_value() -> None:
 
 
 # ---------------------------------------------------------------------------
+# CLI validation (P2 fixes #14 / #15 / #16)
+# ---------------------------------------------------------------------------
+
+
+def test_format_csv_rejected_outside_trend_mode(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--format csv`` with a non-trend mode → exit 2 with parser.error.
+
+    Previously silent fallback to markdown; now the user sees the
+    mismatch immediately.
+    """
+    from mtg_synergy_graph.bench.cli import main
+
+    synergy = tmp_path / "synergy.db"
+    synergy.touch()
+    # Empty fixture so handle_inspect_gems doesn't get to its own
+    # error paths — parser.error fires first.
+    fixture_path = tmp_path / "baseline.json"
+    fixture_path.write_text(
+        '{"schema_version": 2, "config_hash": "x", "created_at": "t", "entries": []}',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "audit",
+                "--inspect-gems",
+                "--format",
+                "csv",
+                "--db",
+                str(synergy),
+                "--fixture",
+                str(fixture_path),
+            ]
+        )
+    # argparse's parser.error exits with code 2.
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "--format csv" in err
+    assert "--trend" in err
+
+
+def test_trend_n_negative_rejected(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--trend-n -1`` → argparse rejects with ArgumentTypeError."""
+    from mtg_synergy_graph.bench.cli import main
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(["audit", "--trend", "hidden_gems", "--trend-n", "-1"])
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert ">= 0" in err or ">=0" in err
+
+
+def test_trend_n_zero_accepted(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--trend-n 0`` → accepted (header-only is legitimate)."""
+    from mtg_synergy_graph.bench.cli import main
+
+    history_path = tmp_path / ".audit" / "history.csv"
+    bench_history.append_run(_make_report(live_config_hash="abc"), path=history_path)
+
+    rc = main(
+        [
+            "audit",
+            "--trend",
+            "hidden_gems",
+            "--trend-n",
+            "0",
+            "--history",
+            str(history_path),
+        ]
+    )
+    assert rc == 0
+
+
+def test_commander_filter_rejected_with_trend(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--commander X`` with ``--trend`` → parser.error, exit 2."""
+    from mtg_synergy_graph.bench.cli import main
+
+    history_path = tmp_path / ".audit" / "history.csv"
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "audit",
+                "--trend",
+                "hidden_gems",
+                "--commander",
+                "Anything",
+                "--history",
+                str(history_path),
+            ]
+        )
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "--commander" in err
+    assert "--trend" in err
+
+
+# ---------------------------------------------------------------------------
 # Integration: audit then trend
 # ---------------------------------------------------------------------------
 

--- a/tests/bench/test_handle_trend_hidden_gems.py
+++ b/tests/bench/test_handle_trend_hidden_gems.py
@@ -1,0 +1,281 @@
+"""Tests for ``bench.py audit --trend hidden_gems`` (Unit 5 of hidden-gem plan).
+
+Covers ``handle_trend_hidden_gems`` + CLI integration:
+
+* Renders CSV (default), Markdown, JSON formats.
+* Exits 0 with actionable stderr on a fresh checkout with no history.
+* Dispatches via the existing register() table.
+* ``--trend hidden_gems`` slots into the existing mode mutex group.
+* ``--output PATH`` and ``--trend-n INT`` work.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from mtg_synergy_graph.bench import handlers
+from mtg_synergy_graph.bench import history as bench_history
+from mtg_synergy_graph.bench.fixture import IdentityReport
+from mtg_synergy_graph.bench.histogram import Histogram, Verdict
+from mtg_synergy_graph.bench.report import AuditReport
+
+
+def _make_report(live_config_hash: str = "abc1234567890def") -> AuditReport:
+    identity = IdentityReport(
+        config_hash_mismatch=None,
+        missing_commanders=[],
+        score_mismatches=[],
+    )
+    return AuditReport(
+        fixture_path="baseline.json",
+        pinned_config_hash="pinned_hash",
+        live_config_hash=live_config_hash,
+        aggregate_score_delta=0.0,
+        commanders_compared=100,
+        identity_report=identity,
+        histogram=Histogram(samples={}),
+        verdict=Verdict.TRIVIAL,
+        aggregate_hidden_gem_hit_rate=0.1467,
+        pinned_hidden_gem_hit_rate=0.15,
+        hidden_gem_hit_rate_delta=-0.0034,
+        hidden_gem_warning=False,
+        commanders_with_edhrec=97,
+    )
+
+
+def _args(
+    history_path: Path,
+    *,
+    trend: str = "hidden_gems",
+    trend_n: int = 20,
+    fmt: str = "csv",
+    output: str | None = None,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        history=str(history_path),
+        trend=trend,
+        trend_n=trend_n,
+        format=fmt,
+        output=output,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_commit_sha(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(bench_history, "_commit_sha", lambda: "deadbeef12345")
+
+
+# ---------------------------------------------------------------------------
+# Happy path — CSV (default)
+# ---------------------------------------------------------------------------
+
+
+def test_csv_format_shows_header_and_newest_rows(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """5 rows in history + ``--trend-n 3 --format csv`` → header + 3 newest rows."""
+    history_path = tmp_path / ".audit" / "history.csv"
+    for i in range(5):
+        bench_history.append_run(
+            _make_report(live_config_hash=f"hash_{i:02d}"),
+            path=history_path,
+        )
+
+    rc = handlers.handle_trend_hidden_gems(_args(history_path, trend_n=3, fmt="csv"))
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Header present.
+    assert out.startswith("timestamp,")
+    # 3 most-recent hashes appear; earliest two do not.
+    assert "hash_02" in out
+    assert "hash_03" in out
+    assert "hash_04" in out
+    assert "hash_00" not in out
+    assert "hash_01" not in out
+
+
+# ---------------------------------------------------------------------------
+# Markdown
+# ---------------------------------------------------------------------------
+
+
+def test_md_format_emits_markdown_table(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    history_path = tmp_path / ".audit" / "history.csv"
+    bench_history.append_run(_make_report(live_config_hash="md_hash"), path=history_path)
+
+    rc = handlers.handle_trend_hidden_gems(_args(history_path, fmt="md"))
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Markdown table has pipe-delimited header row.
+    assert "|" in out
+    assert "timestamp" in out
+    assert "md_hash" in out
+    # Separator row with dashes.
+    assert "---" in out
+
+
+# ---------------------------------------------------------------------------
+# JSON
+# ---------------------------------------------------------------------------
+
+
+def test_json_format_emits_valid_list(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    history_path = tmp_path / ".audit" / "history.csv"
+    bench_history.append_run(_make_report(live_config_hash="json_hash"), path=history_path)
+
+    rc = handlers.handle_trend_hidden_gems(_args(history_path, fmt="json"))
+    assert rc == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert isinstance(payload, list)
+    assert payload[0]["config_hash"] == "json_hash"
+
+
+# ---------------------------------------------------------------------------
+# Edge — no history yet
+# ---------------------------------------------------------------------------
+
+
+def test_missing_history_exits_0_with_stderr(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """No ``.audit/history.csv`` → exit 0, stderr actionable message, empty stdout."""
+    history_path = tmp_path / ".audit" / "history.csv"  # doesn't exist
+    rc = handlers.handle_trend_hidden_gems(_args(history_path))
+    assert rc == 0
+    cap = capsys.readouterr()
+    assert cap.out == ""
+    assert "no history" in cap.err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Edge — trend-n 0 in CSV format → header only
+# ---------------------------------------------------------------------------
+
+
+def test_trend_n_zero_yields_header_only_in_csv(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    history_path = tmp_path / ".audit" / "history.csv"
+    bench_history.append_run(_make_report(live_config_hash="only"), path=history_path)
+
+    rc = handlers.handle_trend_hidden_gems(_args(history_path, trend_n=0, fmt="csv"))
+    assert rc == 0
+    out = capsys.readouterr().out
+    # CSV format: header present but no data rows.
+    lines = [line for line in out.splitlines() if line.strip()]
+    assert len(lines) == 1
+    assert lines[0].startswith("timestamp,")
+    assert "only" not in out
+
+
+# ---------------------------------------------------------------------------
+# --output PATH
+# ---------------------------------------------------------------------------
+
+
+def test_output_writes_to_file_with_stderr_confirmation(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    history_path = tmp_path / ".audit" / "history.csv"
+    bench_history.append_run(_make_report(live_config_hash="output_hash"), path=history_path)
+
+    out_path = tmp_path / "trend.csv"
+    rc = handlers.handle_trend_hidden_gems(
+        _args(history_path, output=str(out_path)),
+    )
+    assert rc == 0
+    assert out_path.exists()
+    content = out_path.read_text(encoding="utf-8")
+    assert "output_hash" in content
+    cap = capsys.readouterr()
+    assert cap.out == ""
+    assert str(out_path) in cap.err
+
+
+# ---------------------------------------------------------------------------
+# CLI dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_cli_dispatch_routes_to_handle_trend(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``main(["audit", "--trend", "hidden_gems"])`` routes via register()."""
+    import mtg_synergy_graph.bench  # ensure registration  # noqa: F401
+    from mtg_synergy_graph.bench.cli import main
+
+    history_path = tmp_path / ".audit" / "history.csv"
+    bench_history.append_run(_make_report(live_config_hash="cli_hash"), path=history_path)
+
+    rc = main(
+        [
+            "audit",
+            "--trend",
+            "hidden_gems",
+            "--history",
+            str(history_path),
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "cli_hash" in out
+
+
+def test_trend_mutually_exclusive_with_other_modes() -> None:
+    """``--trend`` is in the mode mutex group → combining with another
+    mode flag raises SystemExit from argparse."""
+    from mtg_synergy_graph.bench.cli import main
+
+    with pytest.raises(SystemExit):
+        main(["audit", "--trend", "hidden_gems", "--expect-identity"])
+
+
+def test_trend_rejects_unknown_value() -> None:
+    """``--trend bogus`` rejected by argparse choices."""
+    from mtg_synergy_graph.bench.cli import main
+
+    with pytest.raises(SystemExit):
+        main(["audit", "--trend", "bogus"])
+
+
+# ---------------------------------------------------------------------------
+# Integration: audit then trend
+# ---------------------------------------------------------------------------
+
+
+def test_audit_appends_and_trend_shows_it(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """After ``bench.py audit`` runs, ``--trend`` shows the just-appended row.
+
+    Simulated by directly invoking ``history.append_run`` (covered elsewhere
+    end-to-end) then calling handle_trend.
+    """
+    history_path = tmp_path / ".audit" / "history.csv"
+    bench_history.append_run(
+        _make_report(live_config_hash="just_appended"),
+        path=history_path,
+    )
+
+    rc = handlers.handle_trend_hidden_gems(_args(history_path))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "just_appended" in out

--- a/tests/bench/test_hidden_gems_core.py
+++ b/tests/bench/test_hidden_gems_core.py
@@ -1,0 +1,388 @@
+"""Unit 1 of plan 003 — hidden-gem metric core.
+
+Pure-function tests for ``plausibility`` +
+``hidden_gem_hit_rate_for_commander`` +
+``aggregate_hidden_gem_hit_rate``.
+
+Every scenario here is DB-agnostic: tests pass tensor rows as plain
+``(candidate, rule_id, contribution)`` tuples. The module stays DB-free
+by design; Unit 2 shapes sqlite rows into this form.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from mtg_synergy_graph.bench.hidden_gems import (
+    _HIDDEN_GEM_WARN_THRESHOLD,
+    HiddenGemEntry,
+    HiddenGemReport,
+    aggregate_hidden_gem_hit_rate,
+    hidden_gem_hit_rate_for_commander,
+    plausibility,
+)
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+
+def test_threshold_constant_is_002() -> None:
+    """FR4 pins the warning threshold at 0.02."""
+    assert pytest.approx(0.02) == _HIDDEN_GEM_WARN_THRESHOLD
+
+
+# ---------------------------------------------------------------------------
+# plausibility
+# ---------------------------------------------------------------------------
+
+
+def test_plausibility_true_when_at_least_two_rules_fire() -> None:
+    """FR2 leg 1: ``N_rules_firing(cmdr, cand) >= 2``."""
+    rows = [
+        ("card_a", "rule_x", 0.3),
+        ("card_a", "rule_y", 0.2),
+        # card_b below median, only 1 rule — still included to flesh
+        # out a median worth comparing against.
+        ("card_b", "rule_x", 0.1),
+    ]
+    assert plausibility("C", "card_a", rows) is True
+
+
+def test_plausibility_false_when_single_rule_below_median() -> None:
+    """One rule firing AND total ≤ median → False."""
+    rows = [
+        ("card_a", "rule_x", 0.1),
+        ("card_b", "rule_x", 1.0),
+        ("card_b", "rule_y", 1.0),
+        ("card_c", "rule_x", 0.5),
+        ("card_c", "rule_z", 0.5),
+    ]
+    # card_a total 0.1, medians of {0.1, 2.0, 1.0} = 1.0 → 0.1 < 1.0.
+    assert plausibility("C", "card_a", rows) is False
+
+
+def test_plausibility_true_via_median_or_leg() -> None:
+    """FR2 leg 2: single rule but contribution > per-commander median."""
+    rows = [
+        ("card_a", "rule_x", 5.0),  # 1 rule, very high
+        ("card_b", "rule_x", 0.1),
+        ("card_b", "rule_y", 0.1),
+        ("card_c", "rule_x", 0.1),
+        ("card_c", "rule_z", 0.1),
+    ]
+    # card_a total 5.0, totals are {5.0, 0.2, 0.2}, median 0.2 → 5.0 > 0.2.
+    assert plausibility("C", "card_a", rows) is True
+
+
+def test_plausibility_false_when_equal_to_median() -> None:
+    """Strict inequality — ``total == median`` → False (unless N_rules leg)."""
+    rows = [
+        ("card_a", "rule_x", 1.0),  # 1 rule
+        ("card_b", "rule_x", 1.0),  # 1 rule
+        ("card_c", "rule_x", 1.0),  # 1 rule
+    ]
+    # All equal, median = 1.0, card_a total = 1.0 → NOT strictly greater.
+    assert plausibility("C", "card_a", rows) is False
+
+
+def test_plausibility_ignores_negative_contributions() -> None:
+    """Negatives shouldn't count toward ``N_rules_firing`` or total.
+
+    If a rule subtracts, the card is less plausible, not more.
+    """
+    rows = [
+        # card_a: 2 negative + 1 positive → only 1 firing, total = 0.5
+        ("card_a", "rule_neg_1", -0.5),
+        ("card_a", "rule_neg_2", -0.3),
+        ("card_a", "rule_pos", 0.5),
+        ("card_b", "rule_pos", 1.0),
+        ("card_b", "rule_pos2", 1.0),
+    ]
+    # card_a only has 1 rule > 0; totals (pos only) = {0.5, 2.0},
+    # median = 1.25, card_a = 0.5 < 1.25 → False.
+    assert plausibility("C", "card_a", rows) is False
+
+
+def test_plausibility_all_zero_contributions_always_false() -> None:
+    """Every contribution = 0 → both legs fail → every candidate False."""
+    rows = [
+        ("card_a", "rule_x", 0.0),
+        ("card_a", "rule_y", 0.0),
+        ("card_b", "rule_x", 0.0),
+    ]
+    assert plausibility("C", "card_a", rows) is False
+    assert plausibility("C", "card_b", rows) is False
+
+
+def test_plausibility_zero_median_falls_back_to_n_rules() -> None:
+    """When every non-zero candidate total is 0 → median is vacuous.
+
+    If the median leg would make every non-zero candidate "greater than
+    zero" and therefore plausible, that's wrong. Fall back to the
+    N_rules leg.
+    """
+    # All contributions zero — nothing positive.
+    rows = [
+        ("card_a", "rule_x", 0.0),
+        ("card_b", "rule_x", 0.0),
+    ]
+    assert plausibility("C", "card_a", rows) is False
+
+
+def test_plausibility_single_candidate_no_zero_division() -> None:
+    """Commander with one candidate → median = that one value; clean."""
+    rows = [("card_a", "rule_x", 0.7)]
+    # Only one candidate, only one rule → N_rules = 1, median = 0.7,
+    # total = 0.7, NOT strictly greater → False.
+    assert plausibility("C", "card_a", rows) is False
+
+
+def test_plausibility_candidate_missing_from_rows_is_false() -> None:
+    """Asking about a candidate with no rule firings → False."""
+    rows = [
+        ("card_a", "rule_x", 0.5),
+        ("card_a", "rule_y", 0.5),
+    ]
+    assert plausibility("C", "card_missing", rows) is False
+
+
+def test_plausibility_duplicate_rule_ids_sum_into_total() -> None:
+    """Same rule_id firing twice — both count toward N_rules + total.
+
+    Unit 1 does no deduplication: tensor rows are authoritative.
+    If Unit 2's query ever produces duplicates, we treat each row as
+    real.
+    """
+    rows = [
+        ("card_a", "rule_x", 0.4),
+        ("card_a", "rule_x", 0.4),  # duplicate rule_id
+        ("card_b", "rule_x", 0.1),
+    ]
+    # card_a has 2 firings → True via N_rules leg.
+    assert plausibility("C", "card_a", rows) is True
+
+
+# ---------------------------------------------------------------------------
+# hidden_gem_hit_rate_for_commander
+# ---------------------------------------------------------------------------
+
+
+def test_hit_rate_happy_path_two_hidden_plausible() -> None:
+    """5 of our top-30 hidden, EDHREC covers 3; remaining 2 each fire 3
+    rules → rate = 2/30."""
+    our_top_30 = ["c1", "c2", "c3", "c4", "c5", *[f"filler_{i}" for i in range(25)]]
+    edhrec = {"c1", "c2", "c3"}
+    # c4, c5 each have 3 rules firing → plausible.
+    rows: list[tuple[str, str, float]] = [
+        ("c4", "rule_a", 0.3),
+        ("c4", "rule_b", 0.2),
+        ("c4", "rule_c", 0.1),
+        ("c5", "rule_a", 0.2),
+        ("c5", "rule_b", 0.2),
+        ("c5", "rule_c", 0.2),
+        # Some non-hidden candidates to stabilize the median.
+        ("c1", "rule_a", 0.1),
+    ]
+    entry = hidden_gem_hit_rate_for_commander("C", our_top_30, edhrec, rows)
+    assert entry is not None
+    assert entry.commander == "C"
+    assert entry.rate == pytest.approx(2 / 30)
+    assert set(entry.hidden_cards) == {"c4", "c5"}
+
+
+def test_hit_rate_happy_path_median_or_leg_one_hidden() -> None:
+    """1 hidden card, N_rules=1 but total > median → rate = 1/30."""
+    our_top_30 = ["c1", *[f"filler_{i}" for i in range(29)]]
+    edhrec: set[str] = set()  # c1 is hidden
+    rows: list[tuple[str, str, float]] = [
+        # c1 single rule, very high total.
+        ("c1", "rule_a", 10.0),
+        # baseline candidates so median = small.
+        ("other_1", "rule_a", 0.1),
+        ("other_2", "rule_a", 0.1),
+    ]
+    entry = hidden_gem_hit_rate_for_commander("C", our_top_30, edhrec, rows)
+    assert entry is not None
+    assert entry.rate == pytest.approx(1 / 30)
+    assert entry.hidden_cards == ("c1",)
+
+
+def test_hit_rate_empty_hidden_set_zero_rate() -> None:
+    """EDHREC covers all our top-30 → rate 0, empty hidden_cards list."""
+    our_top_30 = [f"c_{i}" for i in range(30)]
+    edhrec = set(our_top_30)
+    entry = hidden_gem_hit_rate_for_commander("C", our_top_30, edhrec, [])
+    assert entry is not None
+    assert entry.rate == 0.0
+    assert entry.hidden_cards == ()
+
+
+def test_hit_rate_edhrec_none_returns_none() -> None:
+    """``edhrec_top_30=None`` → skip (function returns None)."""
+    our_top_30 = [f"c_{i}" for i in range(30)]
+    entry = hidden_gem_hit_rate_for_commander("C", our_top_30, None, [])
+    assert entry is None
+
+
+def test_hit_rate_single_candidate_no_crash() -> None:
+    """One candidate across entire commander → median logic holds."""
+    our_top_30 = ["only_card"]
+    edhrec: set[str] = set()
+    rows = [("only_card", "rule_a", 0.5)]
+    entry = hidden_gem_hit_rate_for_commander("C", our_top_30, edhrec, rows)
+    assert entry is not None
+    # N_rules = 1, median = 0.5, total = 0.5 → not plausible.
+    assert entry.rate == 0.0
+    assert entry.hidden_cards == ()
+
+
+def test_hit_rate_all_zero_contributions_no_plausible() -> None:
+    """All-zero tensor → plausibility False everywhere → rate 0."""
+    our_top_30 = [f"c_{i}" for i in range(30)]
+    edhrec: set[str] = set()
+    rows = [(f"c_{i}", "rule_a", 0.0) for i in range(30)]
+    entry = hidden_gem_hit_rate_for_commander("C", our_top_30, edhrec, rows)
+    assert entry is not None
+    assert entry.rate == 0.0
+    assert entry.hidden_cards == ()
+
+
+def test_hit_rate_duplicates_in_our_top_30_raises() -> None:
+    """Duplicate in ``our_top_30`` → ``ValueError``."""
+    our_top_30 = ["c1", "c2", "c1"]
+    with pytest.raises(ValueError, match="our_top_30 must be unique"):
+        hidden_gem_hit_rate_for_commander("C", our_top_30, set(), [])
+
+
+def test_hit_rate_determinism_same_inputs_same_output() -> None:
+    """R7: repeated calls on identical inputs → identical dataclass."""
+    our_top_30 = ["c1", "c2", "c3", *[f"filler_{i}" for i in range(27)]]
+    edhrec = {"c1"}
+    rows = [
+        ("c2", "rule_a", 0.3),
+        ("c2", "rule_b", 0.3),
+        ("c3", "rule_a", 0.1),
+    ]
+    a = hidden_gem_hit_rate_for_commander("C", our_top_30, edhrec, rows)
+    b = hidden_gem_hit_rate_for_commander("C", list(our_top_30), set(edhrec), list(rows))
+    assert a == b
+    assert a is not None and b is not None
+    assert a.rate == b.rate
+    assert a.hidden_cards == b.hidden_cards
+
+
+def test_hit_rate_ordering_of_our_top_30_does_not_matter() -> None:
+    """Reordering ``our_top_30`` → same entry (set semantics on input)."""
+    cards = ["c1", "c2", "c3", *[f"filler_{i}" for i in range(27)]]
+    edhrec = {"c1"}
+    rows = [
+        ("c2", "rule_a", 0.3),
+        ("c2", "rule_b", 0.3),
+    ]
+    a = hidden_gem_hit_rate_for_commander("C", cards, edhrec, rows)
+    reordered = list(reversed(cards))
+    b = hidden_gem_hit_rate_for_commander("C", reordered, edhrec, rows)
+    assert a is not None and b is not None
+    assert a.rate == b.rate
+    assert set(a.hidden_cards) == set(b.hidden_cards)
+
+
+def test_hit_rate_hidden_cards_tuple_sorted() -> None:
+    """``hidden_cards`` output is sorted for deterministic equality.
+
+    Without sorting, set-subtraction order would depend on hash
+    randomization and break the deep-equality determinism test.
+    """
+    our_top_30 = ["zeta", "alpha", "mu", *[f"filler_{i}" for i in range(27)]]
+    edhrec: set[str] = set()
+    rows: list[tuple[str, str, float]] = [
+        ("zeta", "rule_a", 1.0),
+        ("zeta", "rule_b", 1.0),
+        ("alpha", "rule_a", 1.0),
+        ("alpha", "rule_b", 1.0),
+        ("mu", "rule_a", 1.0),
+        ("mu", "rule_b", 1.0),
+    ]
+    entry = hidden_gem_hit_rate_for_commander("C", our_top_30, edhrec, rows)
+    assert entry is not None
+    # alphabetical order; not insertion order.
+    assert entry.hidden_cards == ("alpha", "mu", "zeta")
+
+
+# ---------------------------------------------------------------------------
+# aggregate_hidden_gem_hit_rate
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_mixes_none_and_real_entries() -> None:
+    """None entries → skipped_commanders; mean over non-None."""
+    e1 = HiddenGemEntry(commander="C1", rate=0.1, hidden_cards=("x",))
+    e2 = HiddenGemEntry(commander="C2", rate=0.2, hidden_cards=("y",))
+    report = aggregate_hidden_gem_hit_rate([("C1", e1), ("C2", e2), ("C3_skipped", None)])
+    assert isinstance(report, HiddenGemReport)
+    assert report.aggregate == pytest.approx(0.15)
+    assert set(report.per_commander.keys()) == {"C1", "C2"}
+    assert report.skipped_commanders == ("C3_skipped",)
+
+
+def test_aggregate_all_none_gives_none_aggregate() -> None:
+    """Every entry None → aggregate None; all commanders skipped."""
+    report = aggregate_hidden_gem_hit_rate([("C1", None), ("C2", None), ("C3", None)])
+    assert report.aggregate is None
+    assert report.per_commander == {}
+    assert set(report.skipped_commanders) == {"C1", "C2", "C3"}
+
+
+def test_aggregate_empty_input_gives_none_aggregate() -> None:
+    """Empty iterable → aggregate None; no crash."""
+    report = aggregate_hidden_gem_hit_rate([])
+    assert report.aggregate is None
+    assert report.per_commander == {}
+    assert report.skipped_commanders == ()
+
+
+def test_aggregate_single_real_entry() -> None:
+    """Single real entry → aggregate = that entry's rate."""
+    e = HiddenGemEntry(commander="C1", rate=0.333, hidden_cards=())
+    report = aggregate_hidden_gem_hit_rate([("C1", e)])
+    assert report.aggregate == pytest.approx(0.333)
+    assert report.per_commander == {"C1": e}
+    assert report.skipped_commanders == ()
+
+
+def test_aggregate_preserves_entries_in_per_commander_dict() -> None:
+    """Non-None entries are stored verbatim, keyed by commander name."""
+    e1 = HiddenGemEntry(commander="C1", rate=0.1, hidden_cards=("a", "b"))
+    e2 = HiddenGemEntry(commander="C2", rate=0.5, hidden_cards=("c",))
+    report = aggregate_hidden_gem_hit_rate([("C1", e1), ("C2", e2)])
+    assert report.per_commander["C1"] is e1
+    assert report.per_commander["C2"] is e2
+
+
+# ---------------------------------------------------------------------------
+# Dataclass semantics
+# ---------------------------------------------------------------------------
+
+
+def test_hidden_gem_entry_is_frozen() -> None:
+    """``HiddenGemEntry`` is frozen for immutability (FR per project rules)."""
+    e = HiddenGemEntry(commander="C", rate=0.1, hidden_cards=("x",))
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        e.rate = 0.2  # type: ignore[misc]
+
+
+def test_hidden_gem_report_is_frozen() -> None:
+    """``HiddenGemReport`` is frozen."""
+    r = HiddenGemReport(aggregate=0.1, per_commander={}, skipped_commanders=())
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        r.aggregate = 0.2  # type: ignore[misc]
+
+
+def test_hidden_gem_entry_deep_equality() -> None:
+    """Equivalent inputs → equal dataclass instances (supports R7)."""
+    a = HiddenGemEntry(commander="C", rate=0.5, hidden_cards=("x", "y"))
+    b = HiddenGemEntry(commander="C", rate=0.5, hidden_cards=("x", "y"))
+    assert a == b

--- a/tests/bench/test_hidden_gems_core.py
+++ b/tests/bench/test_hidden_gems_core.py
@@ -16,7 +16,7 @@ import dataclasses
 import pytest
 
 from mtg_synergy_graph.bench.hidden_gems import (
-    _HIDDEN_GEM_WARN_THRESHOLD,
+    HIDDEN_GEM_WARN_THRESHOLD,
     HiddenGemEntry,
     HiddenGemReport,
     aggregate_hidden_gem_hit_rate,
@@ -31,7 +31,7 @@ from mtg_synergy_graph.bench.hidden_gems import (
 
 def test_threshold_constant_is_002() -> None:
     """FR4 pins the warning threshold at 0.02."""
-    assert pytest.approx(0.02) == _HIDDEN_GEM_WARN_THRESHOLD
+    assert pytest.approx(0.02) == HIDDEN_GEM_WARN_THRESHOLD
 
 
 # ---------------------------------------------------------------------------

--- a/tests/bench/test_history.py
+++ b/tests/bench/test_history.py
@@ -1,0 +1,322 @@
+"""Tests for ``.audit/history.csv`` append-only log (Unit 5 of hidden-gem plan).
+
+Covers the read / write surface of ``bench.history``:
+
+* ``append_run`` writes a header on first call, appends data-only rows
+  afterwards, tolerates missing git checkouts, and never raises on I/O
+  failure.
+* ``read_last`` returns the last N rows, skips malformed lines with a
+  stderr warning, and returns [] when the file doesn't exist.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mtg_synergy_graph.bench import history as bench_history
+from mtg_synergy_graph.bench.fixture import IdentityReport
+from mtg_synergy_graph.bench.histogram import Histogram, Verdict
+from mtg_synergy_graph.bench.report import AuditReport
+
+# Capture the real ``_commit_sha`` before the autouse stub below replaces
+# the module attribute. Tests that want to exercise the real function
+# reinstate this reference via ``monkeypatch.setattr`` on the module.
+_REAL_COMMIT_SHA = bench_history._commit_sha
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_report(
+    *,
+    live_config_hash: str = "abc1234567890def",
+    aggregate_score_delta: float = 0.0,
+    aggregate_hidden_gem_hit_rate: float | None = 0.1467,
+    hidden_gem_hit_rate_delta: float | None = -0.0034,
+    commanders_compared: int = 100,
+    commanders_with_edhrec: int = 97,
+    verdict: Verdict = Verdict.TRIVIAL,
+) -> AuditReport:
+    """Synthesize an ``AuditReport`` with just the fields ``append_run`` reads."""
+    identity = IdentityReport(
+        config_hash_mismatch=None,
+        missing_commanders=[],
+        score_mismatches=[],
+    )
+    return AuditReport(
+        fixture_path="baseline.json",
+        pinned_config_hash="pinned_hash",
+        live_config_hash=live_config_hash,
+        aggregate_score_delta=aggregate_score_delta,
+        commanders_compared=commanders_compared,
+        identity_report=identity,
+        histogram=Histogram(samples={}),
+        verdict=verdict,
+        aggregate_hidden_gem_hit_rate=aggregate_hidden_gem_hit_rate,
+        pinned_hidden_gem_hit_rate=0.15,
+        hidden_gem_hit_rate_delta=hidden_gem_hit_rate_delta,
+        hidden_gem_warning=False,
+        commanders_with_edhrec=commanders_with_edhrec,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_commit_sha(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return a stable hash so tests 1-3 don't depend on the real git state."""
+    monkeypatch.setattr(bench_history, "_commit_sha", lambda: "deadbeefcafe")
+
+
+# ---------------------------------------------------------------------------
+# append_run
+# ---------------------------------------------------------------------------
+
+
+def test_append_run_writes_header_and_row_on_empty_dir(tmp_path: Path) -> None:
+    """First ``append_run`` on a fresh dir writes header + data row."""
+    path = tmp_path / ".audit" / "history.csv"
+    report = _make_report()
+
+    bench_history.append_run(report, path=path)
+
+    assert path.exists()
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    header = lines[0].split(",")
+    assert header == [
+        "timestamp",
+        "commit_sha",
+        "config_hash",
+        "aggregate_score_delta",
+        "hidden_gem_hit_rate",
+        "hidden_gem_hit_rate_delta",
+        "commanders_compared",
+        "commanders_with_edhrec",
+        "verdict",
+    ]
+    # Data row contains our commit stub and config hash.
+    assert "deadbeefcafe" in lines[1]
+    assert "abc1234567890def" in lines[1]
+
+
+def test_append_run_second_call_appends_only_data(tmp_path: Path) -> None:
+    """Subsequent ``append_run`` calls must not re-emit the header."""
+    path = tmp_path / ".audit" / "history.csv"
+    bench_history.append_run(_make_report(), path=path)
+    bench_history.append_run(_make_report(live_config_hash="second_hash"), path=path)
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3  # header + 2 rows
+    assert lines[0].startswith("timestamp,")
+    assert "abc1234567890def" in lines[1]
+    assert "second_hash" in lines[2]
+
+
+def test_append_run_empty_file_triggers_header_write(tmp_path: Path) -> None:
+    """An existing but empty file should trigger a header write."""
+    path = tmp_path / ".audit" / "history.csv"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch()  # size 0
+
+    bench_history.append_run(_make_report(), path=path)
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert lines[0].startswith("timestamp,")
+    assert len(lines) == 2
+
+
+# ---------------------------------------------------------------------------
+# read_last
+# ---------------------------------------------------------------------------
+
+
+def test_read_last_returns_newest_rows_in_file_order(tmp_path: Path) -> None:
+    """``read_last(3)`` on a 10-row file returns rows 8, 9, 10 (chronological)."""
+    path = tmp_path / ".audit" / "history.csv"
+    for i in range(10):
+        bench_history.append_run(
+            _make_report(live_config_hash=f"hash_{i:02d}"),
+            path=path,
+        )
+
+    rows = bench_history.read_last(3, path=path)
+    assert len(rows) == 3
+    assert [r.config_hash for r in rows] == ["hash_07", "hash_08", "hash_09"]
+
+
+def test_read_last_returns_all_when_n_exceeds_file(tmp_path: Path) -> None:
+    """``read_last(n)`` with ``n > file_length`` returns all rows (no padding)."""
+    path = tmp_path / ".audit" / "history.csv"
+    bench_history.append_run(_make_report(live_config_hash="only"), path=path)
+
+    rows = bench_history.read_last(20, path=path)
+    assert len(rows) == 1
+    assert rows[0].config_hash == "only"
+
+
+def test_read_last_returns_empty_when_file_missing(tmp_path: Path) -> None:
+    """``read_last`` on a missing file returns ``[]``."""
+    path = tmp_path / ".audit" / "nope.csv"
+    rows = bench_history.read_last(5, path=path)
+    assert rows == []
+
+
+def test_read_last_skips_malformed_lines_with_warning(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A row with the wrong field count is skipped, but other rows survive."""
+    path = tmp_path / ".audit" / "history.csv"
+    # Two valid rows + one malformed between them.
+    bench_history.append_run(_make_report(live_config_hash="good_a"), path=path)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write("garbage_row_with,only_two_fields\n")
+    bench_history.append_run(_make_report(live_config_hash="good_b"), path=path)
+
+    rows = bench_history.read_last(10, path=path)
+    hashes = [r.config_hash for r in rows]
+    assert "good_a" in hashes
+    assert "good_b" in hashes
+    err = capsys.readouterr().err
+    assert "skipping" in err.lower() or "malformed" in err.lower() or "bad" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Optional-field handling
+# ---------------------------------------------------------------------------
+
+
+def test_append_run_none_gem_rate_writes_empty_string(tmp_path: Path) -> None:
+    """``aggregate_hidden_gem_hit_rate is None`` → CSV column is empty (not "None")."""
+    path = tmp_path / ".audit" / "history.csv"
+    report = _make_report(
+        aggregate_hidden_gem_hit_rate=None,
+        hidden_gem_hit_rate_delta=None,
+        commanders_with_edhrec=0,
+    )
+    bench_history.append_run(report, path=path)
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    data_row = lines[1].split(",")
+    # Find the position by parsing the header.
+    header = lines[0].split(",")
+    gem_rate_idx = header.index("hidden_gem_hit_rate")
+    gem_delta_idx = header.index("hidden_gem_hit_rate_delta")
+    assert data_row[gem_rate_idx] == ""
+    assert data_row[gem_delta_idx] == ""
+    # Not the literal string "None".
+    assert "None" not in data_row
+
+
+# ---------------------------------------------------------------------------
+# Git-commit handling
+# ---------------------------------------------------------------------------
+
+
+def test_commit_sha_empty_when_git_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_commit_sha`` returns "" if subprocess.run raises FileNotFoundError
+    (git binary missing) or CalledProcessError (not a git checkout)."""
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise FileNotFoundError("no git")
+
+    # Reinstate the real function so we exercise it instead of the autouse stub.
+    monkeypatch.setattr(bench_history, "_commit_sha", _REAL_COMMIT_SHA)
+    monkeypatch.setattr(subprocess, "run", _boom)
+
+    assert bench_history._commit_sha() == ""
+
+
+def test_commit_sha_empty_on_non_git_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Running the real ``_commit_sha`` in a non-git directory → empty string."""
+    monkeypatch.setattr(bench_history, "_commit_sha", _REAL_COMMIT_SHA)
+    monkeypatch.chdir(tmp_path)
+    sha = bench_history._commit_sha()
+    assert sha == ""
+
+
+def test_append_run_with_empty_commit_sha(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Row shape is stable when commit_sha is empty — other fields still present."""
+    monkeypatch.setattr(bench_history, "_commit_sha", lambda: "")
+    path = tmp_path / ".audit" / "history.csv"
+    bench_history.append_run(_make_report(), path=path)
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    header = lines[0].split(",")
+    data = lines[1].split(",")
+    assert len(data) == len(header)
+    commit_idx = header.index("commit_sha")
+    assert data[commit_idx] == ""
+    # Other fields still populated.
+    config_idx = header.index("config_hash")
+    assert data[config_idx] == "abc1234567890def"
+
+
+# ---------------------------------------------------------------------------
+# Error resilience
+# ---------------------------------------------------------------------------
+
+
+def test_append_run_never_raises_on_io_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """I/O failure logs a stderr warning but does NOT raise."""
+    # Point at a path that can never be written (parent doesn't exist and
+    # we sabotage mkdir).
+    bad_path = Path("/nonexistent/root/impossible/history.csv")
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise OSError("read-only")
+
+    monkeypatch.setattr(Path, "mkdir", _boom)
+    # Should not raise.
+    bench_history.append_run(_make_report(), path=bad_path)
+
+    err = capsys.readouterr().err
+    # A warning is emitted.
+    assert "history" in err.lower() or "warn" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_preserves_fields(tmp_path: Path) -> None:
+    """Write then read: every numeric field round-trips as expected."""
+    path = tmp_path / ".audit" / "history.csv"
+    report = _make_report(
+        live_config_hash="roundtrip_hash",
+        aggregate_score_delta=1.234567,
+        aggregate_hidden_gem_hit_rate=0.555,
+        hidden_gem_hit_rate_delta=-0.025,
+        commanders_compared=100,
+        commanders_with_edhrec=95,
+        verdict=Verdict.POSITIVE,
+    )
+    bench_history.append_run(report, path=path)
+
+    rows = bench_history.read_last(1, path=path)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.commit_sha == "deadbeefcafe"
+    assert row.config_hash == "roundtrip_hash"
+    assert row.aggregate_score_delta == pytest.approx(1.234567, rel=1e-5)
+    assert row.hidden_gem_hit_rate == pytest.approx(0.555, rel=1e-5)
+    assert row.hidden_gem_hit_rate_delta == pytest.approx(-0.025, rel=1e-5)
+    assert row.commanders_compared == 100
+    assert row.commanders_with_edhrec == 95
+    assert row.verdict == "positive"

--- a/tests/bench/test_history.py
+++ b/tests/bench/test_history.py
@@ -295,6 +295,58 @@ def test_append_run_never_raises_on_io_failure(
 # ---------------------------------------------------------------------------
 
 
+def test_truncated_file_between_appends_still_gets_header(tmp_path: Path) -> None:
+    """P2 fix #12: file truncated to 0 bytes between appends → second
+    append re-emits the header instead of producing a bare data row.
+
+    Not true concurrency but exercises the "empty file after first
+    write" edge the TOCTOU fix must handle. With the old
+    ``Path.stat().st_size == 0`` branch outside the ``open`` call the
+    behavior was still correct for serial truncation; the new
+    ``tell()``-based check must preserve it.
+    """
+    path = tmp_path / ".audit" / "history.csv"
+    bench_history.append_run(_make_report(live_config_hash="first"), path=path)
+    # Truncate the file to 0 bytes (simulates a concurrent writer that
+    # observed an empty state between our check and write).
+    path.write_text("", encoding="utf-8")
+    bench_history.append_run(_make_report(live_config_hash="second"), path=path)
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    # After truncation + re-append: header + exactly one data row.
+    assert len(lines) == 2
+    assert lines[0].startswith("timestamp,")
+    assert "second" in lines[1]
+
+
+def test_read_last_emits_aggregate_skip_summary_for_malformed_rows(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """P2 fix #17: read_last emits one consolidated summary warning
+    alongside per-row warnings when malformed rows are skipped."""
+    path = tmp_path / ".audit" / "history.csv"
+    # Start with a valid header via append_run.
+    bench_history.append_run(_make_report(live_config_hash="good_1"), path=path)
+    # Inject 3 malformed rows interleaved with valid ones.
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write("malformed,too,few\n")
+        fh.write("malformed,two,fields\n")
+    bench_history.append_run(_make_report(live_config_hash="good_2"), path=path)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write("one_field_row\n")
+    bench_history.append_run(_make_report(live_config_hash="good_3"), path=path)
+
+    # 3 malformed + 3 valid = 6 data rows; 3 skipped.
+    rows = bench_history.read_last(10, path=path)
+    err = capsys.readouterr().err
+    assert len(rows) == 3
+    # Summary line present.
+    assert "skipped 3" in err
+    assert "of 6" in err
+    assert "malformed" in err.lower()
+
+
 def test_round_trip_preserves_fields(tmp_path: Path) -> None:
     """Write then read: every numeric field round-trips as expected."""
     path = tmp_path / ".audit" / "history.csv"

--- a/tests/bench/test_hook_entry.py
+++ b/tests/bench/test_hook_entry.py
@@ -100,6 +100,38 @@ def test_hook_pass_after_repin(isolated_cwd: Path, capsys: pytest.CaptureFixture
     assert (isolated_cwd / ".audit" / "last.md").exists()
 
 
+def test_hook_csv_format_warns_and_skips_write(
+    isolated_cwd: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """BENCH_FORMAT=csv is only meaningful for ``--trend``. The hook
+    should NOT silently fall back to markdown (the historical bug) and
+    should NOT crash; it should emit a stderr warning and skip the
+    ``.audit/last.*`` write.
+    """
+    db_path = isolated_cwd / "synergy.db"
+    fixture_path = isolated_cwd / "baseline.json"
+    _seed(db_path)
+    _prepin(db_path, fixture_path)
+
+    with patch.dict(
+        "os.environ",
+        {
+            "BENCH_DB": str(db_path),
+            "BENCH_FIXTURE": str(fixture_path),
+            "BENCH_FORMAT": "csv",
+        },
+    ):
+        exit_code = hook_entry.main()
+
+    assert exit_code == 0
+    err = capsys.readouterr().err
+    assert "csv" in err.lower()
+    # No last.md or last.json should be written on csv format.
+    assert not (isolated_cwd / ".audit" / "last.md").exists()
+    assert not (isolated_cwd / ".audit" / "last.json").exists()
+
+
 def test_hook_json_format_writes_json(isolated_cwd: Path) -> None:
     """BENCH_FORMAT=json produces parseable JSON at .audit/last.json."""
     db_path = isolated_cwd / "synergy.db"

--- a/tests/bench/test_report_hidden_gems.py
+++ b/tests/bench/test_report_hidden_gems.py
@@ -1,0 +1,271 @@
+"""Audit report integration of hidden-gem metric (Unit 3 of plan 003).
+
+Tests that ``build_report`` aggregates ``legacy["hidden_gem_hit_rate"]``
+across entries, computes the delta vs pinned, and populates the new
+``AuditReport`` fields (aggregate, pinned, delta, warning flag,
+commander count). Markdown and JSON renderers surface the new values
+with the expected formatting and keys.
+
+All fixtures are synthesized in-memory — this file is a pure-function
+test of the report layer, not an end-to-end pipeline test.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mtg_synergy_graph.bench.fixture import FixtureEntry, PinnedFixture
+from mtg_synergy_graph.bench.hidden_gems import _HIDDEN_GEM_WARN_THRESHOLD
+from mtg_synergy_graph.bench.report import build_report
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fixture_with_gem_rates(rates: list[float | None]) -> PinnedFixture:
+    """Build a ``PinnedFixture`` with one entry per rate.
+
+    A ``None`` rate means the commander has no EDHREC data → gem keys
+    absent from ``legacy``.
+    """
+    entries: list[FixtureEntry] = []
+    for i, rate in enumerate(rates):
+        legacy: dict[str, object] = {}
+        if rate is not None:
+            legacy["hidden_gem_hit_rate"] = rate
+            legacy["hidden_cards"] = []
+        entries.append(
+            FixtureEntry(
+                commander=f"Cmdr_{i}",
+                scores={f"cand_{i}": 1.0},
+                legacy=legacy,
+            )
+        )
+    return PinnedFixture(config_hash="x", created_at="t", entries=entries)
+
+
+# ---------------------------------------------------------------------------
+# Happy path — aggregate + delta computed
+# ---------------------------------------------------------------------------
+
+
+def test_both_sides_have_gem_data_aggregate_and_delta_computed() -> None:
+    """Pinned + live both populated → aggregate, delta, count all present."""
+    pinned_rates = [0.1, 0.2, 0.15, 0.1, 0.2, 0.1, 0.15, 0.2, 0.1, 0.2]
+    live_rates = [0.1, 0.15, 0.15, 0.1, 0.2, 0.1, 0.15, 0.2, 0.1, 0.2]
+
+    pinned = _fixture_with_gem_rates(list(pinned_rates))
+    live = _fixture_with_gem_rates(list(live_rates))
+
+    report = build_report("baseline.json", pinned, live)
+    assert report.aggregate_hidden_gem_hit_rate is not None
+    assert report.pinned_hidden_gem_hit_rate is not None
+    assert report.hidden_gem_hit_rate_delta is not None
+    assert report.commanders_with_edhrec == 10
+
+    # Delta = live_mean - pinned_mean
+    expected_pinned = sum(pinned_rates) / 10
+    expected_live = sum(live_rates) / 10
+    assert report.pinned_hidden_gem_hit_rate == expected_pinned
+    assert report.aggregate_hidden_gem_hit_rate == expected_live
+    assert report.hidden_gem_hit_rate_delta == expected_live - expected_pinned
+    # Delta above threshold → no warning.
+    assert report.hidden_gem_warning is False
+
+
+def test_both_sides_zero_gives_zero_delta_no_warning() -> None:
+    """Clean case: both pinned + live all zero → delta 0, no warning."""
+    pinned = _fixture_with_gem_rates([0.0, 0.0, 0.0])
+    live = _fixture_with_gem_rates([0.0, 0.0, 0.0])
+    report = build_report("baseline.json", pinned, live)
+    assert report.aggregate_hidden_gem_hit_rate == 0.0
+    assert report.pinned_hidden_gem_hit_rate == 0.0
+    assert report.hidden_gem_hit_rate_delta == 0.0
+    assert report.hidden_gem_warning is False
+
+
+# ---------------------------------------------------------------------------
+# Threshold boundary tests (strict inequality)
+# ---------------------------------------------------------------------------
+
+
+def test_delta_just_above_threshold_no_warning() -> None:
+    """delta = -0.019 → warning False (above -0.02)."""
+    pinned = _fixture_with_gem_rates([0.2])
+    live = _fixture_with_gem_rates([0.181])
+    report = build_report("baseline.json", pinned, live)
+    assert report.hidden_gem_hit_rate_delta is not None
+    assert abs(report.hidden_gem_hit_rate_delta - (-0.019)) < 1e-9
+    assert report.hidden_gem_warning is False
+
+
+def test_delta_exactly_threshold_no_warning_strict_inequality() -> None:
+    """delta bitwise == -_HIDDEN_GEM_WARN_THRESHOLD → warning False.
+
+    Subtraction against zero is exact in IEEE-754, so ``0.0 - threshold``
+    is bitwise ``-threshold``. This lets us test the strict-inequality
+    boundary cleanly.
+    """
+    pinned = _fixture_with_gem_rates([_HIDDEN_GEM_WARN_THRESHOLD])
+    live = _fixture_with_gem_rates([0.0])
+    report = build_report("baseline.json", pinned, live)
+    assert report.hidden_gem_hit_rate_delta is not None
+    # Delta must be at -threshold (not strictly below) — warning stays False.
+    assert report.hidden_gem_hit_rate_delta == -_HIDDEN_GEM_WARN_THRESHOLD
+    assert report.hidden_gem_warning is False
+
+
+def test_delta_below_threshold_triggers_warning() -> None:
+    """delta = -0.0201 → warning True."""
+    pinned = _fixture_with_gem_rates([0.2000])
+    live = _fixture_with_gem_rates([0.1799])
+    report = build_report("baseline.json", pinned, live)
+    assert report.hidden_gem_hit_rate_delta is not None
+    assert report.hidden_gem_hit_rate_delta < -0.02
+    assert report.hidden_gem_warning is True
+
+
+def test_improvement_never_warns() -> None:
+    """Positive delta (metric improved) → warning False."""
+    pinned = _fixture_with_gem_rates([0.10])
+    live = _fixture_with_gem_rates([0.15])
+    report = build_report("baseline.json", pinned, live)
+    assert report.hidden_gem_hit_rate_delta is not None
+    assert report.hidden_gem_hit_rate_delta == pytest.approx(0.05)
+    assert report.hidden_gem_hit_rate_delta > 0
+    assert report.hidden_gem_warning is False
+
+
+# ---------------------------------------------------------------------------
+# Asymmetric availability (old pin / new pin edges)
+# ---------------------------------------------------------------------------
+
+
+def test_live_has_gem_data_pinned_does_not() -> None:
+    """Old pin (no gem keys) + new live → delta None, warning False."""
+    pinned = _fixture_with_gem_rates([None, None])
+    live = _fixture_with_gem_rates([0.1, 0.2])
+    report = build_report("baseline.json", pinned, live)
+    assert report.pinned_hidden_gem_hit_rate is None
+    assert report.aggregate_hidden_gem_hit_rate == pytest.approx(0.15)
+    assert report.hidden_gem_hit_rate_delta is None
+    assert report.hidden_gem_warning is False
+
+
+def test_pinned_has_gem_data_live_does_not() -> None:
+    """Pinned has data, live has none → delta None, warning False."""
+    pinned = _fixture_with_gem_rates([0.1, 0.2])
+    live = _fixture_with_gem_rates([None, None])
+    report = build_report("baseline.json", pinned, live)
+    assert report.pinned_hidden_gem_hit_rate == pytest.approx(0.15)
+    assert report.aggregate_hidden_gem_hit_rate is None
+    assert report.hidden_gem_hit_rate_delta is None
+    assert report.hidden_gem_warning is False
+
+
+def test_no_edhrec_data_anywhere() -> None:
+    """No commander has gem data → aggregate None, count 0."""
+    pinned = _fixture_with_gem_rates([None, None, None])
+    live = _fixture_with_gem_rates([None, None, None])
+    report = build_report("baseline.json", pinned, live)
+    assert report.aggregate_hidden_gem_hit_rate is None
+    assert report.pinned_hidden_gem_hit_rate is None
+    assert report.hidden_gem_hit_rate_delta is None
+    assert report.commanders_with_edhrec == 0
+    assert report.hidden_gem_warning is False
+
+
+# ---------------------------------------------------------------------------
+# Mixed population (some commanders with EDHREC, some without)
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_population_aggregates_only_over_edhrec_commanders() -> None:
+    """5 with gem data, 5 without → aggregate is mean over 5."""
+    pinned = _fixture_with_gem_rates([0.1, None, 0.2, None, 0.3, None, 0.1, None, 0.2, None])
+    live = _fixture_with_gem_rates([0.1, None, 0.2, None, 0.3, None, 0.1, None, 0.2, None])
+    report = build_report("baseline.json", pinned, live)
+    assert report.commanders_with_edhrec == 5
+    assert report.aggregate_hidden_gem_hit_rate is not None
+    assert abs(report.aggregate_hidden_gem_hit_rate - (0.1 + 0.2 + 0.3 + 0.1 + 0.2) / 5) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Rendering — markdown
+# ---------------------------------------------------------------------------
+
+
+def test_markdown_contains_new_line_with_numeric_values() -> None:
+    """Markdown emits the ``**hidden_gem_hit_rate:**`` line."""
+    pinned = _fixture_with_gem_rates([0.10, 0.20, 0.15])
+    live = _fixture_with_gem_rates([0.12, 0.22, 0.17])
+    report = build_report("baseline.json", pinned, live)
+    md = report.to_markdown()
+    assert "hidden_gem_hit_rate" in md
+    # Aggregate formatted with 4 decimals.
+    assert "0.1700" in md
+    # Delta formatted with explicit sign + 4 decimals.
+    assert "+0.0200" in md
+    # Commander count shown.
+    assert "3 cmdrs" in md
+
+
+def test_markdown_no_edhrec_shows_emdash() -> None:
+    """Empty aggregate → markdown uses em-dash sentinel."""
+    pinned = _fixture_with_gem_rates([None, None])
+    live = _fixture_with_gem_rates([None, None])
+    report = build_report("baseline.json", pinned, live)
+    md = report.to_markdown()
+    assert "hidden_gem_hit_rate" in md
+    assert "no commanders with EDHREC data" in md
+
+
+def test_markdown_asymmetric_pinned_missing_shows_delta_emdash() -> None:
+    """Pinned has no gem data but live does → delta em-dash, count shown."""
+    pinned = _fixture_with_gem_rates([None, None])
+    live = _fixture_with_gem_rates([0.1, 0.2])
+    report = build_report("baseline.json", pinned, live)
+    md = report.to_markdown()
+    # Aggregate printed, delta rendered as em-dash because no pinned mean.
+    assert "hidden_gem_hit_rate" in md
+    assert "0.1500" in md
+    assert "Δ —" in md
+
+
+# ---------------------------------------------------------------------------
+# Rendering — JSON
+# ---------------------------------------------------------------------------
+
+
+def test_json_has_all_four_new_keys_at_expected_types() -> None:
+    """JSON output exposes the four new hidden_gem fields."""
+    pinned = _fixture_with_gem_rates([0.10, 0.20])
+    live = _fixture_with_gem_rates([0.12, 0.22])
+    report = build_report("baseline.json", pinned, live)
+    parsed = json.loads(report.to_json())
+
+    assert "aggregate_hidden_gem_hit_rate" in parsed
+    assert "hidden_gem_hit_rate_delta" in parsed
+    assert "hidden_gem_warning" in parsed
+    assert "commanders_with_edhrec" in parsed
+
+    assert isinstance(parsed["aggregate_hidden_gem_hit_rate"], float)
+    assert isinstance(parsed["hidden_gem_hit_rate_delta"], float)
+    assert isinstance(parsed["hidden_gem_warning"], bool)
+    assert isinstance(parsed["commanders_with_edhrec"], int)
+
+
+def test_json_nulls_when_aggregate_none() -> None:
+    """When no gem data exists, JSON values are ``null`` (not ``0``)."""
+    pinned = _fixture_with_gem_rates([None])
+    live = _fixture_with_gem_rates([None])
+    report = build_report("baseline.json", pinned, live)
+    parsed = json.loads(report.to_json())
+
+    assert parsed["aggregate_hidden_gem_hit_rate"] is None
+    assert parsed["hidden_gem_hit_rate_delta"] is None
+    assert parsed["hidden_gem_warning"] is False
+    assert parsed["commanders_with_edhrec"] == 0

--- a/tests/bench/test_report_hidden_gems.py
+++ b/tests/bench/test_report_hidden_gems.py
@@ -17,7 +17,7 @@ import json
 import pytest
 
 from mtg_synergy_graph.bench.fixture import FixtureEntry, PinnedFixture
-from mtg_synergy_graph.bench.hidden_gems import _HIDDEN_GEM_WARN_THRESHOLD
+from mtg_synergy_graph.bench.hidden_gems import HIDDEN_GEM_WARN_THRESHOLD
 from mtg_synergy_graph.bench.report import build_report
 
 # ---------------------------------------------------------------------------
@@ -93,38 +93,55 @@ def test_both_sides_zero_gives_zero_delta_no_warning() -> None:
 
 
 def test_delta_just_above_threshold_no_warning() -> None:
-    """delta = -0.019 → warning False (above -0.02)."""
-    pinned = _fixture_with_gem_rates([0.2])
-    live = _fixture_with_gem_rates([0.181])
+    """Δ strictly above ``-HIDDEN_GEM_WARN_THRESHOLD`` → warning False.
+
+    Pinned and live chosen so ``live - pinned`` is a small negative
+    delta strictly above the negative threshold. The test asserts
+    behavior (no warning) rather than exact float value, since
+    IEEE-754 would otherwise require an exactly-representable delta.
+    """
+    # Construct inputs so live_mean - pinned_mean is well above
+    # -HIDDEN_GEM_WARN_THRESHOLD (which is 0.02). Using 0.0 and 0.01 is
+    # IEEE-754 exact enough for the behavior claim to be robust.
+    pinned = _fixture_with_gem_rates([0.01])
+    live = _fixture_with_gem_rates([0.0])
     report = build_report("baseline.json", pinned, live)
     assert report.hidden_gem_hit_rate_delta is not None
-    assert abs(report.hidden_gem_hit_rate_delta - (-0.019)) < 1e-9
+    # Behavior claim: delta is above -threshold (so no warning fires).
+    assert report.hidden_gem_hit_rate_delta > -HIDDEN_GEM_WARN_THRESHOLD
     assert report.hidden_gem_warning is False
 
 
 def test_delta_exactly_threshold_no_warning_strict_inequality() -> None:
-    """delta bitwise == -_HIDDEN_GEM_WARN_THRESHOLD → warning False.
+    """delta bitwise == -HIDDEN_GEM_WARN_THRESHOLD → warning False.
 
     Subtraction against zero is exact in IEEE-754, so ``0.0 - threshold``
     is bitwise ``-threshold``. This lets us test the strict-inequality
     boundary cleanly.
     """
-    pinned = _fixture_with_gem_rates([_HIDDEN_GEM_WARN_THRESHOLD])
+    pinned = _fixture_with_gem_rates([HIDDEN_GEM_WARN_THRESHOLD])
     live = _fixture_with_gem_rates([0.0])
     report = build_report("baseline.json", pinned, live)
     assert report.hidden_gem_hit_rate_delta is not None
     # Delta must be at -threshold (not strictly below) — warning stays False.
-    assert report.hidden_gem_hit_rate_delta == -_HIDDEN_GEM_WARN_THRESHOLD
+    assert report.hidden_gem_hit_rate_delta == -HIDDEN_GEM_WARN_THRESHOLD
     assert report.hidden_gem_warning is False
 
 
 def test_delta_below_threshold_triggers_warning() -> None:
-    """delta = -0.0201 → warning True."""
-    pinned = _fixture_with_gem_rates([0.2000])
-    live = _fixture_with_gem_rates([0.1799])
+    """delta strictly below -HIDDEN_GEM_WARN_THRESHOLD → warning True.
+
+    Asserts behavior (warning boolean) rather than exact float value,
+    since the boundary claim is "delta < -threshold strictly".
+    """
+    # Drop of 0.03 (live_mean=0.17, pinned_mean=0.2) is well below the
+    # -0.02 threshold. Exact float representation isn't critical — the
+    # behavior claim is "dropping more than the threshold must warn."
+    pinned = _fixture_with_gem_rates([0.20])
+    live = _fixture_with_gem_rates([0.17])
     report = build_report("baseline.json", pinned, live)
     assert report.hidden_gem_hit_rate_delta is not None
-    assert report.hidden_gem_hit_rate_delta < -0.02
+    assert report.hidden_gem_hit_rate_delta < -HIDDEN_GEM_WARN_THRESHOLD
     assert report.hidden_gem_warning is True
 
 

--- a/tests/bench/test_rule_ops.py
+++ b/tests/bench/test_rule_ops.py
@@ -267,3 +267,246 @@ def test_cli_collinearity_outputs_report(tmp_path: Path, capsys: pytest.CaptureF
     out = capsys.readouterr().out
     assert "bench.py audit --collinearity" in out
     assert "r_a" in out and "r_b" in out
+
+
+# ---------------------------------------------------------------------------
+# CLI --format json tests (CLR-001 / CLR-002)
+# ---------------------------------------------------------------------------
+
+
+def _seed_rule_db(tmp_path: Path) -> Path:
+    """Helper: build a tiny tensor DB for rule/inspect CLI JSON tests."""
+    db_path = tmp_path / "synergy.db"
+    conn = open_db(db_path)
+    try:
+        _seed_tensor(
+            conn,
+            [
+                ("Korvold", "Bloodghast", "r1", 0.3),
+                ("Korvold", "Mayhem Devil", "r1", 0.5),
+                ("Muldrotha", "Bloodghast", "r1", 0.1),
+            ],
+        )
+    finally:
+        conn.close()
+    return db_path
+
+
+def test_cli_rule_json_returns_valid_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """``--rule RULE_ID --format json`` emits a parseable JSON object
+    with the expected top-level keys."""
+    import json
+
+    db_path = _seed_rule_db(tmp_path)
+
+    exit_code = bench_cli.main(["audit", "--rule", "r1", "--format", "json", "--db", str(db_path)])
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["rule_id"] == "r1"
+    assert payload["commanders_affected"] == 2
+    assert payload["candidates_affected"] == 2
+    assert "aggregate_contribution" in payload
+    assert "config_hash" in payload
+    top = payload["top_commanders"]
+    assert isinstance(top, list)
+    assert top[0]["commander"] == "Korvold"
+
+
+def test_cli_rule_json_output_path_writes_file(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """``--format json --output PATH`` writes to PATH with stderr
+    confirmation and empty stdout (no duplicate render)."""
+    import json
+
+    db_path = _seed_rule_db(tmp_path)
+    out_path = tmp_path / "rule.json"
+
+    exit_code = bench_cli.main(
+        [
+            "audit",
+            "--rule",
+            "r1",
+            "--format",
+            "json",
+            "--output",
+            str(out_path),
+            "--db",
+            str(db_path),
+        ]
+    )
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "report written to" in captured.err
+    assert str(out_path) in captured.err
+    payload = json.loads(out_path.read_text())
+    assert payload["rule_id"] == "r1"
+
+
+def test_cli_rule_markdown_default_unchanged(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Regression: omitting ``--format`` keeps the markdown-ish text
+    output shape (``# bench.py audit --rule r1`` + Korvold row)."""
+    db_path = _seed_rule_db(tmp_path)
+
+    exit_code = bench_cli.main(["audit", "--rule", "r1", "--db", str(db_path)])
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "# bench.py audit --rule r1" in out
+    assert "Korvold" in out
+    # Must NOT look like JSON.
+    assert not out.strip().startswith("{")
+
+
+def test_cli_inspect_json_returns_valid_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """``--inspect RULE_ID --format json`` emits a JSON object with
+    per-row contribution rows."""
+    import json
+
+    db_path = _seed_rule_db(tmp_path)
+
+    exit_code = bench_cli.main(["audit", "--inspect", "r1", "--format", "json", "--db", str(db_path)])
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["rule_id"] == "r1"
+    assert payload["n_rows"] == 3
+    assert isinstance(payload["rows"], list)
+    first = payload["rows"][0]
+    for key in ("commander", "candidate", "contribution", "idf_weight", "raw_count"):
+        assert key in first
+    # Largest-magnitude row sorts first: Korvold / Mayhem Devil (0.5).
+    assert first["commander"] == "Korvold"
+    assert first["candidate"] == "Mayhem Devil"
+
+
+def test_cli_inspect_json_output_path_writes_file(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """``--inspect --format json --output PATH`` writes to PATH with
+    stderr confirmation and empty stdout."""
+    import json
+
+    db_path = _seed_rule_db(tmp_path)
+    out_path = tmp_path / "inspect.json"
+
+    exit_code = bench_cli.main(
+        [
+            "audit",
+            "--inspect",
+            "r1",
+            "--format",
+            "json",
+            "--output",
+            str(out_path),
+            "--db",
+            str(db_path),
+        ]
+    )
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "report written to" in captured.err
+    payload = json.loads(out_path.read_text())
+    assert payload["rule_id"] == "r1"
+    assert len(payload["rows"]) == 3
+
+
+def test_cli_inspect_markdown_default_unchanged(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Regression: omitting ``--format`` keeps the table-style text
+    output shape."""
+    db_path = _seed_rule_db(tmp_path)
+
+    exit_code = bench_cli.main(["audit", "--inspect", "r1", "--db", str(db_path)])
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "# bench.py audit --inspect r1" in out
+    # The markdown path prints the column header line.
+    assert "commander" in out and "candidate" in out and "contrib" in out
+    assert not out.strip().startswith("{")
+
+
+def test_cli_collinearity_json_returns_valid_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """``--collinearity --format json`` emits a JSON object with
+    ``pairs_flagged`` + ``vif_per_rule``."""
+    import json
+
+    db_path = tmp_path / "synergy.db"
+    conn = open_db(db_path)
+    try:
+        rows: list[tuple[str, str, str, float]] = []
+        for i in range(1, 20):
+            rows.append((f"C{i}", f"cand_{i}", "r_a", 0.1 * i))
+            rows.append((f"C{i}", f"cand_{i}", "r_b", 0.1 * i))
+        _seed_tensor(conn, rows)
+    finally:
+        conn.close()
+
+    exit_code = bench_cli.main(["audit", "--collinearity", "--format", "json", "--db", str(db_path)])
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert "config_hash" in payload
+    assert payload["rules_examined"] == 2
+    assert isinstance(payload["pairs_flagged"], list)
+    pair = payload["pairs_flagged"][0]
+    for key in ("rule_a", "rule_b", "pearson_r", "vif_a", "vif_b"):
+        assert key in pair
+    assert {pair["rule_a"], pair["rule_b"]} == {"r_a", "r_b"}
+    assert "vif_per_rule" in payload
+    assert set(payload["vif_per_rule"].keys()) == {"r_a", "r_b"}
+
+
+def test_cli_collinearity_json_output_path_writes_file(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """``--collinearity --format json --output PATH`` writes to PATH
+    with stderr confirmation and empty stdout."""
+    import json
+
+    db_path = tmp_path / "synergy.db"
+    conn = open_db(db_path)
+    try:
+        rows: list[tuple[str, str, str, float]] = []
+        for i in range(1, 20):
+            rows.append((f"C{i}", f"cand_{i}", "r_a", 0.1 * i))
+            rows.append((f"C{i}", f"cand_{i}", "r_b", 0.1 * i))
+        _seed_tensor(conn, rows)
+    finally:
+        conn.close()
+    out_path = tmp_path / "collinearity.json"
+
+    exit_code = bench_cli.main(
+        [
+            "audit",
+            "--collinearity",
+            "--format",
+            "json",
+            "--output",
+            str(out_path),
+            "--db",
+            str(db_path),
+        ]
+    )
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "report written to" in captured.err
+    payload = json.loads(out_path.read_text())
+    assert payload["rules_examined"] == 2
+
+
+def test_cli_collinearity_markdown_default_unchanged(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Regression: omitting ``--format`` keeps the text table output."""
+    db_path = tmp_path / "synergy.db"
+    conn = open_db(db_path)
+    try:
+        rows: list[tuple[str, str, str, float]] = []
+        for i in range(1, 20):
+            rows.append((f"C{i}", f"cand_{i}", "r_a", 0.1 * i))
+            rows.append((f"C{i}", f"cand_{i}", "r_b", 0.1 * i))
+        _seed_tensor(conn, rows)
+    finally:
+        conn.close()
+
+    exit_code = bench_cli.main(["audit", "--collinearity", "--db", str(db_path)])
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "# bench.py audit --collinearity" in out
+    assert "r_a" in out and "r_b" in out
+    assert not out.strip().startswith("{")


### PR DESCRIPTION
## Summary

Operationalizes the project's stated intent (`memory/feedback_edhrec_not_goal.md` — "find hidden gems from mechanics") as a measurable `hidden_gem_hit_rate` metric tracked alongside the existing histogram-based `bench.py audit` verdict.

**Tracking-only at MVP.** Prints aggregate + delta on every audit; stderr-warns when the delta drops below −0.02; does NOT gate commits. FR6 escalation (≥20 commits of tracking + human correlation + <10% false-positive) is required before any promotion to a commit-gate.

## What lands

- `src/mtg_synergy_graph/bench/hidden_gems.py` — pure-function metric core + `HIDDEN_GEM_WARN_THRESHOLD = 0.02` with FR6 escalation docstring
- `build_fixture(..., edhrec_conn=...)` populates per-commander `hidden_gem_hit_rate` + `hidden_cards` in `FixtureEntry.legacy` (no schema bump)
- `AuditReport` gains aggregate + delta + FR4 warning; markdown / JSON / stderr summary all show the line
- `bench.py audit --inspect-gems` — per-commander lost/gained diff
- `bench.py audit --trend hidden_gems` — CSV / md / json over `.audit/history.csv` append-on-every-audit
- Shared `src/mtg_synergy_graph/edhrec_helpers.py` — single source of truth for the `High Synergy Cards` top-N query used by both `fixture.py` and `validate.py`
- CLAUDE.md + RULE_HISTORY entries + module-level FR6 escalation docstring

## Plan

- `docs/plans/2026-04-22-003-feat-useful-disagreement-hidden-gem-metric-plan.md`
- Origin: `docs/brainstorms/2026-04-21-useful-disagreement-requirements.md`

## Implementation — 9 commits

1. Plan doc
2. Unit 1 — metric core (29 tests)
3. Unit 2 — `build_fixture` integration (11 tests)
4. Unit 3 — audit report + FR4 warning (20 tests)
5. Unit 4 — `--inspect-gems` CLI handler (15 tests)
6. Unit 5 — `.audit/history.csv` + `--trend hidden_gems` (23 tests)
7. Unit 6 — docs (CLAUDE.md, RULE_HISTORY, memory note)
8. **`/ce-code-review` P1 batch** — 8 fixes including the `edhrec_conn` wiring that makes FR3/FR4 structurally live (was previously dead in the default audit path). +4 integration tests.
9. **`/ce-code-review` P2 batch** — 15 safe_auto fixes: plausibility hoist (O(rows) vs O(hidden × rows)), TOCTOU in history append, CLI validation, `sqlite3.DatabaseError` handling, shared EDHREC helper, boundary-test float precision, frozen-contract fix in `HiddenGemReport`, `TYPE_CHECKING` import guard, et al. +9 tests.

## Stats

| Metric | Before | After |
|---|---|---|
| NDCG@30 (100 cmdrs) | 0.262219416007 | 0.262219416007 |
| Tests | 1271 | **1382** (+111) |
| Coverage | 85.89% | **86.45%** |
| Identity gate (`--expect-identity`) | — | **PASS** |

Aggregate `hidden_gem_hit_rate` on HEAD: **0.7287** across 100 commanders with EDHREC data (first real measurement; pin will be refreshed in a follow-up).

## Code review (completed before PR)

12 reviewer personas ran in parallel (correctness, testing, maintainability, project-standards, agent-native, learnings, performance, api-contract, reliability, adversarial, cli-readiness, kieran-python). 33 findings surfaced; 23 applied in two batches (P1 + P2 safe_auto). Deferred to follow-up: 4 gated_auto/manual items (JSON output for rule/inspect/collinearity, handlers.py split refactor, AuditReport schema_version, CSV header forward-compat shim). 6 P3 items acknowledged as documented-but-not-fixing (split-card name matching, 200 SQLite round-trips to EDHREC, hardcoded /30 denominator, intentional single-rule plausibility OR-clause per FR2, non-atomic `--repin` write, pre-existing `_build_rule_deltas` dead code).

Full review artifact: `.context/compound-engineering/ce-code-review/20260422-220621-f72b3185/`.

## Scope boundaries (non-goals per plan)

- No commit-gating on `hidden_gem_hit_rate` regressions (FR6 escalation required; separate brainstorm + plan)
- No learned plausibility classifier (mechanical-only gate)
- No pairwise Jaccard diversity metric
- No migration to the 2,761-commander pool
- NDCG@30 / histogram verdict remains the primary gate

## Post-landing follow-ups

- Manual one-off: `bench.py audit --repin --yes --edhrec-db data/tags.db` to write the gem baseline into the pin (currently `Δ —` because the pin predates Unit 2)
- Manual retrospective validation per success criterion 3: replay 3 historical reverted experiments (broad `gy_retrieval`, deck-hint-match, Survivor 3 BM25F) to confirm at least one flags non-positively
- Deferred P2 items (#13, #21, #25, #26) as separate issues

## Test plan

- [x] `uv run pytest tests/` — 1382 pass, 86.45% coverage
- [x] `uv run scripts/bench.py audit --expect-identity` — PASS
- [x] `uv run scripts/bench.py audit` — live `hidden_gem_hit_rate: 0.7287 (Δ —, 100 cmdrs with EDHREC)`
- [x] Pre-commit hooks (ruff, ruff-format, pyright, pytest, bench-audit) green on every commit
- [ ] CI checks pass on this PR