### PR TITLE
feat: Content embeddings as zero-shot fallback (plan 003)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,6 @@ repos:
         entry: uv run python -m mtg_synergy_graph.bench.hook_entry
         language: system
         pass_filenames: false
-        files: ^src/mtg_synergy_graph/(complement_rules/.*\.py|universal_scorer\.py|graph_engine\.py)$
+        files: ^src/mtg_synergy_graph/(complement_rules/.*\.py|universal_scorer\.py|graph_engine\.py|embeddings/.*\.py)$
         stages: [pre-commit]
         verbose: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,9 @@ uv run scripts/bench.py audit --unknowns                                 # List 
 uv run scripts/bench.py audit --inspect-gems                             # Per-commander lost/gained hidden-gem diff (plan 003-gem)
 uv run scripts/bench.py audit --trend hidden_gems --trend-n 20           # CSV history of aggregate hidden_gem_hit_rate across audit runs
 uv run scripts/bench.py audit --vs-forge-oracle                          # Kendall-τ sidecar comparing our top-N vs Forge CardRanker (plan 002)
+uv run scripts/build_embeddings.py                                       # Build card_embeddings after cardsfolder refresh (plan 2026-04-23-003)
+uv run scripts/bench.py audit --embedding-dedup                          # Rule-pair redundancy diagnostic in embedding space
+uv run scripts/bench.py audit --embedding-dedup --threshold 0.90         # Looser threshold for exploration
 
 # Forge-Second-Oracle pipeline (plan 2026-04-23-002) — design-time only, never at inference.
 uv run scripts/forge_oracle.py build                                     # Build data/forge_oracle.db from Forge precon .dck corpus (~670 decks)
@@ -47,8 +50,9 @@ uv run scripts/forge_oracle.py propose-rules --top 20                    # N rul
 ```
 
 The bench.py hook also runs advisorily on pre-commit when edits touch
-`complement_rules/`, `universal_scorer.py`, or `graph_engine.py`; see
-`memory/feedback_audit_every_change.md` for the guardrail.
+`complement_rules/`, `universal_scorer.py`, `graph_engine.py`, or
+`embeddings/`; see `memory/feedback_audit_every_change.md` for the
+guardrail.
 
 ## Data Model
 
@@ -188,6 +192,33 @@ from mechanics" intent, now measurable.
 5. Compute IDF weights from candidate frequency
 6. Score each candidate = sum of IDF-weighted synergy - anti-synergy + staple bonus
 7. Sort by (-score, cmc, edhrec_rank, name)
+
+### Content embeddings (plan 003, flag-gated)
+
+128-dim deterministic TF-IDF + truncated-SVD vectors per card (hand-rolled,
+numpy only — no scipy/sklearn). Features: `port_type`, `event_class`,
+`zone_origin`/`zone_destination`, `counter_type`, `branch_kind`,
+exploded `port_attributes` rows, Scryfall keywords. No oracle-text,
+no popularity.
+
+- **Storage**: `card_embeddings` + `card_embeddings_config` tables in
+  `data/synergy.db`. Built by `scripts/build_embeddings.py`; rebuilt
+  after each `import_cardsfolder.py` refresh. Hybrid hash discipline
+  (plan 2026-04-23-003 D3): `EmbeddingConfigInputs` + KV table +
+  `ScoringConfigInputs.vectorizer_version`.
+- **Scoring**: `embedding_contribution = w_emb · exp(-k · N_rules) ·
+  cosine(v_cand, v_cmdr_target)`. Exponential decay so well-rule-
+  covered candidates see near-zero contribution.
+- **Flag**: `_ENABLE_EMBEDDING_CONTRIBUTION = False` default-off
+  (`src/mtg_synergy_graph/embeddings/contribution.py`). Audit-gated
+  weight sweep + re-pin required before flipping to True.
+- **Diagnostic**: `bench.py audit --embedding-dedup` flags rule
+  pairs with near-parallel candidate-activation sets in embedding
+  space. Complements `--collinearity` (different mechanism, same
+  intent).
+- **Commander target**: lazy + `functools.cache` keyed by
+  `(commander_set, hi_syn_limit)`. EDHREC hi-syn used OFFLINE
+  ONLY at target-vector build; inference path is EDHREC-clean.
 
 ### Key Files
 

--- a/docs/plans/2026-04-23-003-feat-content-embeddings-fallback-plan.md
+++ b/docs/plans/2026-04-23-003-feat-content-embeddings-fallback-plan.md
@@ -1,0 +1,1099 @@
+---
+title: "feat: Content embeddings as zero-shot fallback"
+type: feat
+status: active
+date: 2026-04-23
+origin: docs/brainstorms/2026-04-21-content-embeddings-requirements.md
+---
+
+# Content embeddings as zero-shot fallback
+
+## Overview
+
+Add a deterministic 128-dim content-embedding substrate per card (hand-rolled
+TF-IDF + truncated-SVD over structured port/keyword features) and wire an
+audit-gated `embedding_contribution` term into `universal_scorer` that is
+exponentially dampened by the number of rules already firing on the
+`(commander, candidate)` pair. The intended effect: lift structurally-similar
+candidates for heterogeneous-hi-syn commanders (Animar, Kess, Yuriko) and
+day-0 Forge-imported cards without writing per-sub-cluster rules (which would
+violate `memory/feedback_no_individual_rules.md`). Also adds a new
+`bench.py audit --embedding-dedup` diagnostic that flags rule pairs whose
+candidate-activation sets are near-parallel in embedding space.
+
+Ships behind `_ENABLE_EMBEDDING_CONTRIBUTION = False`. Only the final unit
+flips scores; all infrastructure units land `--expect-identity` clean.
+
+## Problem Frame
+
+Two structurally identical gaps in the current rule-based scorer
+(see origin: `docs/brainstorms/2026-04-21-content-embeddings-requirements.md`):
+
+1. **Heterogeneous hi-syn commanders.** Animar's hi-syn spans counter doublers,
+   SpellCast-Draw creatures, ETB-Draw creatures, self-bouncers, mana dorks,
+   X-cost creatures — no single mechanical rule unifies them. Writing one rule
+   per sub-cluster would violate the "general not individual" memory
+   constraint.
+2. **Day-0 unreleased cards.** When a Forge cardsfolder refresh lands a new set,
+   its cards have structural features (port tuples) but no hand-authored rule
+   mentions their novel mechanics yet. The scorer silently under-scores them
+   until humans catch up.
+
+Both gaps share the same shape: a candidate whose port profile is
+*structurally similar* to things the commander wants, without matching any
+specific hand-written rule. A deterministic embedding over structured
+features captures that similarity without training, without popularity data,
+and without oracle-text n-grams.
+
+This is the **structural** answer to the "no individual rules" constraint:
+instead of writing more rules, let the embedding cover the long tail while
+the rule-coverage decay keeps embeddings near-invisible on
+well-rule-covered candidates.
+
+## Requirements Trace
+
+- **R1.** One 128-dim deterministic vector per card in the DB, derived entirely
+  from structured features: `port_attributes` rows, port-row categorical fields
+  (`port_type`, `event_class`, `zone_origin`, `zone_destination`, `counter_type`,
+  `branch_kind`), and Scryfall `keywords`. No oracle-text, no numeric features,
+  no popularity. (FR1)
+- **R2.** Per-commander target vector = mean of commander's own port-feature
+  vector and the vectors of its EDHREC golden-set hi-syn cards, if any. For
+  commanders not in the golden set: target = commander's own port-feature
+  vector. (FR2)
+- **R3.** New additive scoring term per candidate:
+  `embedding_contribution = w_emb · exp(-k · N_rules) · cosine(v_candidate, v_cmdr_target)`,
+  where `N_rules` counts rules firing a positive contribution on this
+  `(commander, candidate)` pair. Smooth exponential decay, no discontinuity. (FR3)
+- **R4.** Cold-start works by construction: every card has a vector after
+  `scripts/build_embeddings.py` runs against a refreshed DB. No special
+  cold-start code path. (FR4)
+- **R5.** `bench.py audit --embedding-dedup` flags rule pairs whose
+  candidate-activation sets exceed mean-pairwise-cosine threshold (default
+  0.95) in embedding space. Read-only diagnostic, no scoring impact. (FR5)
+- **R6.** `recommend.py --explain` renders an `embedding_contribution` line
+  plus the three nearest rule-covered neighbors when the contribution is
+  nonzero. (FR6)
+- **R7.** Ships behind `_ENABLE_EMBEDDING_CONTRIBUTION = False`. Audit-gated
+  flip via weight sweep over `w_emb ∈ {0.1, 0.3, 0.5, 1.0}`,
+  `k ∈ {0.5, 0.8, 1.2}`. No commander regresses beyond MARGINAL. Flag and
+  weight constants plumbed into `ScoringConfigInputs` and
+  `compute_config_hash` so tuning re-invalidates the pinned tensor. (FR7)
+- **R8.** Determinism: same DB + same vectorizer version + same config →
+  bitwise-identical vectors → bitwise-identical scores.
+- **R9.** Inference latency ≤ 5% regression: per-candidate cost is one
+  precomputed vector lookup + one dot product.
+
+## Scope Boundaries
+
+- No oracle-text features (n-grams or otherwise) anywhere in the pipeline.
+- No neural / transformer / learned-weight embeddings.
+- No popularity-adjacent features (EDHREC rank, deck percentages, reprint
+  frequency).
+- No k-NN queries at inference — only precomputed-vector dot products.
+- No auto-propose from `--embedding-dedup` into the `rules` table — humans
+  read the diagnostic report and decide. Matches the audit-every-change
+  guardrail.
+- No replacement of the rule-based scorer — embeddings are strictly additive
+  fallback, not a new scoring backbone.
+- No online re-training or continuous learning — vectors rebuild on DB
+  re-import, period.
+
+### Deferred to Separate Tasks
+
+- **Morgan/ECFP circular fingerprints over typed port-nodes.** Brainstorm
+  naturally-successor work; revisit once plan 003 typed-port-graph is
+  generalized beyond the current 16 peer-tribal rules. Separate future
+  brainstorm.
+- **Dimensionality tuning (128 → N).** First cut is fixed at 128. Any sweep
+  of SVD rank is a follow-up audit, not part of this plan.
+- **Adding scipy to dependencies.** Only if `numpy.linalg.svd` profiling
+  shows a real problem on the 32k × ~5k corpus. Default stance: hand-roll on
+  numpy only (matches the existing zero-extra-dep posture).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/mtg_synergy_graph/complement_rules/pathway.py` — canonical
+  `_ENABLE_*` flag pattern. Flag constant at module top; plumbed into
+  `ScoringConfigInputs`; infra units land identity-clean; only the flip unit
+  changes scores. This plan mirrors it exactly.
+- `src/mtg_synergy_graph/universal_scorer.py` — `UniversalScore` dataclass
+  (lines 270–286) is the injection site for an `embedding_contribution`
+  field; `score_all_universal` results loop (lines 938–950) is where the
+  term gets populated per candidate. `distinct_rules` `@cached_property`
+  already gives us `N_rules` for free.
+- `src/mtg_synergy_graph/engine.py` — `SynergyEngine._render_explanation`
+  (lines 445–484) is where the new `embedding_contribution:` + nearest-neighbor
+  explain lines go. `_score_cache` keyed by `tuple(cmdr_set)` is the existing
+  commander-level cache.
+- `src/mtg_synergy_graph/bench/collinearity.py` — direct numpy-based pairwise
+  diagnostic template. `handle_collinearity` at `bench/handlers.py:408–424`
+  is the handler-shape template for the new `--embedding-dedup`.
+- `src/mtg_synergy_graph/bench/cli.py` — mutex-group mode registration
+  pattern (lines 115–173); adding `--embedding-dedup` is one
+  `mode.add_argument` + one `_HANDLERS` row + one `_resolve_mode` branch.
+- `src/mtg_synergy_graph/bench/tensor.py` — `compute_config_hash` (lines
+  38–77). Must grow three new inputs (`enable_embedding_contribution`,
+  `embedding_w`, `embedding_k`) plus the `vectorizer_version` read from the
+  `card_embeddings_config` KV table.
+- `src/mtg_synergy_graph/forge_oracle/config.py` — `OracleConfigInputs`
+  NamedTuple + `compute_oracle_hash` + `verify_current_or_raise`. Template
+  for `EmbeddingConfigInputs` and the `card_embeddings_config` KV table.
+- `src/mtg_synergy_graph/forge_oracle/gap_weight.py` — the graceful-fallback
+  reader contract (`{}` on missing file / DB error / missing table / empty
+  table / all-zero values, each with `logging.warning`). Copy verbatim for
+  `load_card_embeddings`.
+- `src/mtg_synergy_graph/attributes.py` — `explode_filter` + `classify_attr_token`.
+  These are the canonical per-token expansion; `port_attributes` rows are
+  already pre-tokenized, so FR1's tokenization question reduces to iterating
+  existing rows.
+- `scripts/build_graph_cache.py` — precedent for a standalone
+  `scripts/build_*.py` user-invoked build step. `scripts/build_embeddings.py`
+  mirrors this.
+- `src/mtg_synergy_graph/schema.sql` — `graph_cache` table at lines 153–159
+  is the blob-in-sqlite + versioned precedent. `rule_contributions` at
+  lines 204–220 is the config-hash-keyed table precedent.
+- `tests/conftest.py` (lines 46–64) — autouse `_stub_forge_sha_when_checkout_absent`
+  fixture is the template for a CI stub when rebuilt-artifact tests would
+  fail without dev-only setup.
+
+### Institutional Learnings
+
+- **`docs/solutions/best-practices/flag-gated-multi-port-rule-pattern-2026-04-23.md`**
+  — governing discipline for this plan. Infra identity-clean; `ScoringConfigInputs`
+  field added in the same unit as the flip; audit-iterate with
+  `hidden_gem_hit_rate` + aggregate delta; never chase aggregate gains at
+  the cost of hidden-gem rate.
+- **`docs/solutions/best-practices/offline-oracle-hash-pattern-2026-04-23.md`**
+  — partial application. The doc explicitly says "do not apply to inference-path
+  subsystems," and embeddings are inference-path consumed. But the embedding
+  **build** is offline-derived with configurable knobs (`svd_dims`,
+  `vectorizer_version`, `tfidf_smoothing`, `min_df`) that can drift silently.
+  **Hybrid resolution:** put the knobs in `ScoringConfigInputs` (so the pinned
+  tensor invalidates) AND write them into a `card_embeddings_config` KV
+  table (so a stale on-disk table is detected at inference startup).
+  Both guards fire in different failure modes; keep both.
+- **`docs/solutions/test-failures/forge-oracle-ci-git-checkout-stub-2026-04-23.md`**
+  — rebuild-required tests need an autouse conftest stub established in the
+  same commit as the first test, not retroactively after CI fails.
+- **`docs/solutions/build-errors/gitignore-negation-under-ignored-parent-2026-04-23.md`**
+  — if any embedding metadata file is committed (e.g., a pinned
+  `vectorizer_version` marker), use `!data/...` negation form; add a guard
+  in `tests/test_seed_files_tracked.py`.
+- **CLAUDE.md note on reverted `card_hints`-family rules** (`deck_hint_match`,
+  `deck_needs_fulfilled`, `buffed_by_match`) — a critical warning. Those
+  rules regressed NDCG@30 because curated-similarity signal diluted the
+  mechanical port signal. Structural-similarity signals have the same
+  failure mode. Mitigations: start with the smallest `w_emb`; lean on the
+  exponential decay aggressively; measure `hidden_gem_hit_rate` alongside
+  aggregate delta at every audit step; if `hidden_gem_hit_rate` drops, the
+  flag stays `False` even if aggregate looks fine.
+
+### External References
+
+None needed. TF-IDF + truncated SVD is well-established IR math; the
+brainstorm is prescriptive about the algorithm; the codebase patterns for
+flag-gated scoring-path integration + numpy-only numerics + bench-handler
+registration are all strong.
+
+## Key Technical Decisions
+
+- **D1. Hand-roll TF-IDF + `numpy.linalg.svd` on a dense matrix.** Zero-dep
+  policy already in place; numpy is the only runtime numeric dep; ~32k ×
+  ~5k fits comfortably in memory and SVD runs in seconds. Adding sklearn
+  would be a major dep escalation. If profiling ever shows SVD is the
+  bottleneck, add scipy as an optional `[embeddings]` extra — not today.
+- **D2. Embedding table lives in the main `data/synergy.db`, not a sidecar.**
+  Vectors are read at inference per candidate per commander; sidecar
+  isolation is only right for offline-only data (forge_oracle pattern). New
+  `card_embeddings` table mirrors the existing `graph_cache` blob-in-sqlite
+  pattern.
+- **D3. Hybrid hash strategy.** Add `enable_embedding_contribution`,
+  `embedding_w`, `embedding_k`, `vectorizer_version` to `ScoringConfigInputs`
+  AND write an `EmbeddingConfigInputs` NamedTuple into a
+  `card_embeddings_config` KV table. The first protects the pinned audit
+  tensor; the second detects stale on-disk vectors at startup. Neither
+  subsumes the other.
+- **D4. Separate `scripts/build_embeddings.py` user-invoked build step.**
+  Matches `scripts/build_graph_cache.py` precedent. Importer stays lean;
+  embedding rebuild is opt-in (typically after each cardsfolder refresh).
+- **D5. Lazy commander-target vectors with module-level `functools.cache`.**
+  Keyed by commander oracle_id. 100 golden-set commanders warm up during
+  bench/audit runs; user queries pay a microsecond read on first hit.
+  Simpler than a second persisted table.
+- **D6. Graceful-fallback reader for the inference path.** Missing table /
+  `sqlite3.DatabaseError` / missing columns / empty table / all-zero blobs
+  → return `{}` + `logging.warning`. Never raise from the scorer. Copies
+  `forge_oracle/gap_weight.py:load_forge_signals` contract.
+- **D7. `--embedding-dedup` exits 2 on missing tensor or missing embeddings.**
+  Matches the offline-oracle three-tier strictness split: diagnostics whose
+  entire purpose is the data must fail loudly with a rebuild hint, not
+  silently degrade.
+- **D8. `port_attributes` rows are already pre-tokenized.** FR1's "exact
+  feature tokenization for multi-value columns" open question dissolves:
+  `attributes.explode_filter()` has already done the work at importer
+  time. Vectorizer iterates existing rows; no re-parsing of raw
+  `valid_filter` strings.
+- **D9. All three flip knobs plumbed into `ScoringConfigInputs`.** The bool
+  alone isn't enough — tuning `w_emb` or `k` changes scores and must
+  invalidate the pinned tensor. Follow the `pathway` plan 001 precedent
+  for "add the `ScoringConfigInputs` field in the same unit as the flip"
+  to avoid re-pin churn during infra units.
+- **D10. Pre-commit `bench-audit` regex extended to `embeddings/`.** So any
+  change under the new subpackage triggers the advisory audit hook. Matches
+  `memory/feedback_audit_every_change.md`.
+- **D11. Embedding-dedup surfaces pairs for humans; no auto-merge.** The
+  dedup signal is ideation input to rule-consolidation work, not a
+  code-rewriting agent. Matches audit-every-change guardrail.
+- **D12. Identity contract: flag-off bitwise-identical to current baseline.**
+  `tests/bench/test_universal_scorer_identity.py` gains an assertion that
+  flag-off scores match the pre-plan baseline. Same contract as plan 001
+  Unit 3's `--expect-identity`.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Feature tokenization for multi-value columns.** Resolved by D8 — reuse
+  already-exploded `port_attributes` rows.
+- **TfidfVectorizer vs hand-roll.** Resolved by D1 — hand-roll (zero
+  extra deps; the math is ~40 lines).
+- **SVD implementation.** Resolved by D1 — `numpy.linalg.svd` dense.
+  Revisit only if profiling shows a problem.
+- **Refresh cadence: in-importer vs separate.** Resolved by D4 — separate
+  `scripts/build_embeddings.py`.
+- **Commander target vector for non-golden-set commanders.** Resolved per
+  FR2 — default to commander's own port-feature vector.
+- **Dedup signal's interaction with the `rules` table.** Resolved by D11
+  — surface for humans only, no auto-merge.
+- **Sidecar vs main DB.** Resolved by D2 — main DB.
+- **Hash strategy.** Resolved by D3 — hybrid (`ScoringConfigInputs` +
+  `card_embeddings_config` KV).
+
+### Deferred to Implementation
+
+- **Exact feature-token names.** The vectorizer emits tokens like
+  `port_type:Trigger`, `event_class:SpellCast`, `attr:subtype:Goblin`,
+  `keyword:Flying`. Final naming convention ironed out in Unit 1 and
+  captured as a frozen `TOKEN_FORMAT_VERSION`. Bumping this string bumps
+  `vectorizer_version`.
+- **Minimum document frequency (`min_df`) for TF-IDF dampening.** Tokens
+  seen on fewer than N cards get pruned to reduce dimensionality and
+  numerical noise. Initial value (2 or 3) picked during Unit 1 once the
+  actual token-frequency distribution is seen.
+- **Exact `w_emb` and `k` chosen post-landing.** Audit sweep is operational
+  work, not planning. Candidates: `w_emb ∈ {0.1, 0.3, 0.5, 1.0}`,
+  `k ∈ {0.5, 0.8, 1.2}` per FR7.
+- **Whether the `--embedding-dedup` report writes to `.audit/`.** Mirror
+  `--collinearity` behavior once Unit 6 is implemented.
+- **Whether to add an optional scipy extra.** Only if Unit 1 profiling of
+  `numpy.linalg.svd` on the real 32k × ~5k matrix shows > 30s build time.
+  Default: no.
+
+## Output Structure
+
+```
+src/mtg_synergy_graph/
+  embeddings/
+    __init__.py
+    vectorizer.py        # Hand-rolled TF-IDF feature-bag builder + token format
+    svd.py               # numpy truncated SVD + L2 normalization
+    config.py            # EmbeddingConfigInputs NamedTuple + compute_embedding_hash + verify
+    store.py             # write_vectors / read_vectors / load_card_embeddings
+    commander_target.py  # build_commander_target_vector (functools.cache)
+    contribution.py      # _ENABLE_EMBEDDING_CONTRIBUTION + _EMBEDDING_W + _EMBEDDING_K
+                         # + embedding_contribution(score, target_vec, vectors) -> float
+    dedup.py             # embedding_dedup(conn, threshold) -> list[RulePair]
+  bench/
+    embedding_dedup_handler.py   # handle_embedding_dedup(args)
+scripts/
+  build_embeddings.py    # User-invoked build step
+tests/
+  embeddings/
+    test_vectorizer.py
+    test_svd.py
+    test_config.py
+    test_store.py
+    test_commander_target.py
+    test_contribution.py
+    test_dedup.py
+  bench/
+    test_embedding_dedup_handler.py
+data/
+  # card_embeddings table inside data/synergy.db (gitignored already)
+```
+
+*This tree is a scope declaration, not a constraint. Unit-level file lists
+are authoritative.*
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for
+> review, not implementation specification. The implementing agent should
+> treat it as context, not code to reproduce.*
+
+### Feature-bag tokenization (Unit 1)
+
+Per card, emit a multiset of string tokens from structured sources:
+
+```
+for each row in card_ports WHERE card_name = ?:
+    emit "port_type:{port_type}"
+    emit "event_class:{event_class}"            if not null
+    emit "zone_origin:{zone_origin}"            if not null
+    emit "zone_destination:{zone_destination}"  if not null
+    emit "counter_type:{counter_type}"          if not null
+    emit "branch_kind:{branch_kind}"            if not null
+for each row in port_attributes WHERE port_id IN (ports of card):
+    emit "attr:{attr_kind}:{attr_value}"
+for each kw in json.loads(cards.keywords):
+    emit "keyword:{kw}"
+```
+
+TF-IDF over the corpus, truncated-SVD to 128 dims, L2-normalize. Token
+format stability captured by `TOKEN_FORMAT_VERSION` constant; bumping it
+bumps `vectorizer_version`, which participates in the hybrid hash.
+
+### Scoring-path integration (Unit 7)
+
+```
+# inside score_all_universal's results loop:
+n_rules = len(score.distinct_rules)           # existing @cached_property
+if _ENABLE_EMBEDDING_CONTRIBUTION:
+    v_cand = vectors.get(candidate_name)       # dict[str, ndarray] from load_card_embeddings
+    v_cmdr = commander_target                  # precomputed for this cmdr_set
+    if v_cand is not None and v_cmdr is not None:
+        cos = float(v_cand @ v_cmdr)           # L2-normalized, so dot product IS cosine
+        decay = math.exp(-_EMBEDDING_K * n_rules)
+        score.embedding_contribution = _EMBEDDING_W * decay * cos
+```
+
+`score.score` sums the new field alongside existing bonuses. When
+`_ENABLE_EMBEDDING_CONTRIBUTION = False` OR any lookup returns None, the
+field stays 0.0 and scores are bitwise-identical to baseline.
+
+### Dedup diagnostic (Unit 6)
+
+```
+# consumes rule_contributions tensor (plan 001) + card_embeddings
+for rule in registered_rules:
+    activation_set[rule] = {cand for (_, cand, r, contribution) in tensor where r == rule AND contribution > 0}
+    mean_vec[rule] = mean(vectors[c] for c in activation_set[rule])   # L2-normalized
+for (rule_a, rule_b) in pairs(registered_rules):
+    cos_ab = mean_vec[rule_a] @ mean_vec[rule_b]
+    if cos_ab > threshold:  # default 0.95
+        flag (rule_a, rule_b, cos_ab)
+```
+
+Output is a sorted markdown table; JSON mode mirrors
+`handle_collinearity`'s structure.
+
+## Implementation Units
+
+- [ ] **Unit 1: Feature vectorizer (pure function)**
+
+**Goal:** Hand-rolled TF-IDF + truncated-SVD vectorizer over structured
+inputs. No DB writes yet — pure function from `{card_name: feature_tokens}`
+to `{card_name: ndarray(128,)}`.
+
+**Requirements:** R1, R8
+
+**Dependencies:** None
+
+**Files:**
+- Create: `src/mtg_synergy_graph/embeddings/__init__.py`
+- Create: `src/mtg_synergy_graph/embeddings/vectorizer.py`
+- Create: `src/mtg_synergy_graph/embeddings/svd.py`
+- Create: `tests/embeddings/__init__.py`
+- Create: `tests/embeddings/test_vectorizer.py`
+- Create: `tests/embeddings/test_svd.py`
+
+**Approach:**
+- `extract_card_tokens(conn) -> dict[str, tuple[str, ...]]` — pull structured
+  features per card from `card_ports` + `port_attributes` + `cards.keywords`.
+- `compute_tfidf(corpus: dict[str, tuple[str, ...]], min_df: int) -> tuple[ndarray, list[str], list[str]]`
+  — returns `(tfidf_matrix, card_names, vocabulary)`. Plain math; no sklearn.
+- `truncated_svd(tfidf: ndarray, k: int = 128) -> ndarray` — calls
+  `numpy.linalg.svd`, takes top-k left singular vectors, L2-normalizes rows.
+- `TOKEN_FORMAT_VERSION: str` constant (e.g., `"v1"`). Bump on any token
+  scheme change.
+- Freeze `min_df` default at 2 for first cut.
+
+**Patterns to follow:**
+- `src/mtg_synergy_graph/bench/collinearity.py` for the numpy-matrix posture.
+- `src/mtg_synergy_graph/attributes.py` for the token-naming convention.
+
+**Test scenarios:**
+- Happy path: 5 synthetic cards with known port/keyword sets → hand-computed
+  TF-IDF matches within 1e-9.
+- Happy path: deterministic SVD — same input fed twice returns bitwise
+  identical output.
+- Edge case: all-zero column (token present on zero cards after min_df
+  prune) does not appear in the vocabulary.
+- Edge case: a card with zero tokens (hypothetical) returns a zero vector;
+  L2 normalization handles zero-norm without NaN.
+- Edge case: duplicate tokens on the same card (same keyword twice) are
+  counted as-is (TF uses raw counts).
+- Integration: vectorizer over a 50-card fixture DB produces 50 distinct
+  128-dim unit vectors.
+
+**Verification:**
+- `uv run pytest tests/embeddings/test_vectorizer.py tests/embeddings/test_svd.py`
+  passes.
+- Pyright clean on the new modules.
+- Manual smoke: running the vectorizer end-to-end on the real
+  `data/synergy.db` (~32k cards) completes in under 60 seconds.
+  Profile only if wall time exceeds this — decide whether scipy is worth it.
+
+---
+
+- [ ] **Unit 2: Schema, config hash, and blob store**
+
+**Goal:** Add the `card_embeddings` and `card_embeddings_config` tables;
+define `EmbeddingConfigInputs` NamedTuple + `compute_embedding_hash` +
+`verify_current_or_raise`; blob round-trip helpers.
+
+**Requirements:** R1, R8, D3
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `src/mtg_synergy_graph/schema.sql` (add two tables)
+- Create: `src/mtg_synergy_graph/embeddings/config.py`
+- Create: `src/mtg_synergy_graph/embeddings/store.py`
+- Create: `tests/embeddings/test_config.py`
+- Create: `tests/embeddings/test_store.py`
+
+**Approach:**
+- Schema:
+  ```sql
+  CREATE TABLE IF NOT EXISTS card_embeddings (
+      card_name          TEXT PRIMARY KEY REFERENCES cards(name),
+      vector             BLOB NOT NULL,
+      vectorizer_version INTEGER NOT NULL,
+      built_at           TEXT NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS card_embeddings_config (
+      key   TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+  );
+  ```
+- `EmbeddingConfigInputs(NamedTuple)` fields: `token_format_version`,
+  `svd_dims`, `min_df`, `vectorizer_version`, `port_signature_version`.
+- `compute_embedding_hash(inputs) -> str` via `hashlib.sha256` over
+  `repr(sorted(inputs._asdict().items()))`. Mirror
+  `forge_oracle/config.py:compute_oracle_hash`.
+- `write_vectors(conn, vectors, config_inputs)` — one transaction:
+  upsert rows + write `config_hash` + one KV row per field for diagnostics.
+- `read_vector(conn, name)` / `load_card_embeddings(conn)` — blob →
+  `np.frombuffer(..., dtype=np.float32)`.
+- `verify_current_or_raise(conn, config_inputs)` — raise
+  `EmbeddingConfigStaleError` with the exact rebuild command in the
+  message. Raise `EmbeddingConfigMissingError` if the KV row is absent.
+
+**Patterns to follow:**
+- `src/mtg_synergy_graph/forge_oracle/config.py` — full NamedTuple + hash
+  + error-class + error-message template.
+- `src/mtg_synergy_graph/forge_oracle/ingest.py` — transaction shape for
+  writing data + config hash together.
+- `src/mtg_synergy_graph/schema.sql` `graph_cache` table for the blob
+  column pattern.
+
+**Test scenarios:**
+- Happy path: `write_vectors` + `load_card_embeddings` round-trip produces
+  bitwise-identical ndarrays.
+- Happy path: `compute_embedding_hash` stable across NamedTuple field
+  reordering (via `sorted(items)`).
+- Edge case: `load_card_embeddings` on a DB without the table → `{}` +
+  `logging.warning`.
+- Edge case: `load_card_embeddings` on an empty table → `{}` +
+  `logging.warning`.
+- Edge case: all-zero blob → excluded from result (all-zero vectors are
+  unusable for cosine).
+- Error path: `verify_current_or_raise` with mismatched hash →
+  `EmbeddingConfigStaleError` whose message contains the rebuild command.
+- Error path: `verify_current_or_raise` with missing KV row →
+  `EmbeddingConfigMissingError`.
+- Integration: full transaction is atomic — if an exception fires
+  mid-`write_vectors`, no partial rows survive.
+
+**Verification:**
+- `uv run pytest tests/embeddings/test_config.py tests/embeddings/test_store.py`
+  passes.
+- Schema change is safely re-runnable (`CREATE TABLE IF NOT EXISTS`) —
+  existing DBs without the tables get them added on next `open_db`.
+- Coverage ≥ 80% on the new modules.
+
+---
+
+- [ ] **Unit 3: Build script + CI conftest stub**
+
+**Goal:** User-invoked `scripts/build_embeddings.py` that wires
+Unit 1 (vectorizer) + Unit 2 (store) end-to-end. Autouse conftest stub so
+embedding-consuming tests pass on CI even when the table hasn't been
+rebuilt.
+
+**Requirements:** R1, R4, R8
+
+**Dependencies:** Units 1, 2
+
+**Files:**
+- Create: `scripts/build_embeddings.py`
+- Modify: `tests/conftest.py` (add autouse stub)
+- Create: `tests/embeddings/test_build_script.py`
+
+**Approach:**
+- Script skeleton mirrors `scripts/build_graph_cache.py`:
+  1. `open_db(...)`
+  2. `extract_card_tokens(conn)`
+  3. `compute_tfidf(...)` → SVD → L2 → `vectors`
+  4. `EmbeddingConfigInputs(...)` assembled from current constants
+  5. `write_vectors(conn, vectors, config_inputs)` (single transaction)
+  6. Print a one-line summary: count of cards, vocabulary size,
+     `config_hash`, wall time.
+- Runs stand-alone; importer does NOT invoke it. Users run manually after
+  each cardsfolder refresh.
+- CI stub in `tests/conftest.py`:
+  ```python
+  # pseudo-code, not implementation:
+  # if `card_embeddings` table has zero rows, autouse fixture seeds a
+  # deterministic 5-card in-memory fixture so downstream tests that
+  # call load_card_embeddings get back a small, non-empty dict.
+  # When the table is populated (dev machine), fixture is a no-op.
+  ```
+  Mirrors the `_stub_forge_sha_when_checkout_absent` fixture from
+  `tests/conftest.py:46–64`.
+
+**Patterns to follow:**
+- `scripts/build_graph_cache.py` for the script shape.
+- `tests/conftest.py` `_stub_forge_sha_when_checkout_absent` for the
+  autouse stub pattern.
+- `docs/solutions/test-failures/forge-oracle-ci-git-checkout-stub-2026-04-23.md`
+  for the CI-first-commit discipline.
+
+**Test scenarios:**
+- Happy path: `scripts/build_embeddings.py` against a 50-card fixture DB
+  populates `card_embeddings` with 50 rows and a valid `config_hash`.
+- Edge case: re-running the script overwrites rows (upsert semantics;
+  `built_at` refreshes).
+- Error path: script is idempotent when nothing changed — hash stable
+  across consecutive builds.
+- Integration: autouse conftest stub activates when the table is missing
+  or empty; tests calling `load_card_embeddings` get a non-empty fixture
+  dict.
+
+**Verification:**
+- `uv run scripts/build_embeddings.py` against the real `data/synergy.db`
+  completes and populates the table.
+- `uv run pytest` passes on a fresh checkout (including CI, which has no
+  pre-populated `card_embeddings`).
+- Simulate-CI pre-push check works:
+  `DROP card_embeddings; uv run pytest` still passes via the stub.
+
+---
+
+- [ ] **Unit 4: Commander target vector (lazy + cached)**
+
+**Goal:** `build_commander_target_vector(commander_set, vectors,
+golden_hi_syn)` that returns the L2-normalized mean of the commander's own
+port-feature vector and the EDHREC golden-set hi-syn vectors (if any).
+Module-level `functools.cache` keyed by `tuple(commander_set)`.
+
+**Requirements:** R2, D5
+
+**Dependencies:** Units 1, 2
+
+**Files:**
+- Create: `src/mtg_synergy_graph/embeddings/commander_target.py`
+- Create: `tests/embeddings/test_commander_target.py`
+
+**Approach:**
+- Read EDHREC golden-set hi-syn cards per commander from the existing
+  golden-set fixture source (brainstorm FR2 — cached in
+  `commander_cache` already; research report lines flag the precedent).
+  Research: look at how `bench/` reads the 100-cmdr golden set.
+- If hi-syn list non-empty: target = L2-normalize(mean(v_cmdr +
+  v_hi_syn_1 + ... + v_hi_syn_N) / (N + 1))
+- If hi-syn list empty (commander not in golden set): target = v_cmdr
+  (commander's own port-feature vector, already L2-normalized).
+- Cache with `@functools.cache` so the 100-cmdr bench run warms up once;
+  user queries hit the cache after the first lookup.
+- Partner commanders: commander_set has len=2 → target computed over
+  the concatenated hi-syn lists.
+
+**Patterns to follow:**
+- `memory/reference_edhrec_502.md` context for the golden set shape.
+- `src/mtg_synergy_graph/engine.py:_score_cache` for the
+  `tuple(cmdr_set)` keying convention.
+- `functools.cache` use-sites already in the codebase (grep for current
+  examples).
+
+**Test scenarios:**
+- Happy path: golden-set commander with known hi-syn list → target is the
+  hand-computed L2-normalized mean.
+- Happy path: non-golden-set commander → target equals its own port vector
+  (no hi-syn contribution).
+- Edge case: partner pair (len=2 cmdr_set) with hi-syn entries from both
+  halves composes correctly.
+- Edge case: commander with zero ports (hypothetical) → target is zero
+  vector; caller handles it by skipping the contribution.
+- Edge case: `@functools.cache` returns the SAME ndarray object on
+  repeated calls (verify via `id()` or numpy `shares_memory`).
+
+**Verification:**
+- `uv run pytest tests/embeddings/test_commander_target.py` passes.
+- Cache hit-rate exercised: calling the function 10 times with the same
+  input only invokes the expensive path once.
+
+---
+
+- [ ] **Unit 5: Inference-path reader with graceful-fallback contract**
+
+**Goal:** `load_card_embeddings(conn) -> dict[str, np.ndarray]` and
+`embedding_contribution(score, v_cmdr, vectors) -> float` that the scorer
+will call in Unit 7. Graceful fallback: every failure mode returns
+`0.0`/`{}` + `logging.warning`, never raises.
+
+**Requirements:** R3, R9, D6
+
+**Dependencies:** Units 2, 4
+
+**Files:**
+- Create: `src/mtg_synergy_graph/embeddings/contribution.py`
+- Create: `tests/embeddings/test_contribution.py`
+
+**Approach:**
+- `_ENABLE_EMBEDDING_CONTRIBUTION: bool = False` (constant; flipped in
+  Unit 7).
+- `_EMBEDDING_W: float = 0.0` and `_EMBEDDING_K: float = 0.8` (constants;
+  initial values tuned post-Unit 7 landing).
+- `embedding_contribution(score: UniversalScore, v_cmdr: np.ndarray |
+  None, vectors: Mapping[str, np.ndarray]) -> float`:
+  - Returns `0.0` if `not _ENABLE_EMBEDDING_CONTRIBUTION`.
+  - Returns `0.0` if `v_cmdr is None`.
+  - Returns `0.0` if `vectors.get(score.candidate)` is None.
+  - Else computes `_EMBEDDING_W * math.exp(-_EMBEDDING_K *
+    len(score.distinct_rules)) * float(v_cand @ v_cmdr)`.
+- `load_card_embeddings(conn)` — thin wrapper over `store.load_card_embeddings`
+  with config-hash verification; on mismatch, log a warning and return
+  `{}` (silent degrade for the inference path, per D6).
+- This module is NOT called by the scorer yet — just shippable and
+  independently tested.
+
+**Execution note:** Start with a failing test asserting the three
+graceful-fallback return paths before writing the function body.
+
+**Patterns to follow:**
+- `src/mtg_synergy_graph/forge_oracle/gap_weight.py:load_forge_signals`
+  for the exact failure-mode taxonomy.
+- `src/mtg_synergy_graph/complement_rules/pathway.py` for the
+  `_ENABLE_*` constant style.
+
+**Test scenarios:**
+- Happy path: flag on + both vectors present + N_rules=0 →
+  `w_emb * 1.0 * cos_sim`.
+- Happy path: flag on + N_rules=5 → `w_emb * exp(-k*5) * cos_sim`
+  (dampened ~10×).
+- Edge case: flag on + `v_cmdr is None` → 0.0.
+- Edge case: flag on + `score.candidate` not in vectors → 0.0.
+- Error path: flag off (default) → 0.0 regardless of inputs.
+- Error path: `load_card_embeddings` with stale config_hash → `{}` +
+  warning; scorer call chain treats as "no vectors available" → 0.0.
+- Error path: `load_card_embeddings` with missing table → `{}` + warning.
+- Integration: `embedding_contribution` is pure (no side effects on
+  `score`); scorer wiring in Unit 7 will assign the return value to
+  `score.embedding_contribution`.
+
+**Verification:**
+- `uv run pytest tests/embeddings/test_contribution.py` passes.
+- No scorer behavior change (flag is off by default).
+- `uv run scripts/bench.py audit --expect-identity` passes against the
+  pre-plan baseline (this unit touches no score-path code).
+
+---
+
+- [ ] **Unit 6: `bench.py audit --embedding-dedup` diagnostic**
+
+**Goal:** New audit mode that consumes the `rule_contributions` tensor +
+`card_embeddings` and flags rule pairs whose candidate-activation sets
+are near-parallel in embedding space.
+
+**Requirements:** R5, D7, D11
+
+**Dependencies:** Units 2, 3 (needs populated `card_embeddings`); upstream
+Survivor 1 `rule_contributions` tensor (already landed).
+
+**Files:**
+- Create: `src/mtg_synergy_graph/embeddings/dedup.py` (pure logic)
+- Create: `src/mtg_synergy_graph/bench/embedding_dedup_handler.py`
+  (handler)
+- Modify: `src/mtg_synergy_graph/bench/cli.py` (mutex-group registration)
+- Modify: `src/mtg_synergy_graph/bench/__init__.py` (`_cli.register`)
+- Modify: `src/mtg_synergy_graph/bench/_stubs.py` (add
+  `embedding_dedup_stub`)
+- Create: `tests/bench/test_embedding_dedup_handler.py`
+- Create: `tests/embeddings/test_dedup.py`
+
+**Approach:**
+- Pure logic in `embeddings/dedup.py`:
+  - Read activation set `{candidate | rule fires positively}` per rule
+    from `rule_contributions WHERE config_hash = current`.
+  - Compute per-rule mean embedding = L2-normalize(mean of vectors over
+    activation set).
+  - For each rule pair: `cos = mean_a @ mean_b`.
+  - Return sorted list of `(rule_a, rule_b, cos)` where `cos > threshold`
+    (default 0.95).
+- Handler `handle_embedding_dedup(args)`:
+  - Verify tensor rows exist for current `config_hash`; exit 2 with
+    rebuild-hint message if not.
+  - Verify `card_embeddings` present and fresh (via
+    `verify_current_or_raise`); exit 2 with rebuild-hint if not.
+  - Render markdown table (default) or JSON (`--format json`).
+  - Optionally persist to `.audit/last_dedup.md` (matches
+    `--collinearity` behavior).
+- CLI registration: one `mode.add_argument("--embedding-dedup", ...)` in
+  the mutex group.
+
+**Patterns to follow:**
+- `src/mtg_synergy_graph/bench/collinearity.py` for the matrix-consumption
+  pattern.
+- `src/mtg_synergy_graph/bench/handlers.py:handle_collinearity` for the
+  handler shape (exit codes, md/json rendering, `.audit/` write).
+- `src/mtg_synergy_graph/bench/cli.py` existing `--collinearity` wiring
+  for the argparse + handler-registration pattern.
+
+**Test scenarios:**
+- Happy path: two synthetic rules with near-identical activation sets →
+  cosine > 0.95 → flagged.
+- Happy path: two synthetic rules with orthogonal activation sets →
+  cosine ≈ 0 → not flagged.
+- Edge case: threshold override via `--threshold` CLI flag.
+- Edge case: rule with zero-card activation set is skipped (no NaN).
+- Edge case: rule with one-card activation set still works (mean over
+  one element).
+- Error path: `--embedding-dedup` without `card_embeddings` present →
+  exit 2 with rebuild hint pointing at `scripts/build_embeddings.py`.
+- Error path: `--embedding-dedup` without tensor rows for current
+  `config_hash` → exit 2 with rebuild hint pointing at
+  `bench.py audit --repin`.
+- Integration: mutex-group behavior — `--embedding-dedup --collinearity`
+  together exits 2 with argparse error (mutex).
+
+**Verification:**
+- `uv run pytest tests/bench/test_embedding_dedup_handler.py
+  tests/embeddings/test_dedup.py` passes.
+- `uv run scripts/bench.py audit --embedding-dedup --help` shows the new
+  flag.
+- Running against real DB produces a coherent ranked report where at
+  least one pair agrees with the existing `--collinearity` MI-VIF output
+  (FR5 success criterion).
+
+---
+
+- [ ] **Unit 7: The flip — plumb flag, wire scorer, render `--explain`**
+
+**Goal:** Add the three constants to `ScoringConfigInputs`, wire the
+`embedding_contribution` term into `score_all_universal`'s results loop,
+extend `_render_explanation` with the new line + three nearest neighbors,
+extend the pre-commit regex, and set `_ENABLE_EMBEDDING_CONTRIBUTION =
+False` (default). Only unit that changes scores; all others stay
+identity-clean.
+
+**Requirements:** R3, R6, R7, R9, D9, D10, D12
+
+**Dependencies:** Units 1–6
+
+**Files:**
+- Modify: `src/mtg_synergy_graph/universal_scorer.py` (extend
+  `UniversalScore`, `ScoringConfigInputs`, `score_all_universal` results
+  loop)
+- Modify: `src/mtg_synergy_graph/bench/tensor.py` (`compute_config_hash`
+  picks up the three new fields)
+- Modify: `src/mtg_synergy_graph/engine.py`
+  (`_render_explanation` — the new line + nearest-neighbor lookup)
+- Modify: `src/mtg_synergy_graph/embeddings/contribution.py` (flip
+  `_ENABLE_EMBEDDING_CONTRIBUTION`, but remain `False` in this unit —
+  the actual flip-to-`True` is a follow-up after the audit sweep)
+- Modify: `.pre-commit-config.yaml` (extend bench-audit regex)
+- Modify: `tests/bench/test_universal_scorer_identity.py` (add
+  flag-off-identity assertion)
+- Create: `tests/test_explain_embedding_render.py` (integration test
+  for the new `--explain` line)
+
+**Approach:**
+- Add `embedding_contribution: float = 0.0` to `UniversalScore`
+  (line ~286). Add to `score` sum (line ~336) and `to_legacy_buckets`
+  (line ~378). Assign in the `score_all_universal` results loop (line
+  ~938–950) from the Unit 5 function, passing the cached
+  `commander_target_vector` from Unit 4 and the loaded vectors dict.
+- Extend `ScoringConfigInputs` with three fields:
+  `enable_embedding_contribution: bool`, `embedding_w: float`,
+  `embedding_k: float`. Also include `vectorizer_version: int` read
+  from the `card_embeddings_config` KV table at scorer init (so
+  rebuilding the table with a new `TOKEN_FORMAT_VERSION` invalidates
+  the tensor).
+- `_render_explanation`: after the existing `self_bridging_cascade`
+  line block, render:
+  ```
+  embedding_contribution: +0.047 (decay × cosine = 0.32 × 0.146)
+    nearest covered neighbors: Spellbinder (cosine 0.88), Experiment Kraj (0.84), Soul of the Harvest (0.81)
+  ```
+  Only when `score.embedding_contribution > 0`. Nearest covered neighbors
+  = top-3 by cosine among the candidates whose `len(distinct_rules) >=
+  1` from the same `(commander, candidates)` run.
+- Pre-commit regex extension:
+  ```yaml
+  # in .pre-commit-config.yaml bench-audit hook
+  files: ^src/mtg_synergy_graph/(complement_rules/.*\.py|universal_scorer\.py|graph_engine\.py|embeddings/.*\.py)$
+  ```
+- **Flag stays `False` in this unit.** The flip-to-`True` happens after
+  the audit sweep (see Operational Notes).
+
+**Execution note:** Start with a failing identity test asserting that
+flag-off scores are bitwise-identical to the pre-plan pinned fixture.
+Add the field plumbing only after the identity test is red.
+
+**Patterns to follow:**
+- `src/mtg_synergy_graph/complement_rules/pathway.py` — canonical
+  precedent for "add `ScoringConfigInputs` field in the same unit as
+  the flip, not earlier." Identical discipline.
+- Plan `docs/plans/2026-04-23-001-feat-self-bridging-cascade-pathway-plan.md`
+  — structural twin.
+- `src/mtg_synergy_graph/engine.py:_render_explanation` existing
+  `self_bridging_cascade:` path_info block (lines 475–483) — same
+  rendering style.
+
+**Test scenarios:**
+- Happy path: flag off (default) → `score.embedding_contribution == 0.0`
+  for every candidate; totals bitwise-identical to pre-plan baseline.
+- Happy path: flag on + `w_emb=0.0` → `score.embedding_contribution ==
+  0.0` → totals still identical.
+- Happy path: flag on + `w_emb=0.5` + N_rules=0 → contribution =
+  `0.5 * cos(v_cand, v_cmdr)`.
+- Happy path: flag on + N_rules=5 → contribution dampened by
+  `exp(-0.8*5) ≈ 0.018`.
+- Edge case: flag on + `card_embeddings` table missing → graceful
+  fallback; all contributions 0.0; scorer emits one `logging.warning`
+  per run, not per candidate.
+- Edge case: flag on + commander has zero port ports (novel commander)
+  → target vector is zero; contributions 0.0.
+- Integration: `--expect-identity` on the pre-plan pinned tensor PASSES
+  (proves flag-off identity).
+- Integration: `recommend.py --explain "Animar, Soul of Elements" |
+  head -50` includes the new `embedding_contribution:` + `nearest
+  covered neighbors:` lines when the flag is flipped locally.
+- Integration: tensor audit with flag flipped + default weights →
+  `config_hash` differs from pre-flip → `bench.py audit` detects drift
+  and requires `--repin` (this is intentional — it enforces that the
+  flip is auditable).
+
+**Verification:**
+- `uv run pytest` passes end-to-end including the new identity
+  assertion.
+- `uv run scripts/bench.py audit --expect-identity` with flag OFF passes.
+- `uv run scripts/bench.py audit --expect-identity` with flag ON fails
+  (expected — the flip changes scores by design). This is the point at
+  which the audit sweep begins.
+- Pre-commit hook regex change verified by staging a touch on
+  `src/mtg_synergy_graph/embeddings/contribution.py` and observing the
+  `bench-audit` advisory hook fires.
+- `recommend.py --explain` on a commander with flag-on + nonzero
+  `w_emb` shows the new lines correctly.
+
+## System-Wide Impact
+
+- **Interaction graph:**
+  - `SynergyEngine.page()` → `score_all_universal()` → new `embedding_contribution`
+    term populated per candidate, read from Unit 5's function, which pulls from
+    Unit 4's commander target cache and Unit 2's blob store.
+  - `bench.py audit` picks up three new `ScoringConfigInputs` fields via
+    `compute_config_hash` → pinned tensor invalidates when any of them
+    change.
+  - Pre-commit `bench-audit` advisory hook triggers on edits under the new
+    `embeddings/` subpackage.
+  - `recommend.py --explain` output grows new lines only when
+    `embedding_contribution > 0`.
+- **Error propagation:** inference-path failures are silent (log + degrade
+  to 0.0); diagnostic (`--embedding-dedup`) failures are loud (exit 2 with
+  rebuild hint). No exception escapes the scorer from embedding code.
+- **State lifecycle risks:**
+  - Rebuilding `card_embeddings` without rebuilding the pinned tensor →
+    `vectorizer_version` drift caught by the `ScoringConfigInputs` hash;
+    next `bench.py audit` fails CLEAN with a clear hash-mismatch message
+    (this is the hybrid-hash payoff).
+  - Crashed mid-build: transaction in Unit 2 is atomic; no partial state.
+  - Pruning a token type (bumping `TOKEN_FORMAT_VERSION`) requires a
+    rebuild; the `card_embeddings_config` KV table detects the stale
+    state on next read.
+- **API surface parity:** no public API changes; all additions are opt-in
+  via flag. `SynergyEngine.page()` signature unchanged.
+- **Integration coverage:** the identity test in Unit 7 is the key
+  mocks-don't-suffice scenario — it exercises the full scoring chain
+  (`find_all_complements` → `score_all_universal` → `UniversalScore.score`)
+  with a pinned fixture to prove flag-off preserves bit-identity. Unit-level
+  mocks alone wouldn't catch a subtle field-ordering regression in
+  `UniversalScore.score`.
+- **Unchanged invariants:**
+  - No EDHREC at inference ranking — EDHREC golden-set hi-syn is only
+    read at **offline** commander-target-vector build time. The
+    inference path reads precomputed vectors only. This stays within
+    `memory/feedback_edhrec_hivemind.md`.
+  - No popularity-adjacent features in the vectorizer inputs.
+  - No new EDHREC dependency in the scoring path — the existing
+    `--explain` tiebreaker is the only place EDHREC ever touches
+    inference, and this plan does not change that.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| NDCG regression similar to the reverted `card_hints`-family rules (structural similarity diluting mechanical port signal). | Start with smallest `w_emb ∈ {0.1, 0.3}`; exponential decay defaults to `k=0.8` so N_rules≥3 candidates see near-zero embedding contribution; measure `hidden_gem_hit_rate` at every audit step; if hidden-gem rate drops, flag stays `False`. Revert to `False` is a one-line diff. |
+| `numpy.linalg.svd` slow on 32k × ~5k dense matrix. | Profile in Unit 1; if > 60s, add scipy as optional `[embeddings]` extra with `scipy.sparse.linalg.svds`. Not in the default path. |
+| Commander target vector drift when the golden-set source is bumped without rebuilding embeddings. | `vectorizer_version` + `EmbeddingConfigInputs` in `ScoringConfigInputs` → next `bench.py audit` fails with hash mismatch. Rebuild is required, not optional. |
+| CI tests fail because `card_embeddings` is regenerable and CI doesn't run `scripts/build_embeddings.py`. | Autouse conftest stub in Unit 3 seeds a deterministic small-table fixture; the forge_oracle precedent (`docs/solutions/test-failures/forge-oracle-ci-git-checkout-stub-2026-04-23.md`) mandates this is established in the same commit as the first test. |
+| Embedding module imports leaking into inference path before flag is flipped. | Structural: the scorer only calls `embedding_contribution(...)` which short-circuits on the flag. Behavioral: Unit 7's identity test catches any accidental score drift at flag-off. |
+| Dedup diagnostic produces noisy false-positive rule pairs (e.g., two rules with tiny activation sets that happen to lie near each other). | Minimum-activation-set filter in Unit 6 (e.g., `|activation_set| >= 20`); makes the signal actionable without swamping humans. Threshold configurable via `--min-activation`. |
+| Audit sweep lands a `w_emb` that regresses one commander beyond MARGINAL even if aggregate improves. | FR7 explicit gate: no commander regresses beyond CONTENTIOUS; if one does, inspect whether it's well-rule-covered (expected — decay should dampen) or sparse (unexpected — revert or tune). Operational, not a planning risk. |
+
+## Documentation / Operational Notes
+
+- Update `CLAUDE.md` "Common Commands" with:
+  ```
+  uv run scripts/build_embeddings.py                                       # Build card_embeddings after cardsfolder refresh
+  uv run scripts/bench.py audit --embedding-dedup                          # Rule-pair redundancy diagnostic in embedding space
+  uv run scripts/bench.py audit --embedding-dedup --threshold 0.90         # Looser threshold for exploration
+  ```
+- Update `CLAUDE.md` "Scoring Architecture" with a new section on the
+  embedding contribution: what it is, when it fires, how decay works,
+  where the flag lives. Cross-reference this plan and the
+  flag-gated-pattern learning.
+- **Audit sweep (post-Unit 7 operational work, NOT an implementation
+  unit):**
+  1. Flip `_ENABLE_EMBEDDING_CONTRIBUTION = True` locally; iterate over
+     `w_emb ∈ {0.1, 0.3, 0.5, 1.0}` × `k ∈ {0.5, 0.8, 1.2}`.
+  2. For each combo: `scripts/bench.py audit --repin --yes` →
+     `scripts/bench.py audit` → record aggregate NDCG@30 delta,
+     `hidden_gem_hit_rate`, and per-commander verdict.
+  3. Choose the combo with the highest aggregate that also improves
+     `hidden_gem_hit_rate` AND has no commander regress beyond
+     MARGINAL.
+  4. If CONTENTIOUS: inspect losers. If losses concentrate on well-covered
+     commanders (expected), ship. If on sparse-coverage commanders
+     (unexpected), tune or revert.
+  5. If HARMFUL on any axis: revert. The flag stays `False`.
+- The promotion-to-`True` commit is separate from this plan. It lands as
+  `perf(audit): promote embedding contribution w_emb=X k=Y (+Δ NDCG, +Δ
+  hidden_gem_hit_rate)` with pinned fixture refresh, mirroring
+  `cb720b2 perf(audit): dampen counter_keyword 1.0 → 0.5` style.
+
+## Success Metrics
+
+1. **Animar-class uplift.** Animar, Kess, Yuriko, and at least 4 other
+   heterogeneous-hi-syn commanders each gain ≥1 hi-syn card in their top-30
+   after the flip. (FR Success 1)
+2. **Cold-start demonstration.** A small set of day-0 Forge-imported cards
+   rank sensibly relative to structurally-similar predecessors with no new
+   rules written. (FR Success 2)
+3. **Aggregate NDCG neutral-or-positive.** Aggregate NDCG@30 on 100-cmdr
+   golden set ≥ current baseline. (FR Success 3)
+4. **Well-covered commanders unaffected.** Atraxa, Korvold, Karador, Prossh
+   show ≤ 0.001 NDCG delta. (FR Success 4)
+5. **Inference latency ≤ 5%.** Per-candidate embedding cost is constant
+   (one dict lookup + one dot product). (FR Success 5)
+6. **Dedup diagnostic value.** `--embedding-dedup` flags ≥ 2 rule pairs
+   that agree with `--collinearity` MI-VIF output AND ≥ 1 pair that
+   MI-VIF missed. (FR Success 6)
+7. **`hidden_gem_hit_rate` ≥ baseline.** This is the non-negotiable
+   gate per the `card_hints` reversion lesson. Aggregate gains at the
+   cost of hidden-gem rate = revert.
+
+## Alternative Approaches Considered
+
+- **sklearn `TfidfVectorizer` + `TruncatedSVD`.** Rejected: would add
+  scikit-learn as a runtime dep (sizeable install footprint, extra
+  lock-file entries). Hand-rolled math is ~40 lines and aligns with the
+  project's zero-extra-dep posture. Revisit only if the corpus grows
+  past the point where numpy.linalg.svd is unacceptably slow.
+- **Oracle-text n-grams as features.** Rejected per origin doc §Non-Goals
+  — structural features only. Text n-grams would recreate the `card_hints`
+  failure mode at higher cardinality.
+- **Neural / transformer embeddings.** Rejected per origin doc §Non-Goals
+  — non-deterministic + non-explainable + requires training infrastructure.
+- **Sidecar `data/card_embeddings.db`.** Rejected per D2 — vectors are
+  consumed at inference; sidecar isolation is only right for offline-only
+  data. Forge_oracle pattern doesn't apply here.
+- **Persist commander target vectors to a second table.** Rejected per
+  D5 — lazy + `functools.cache` is simpler; 100 golden-set commanders
+  warm up during bench. Revisit only if cold-start latency on the first
+  user query per commander becomes a user-visible issue.
+- **Auto-propose rule merges from `--embedding-dedup`.** Rejected per D11
+  — humans read the diagnostic; auto-merging rules would violate the
+  audit-every-change guardrail and make rule consolidation opaque.
+- **Morgan/ECFP circular fingerprints over typed port-nodes as the first
+  embedding.** Deferred per origin doc §Out of Scope — circular
+  fingerprints need plan 003's typed-port-graph vocabulary to be
+  generalized past the current 16 rules. Promising phase-2 upgrade.
+
+## Phased Delivery
+
+### Phase 1 — Offline infrastructure (identity-clean)
+- Unit 1: Vectorizer (pure function)
+- Unit 2: Schema + config hash + store
+- Unit 3: Build script + CI conftest stub
+
+Lands without scoring-path changes. Vectors computable on demand; no
+scorer wiring yet. `--expect-identity` clean throughout.
+
+### Phase 2 — Commander target + inference reader (still identity-clean)
+- Unit 4: Commander target vector (lazy, cached)
+- Unit 5: `embedding_contribution` function with graceful-fallback contract
+
+Reader ready but unused by the scorer. `--expect-identity` still clean.
+
+### Phase 3 — Diagnostic (read-only)
+- Unit 6: `bench.py audit --embedding-dedup`
+
+Ships the dedup report without affecting scores. Humans can start using
+the diagnostic to inform rule consolidation before embeddings go live.
+
+### Phase 4 — The flip (audit-gated)
+- Unit 7: `ScoringConfigInputs` plumb + scorer wire + `--explain` + regex
+
+Default flag `False`. Operational audit sweep begins after this lands
+(separate commits, not in this plan).
+
+## Documentation Plan
+
+- `CLAUDE.md` — new "Content Embeddings" section under "Scoring Architecture"
+  describing the term, flag, decay, cache behavior; extend
+  "Common Commands" with `scripts/build_embeddings.py` + `--embedding-dedup`.
+- `docs/RULE_PLANNING.md` — note that `--embedding-dedup` is now part of
+  the audit-iterate toolkit alongside `--collinearity` and hidden-gem
+  inspection.
+- `docs/RULE_HISTORY.md` — a single dated entry when the flip lands in
+  the audit sweep, recording the chosen `w_emb` + `k` and the aggregate
+  delta + `hidden_gem_hit_rate` delta.
+- No `docs/solutions/` entries in this plan. If a non-obvious issue
+  surfaces during execution (e.g., SVD determinism across numpy versions,
+  CI fixture drift), capture it via `/ce-compound` post-landing.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-21-content-embeddings-requirements.md](../brainstorms/2026-04-21-content-embeddings-requirements.md)
+- **Parent ideation:** [docs/ideation/2026-04-21-recommendation-model-ideation.md](../ideation/2026-04-21-recommendation-model-ideation.md) (Survivor 6 of 7)
+- **Prerequisite plan (landed):** [docs/plans/2026-04-22-001-feat-unified-eval-harness-plan.md](2026-04-22-001-feat-unified-eval-harness-plan.md) — `rule_contributions` tensor consumed by FR5.
+- **Structural twin plan:** [docs/plans/2026-04-23-001-feat-self-bridging-cascade-pathway-plan.md](2026-04-23-001-feat-self-bridging-cascade-pathway-plan.md) — same flag-gated discipline; mirror its unit sequencing.
+- **Related landed plan:** [docs/plans/2026-04-22-002-feat-typed-port-graph-substrate-plan.md](2026-04-22-002-feat-typed-port-graph-substrate-plan.md) — phase-2 circular fingerprints will eventually layer on top of this vocabulary.
+- **Governing learning:** [docs/solutions/best-practices/flag-gated-multi-port-rule-pattern-2026-04-23.md](../solutions/best-practices/flag-gated-multi-port-rule-pattern-2026-04-23.md)
+- **Partial-apply learning:** [docs/solutions/best-practices/offline-oracle-hash-pattern-2026-04-23.md](../solutions/best-practices/offline-oracle-hash-pattern-2026-04-23.md) — hybrid hash discipline (`ScoringConfigInputs` + KV table).
+- **CI fixture learning:** [docs/solutions/test-failures/forge-oracle-ci-git-checkout-stub-2026-04-23.md](../solutions/test-failures/forge-oracle-ci-git-checkout-stub-2026-04-23.md)
+- **Gitignore learning:** [docs/solutions/build-errors/gitignore-negation-under-ignored-parent-2026-04-23.md](../solutions/build-errors/gitignore-negation-under-ignored-parent-2026-04-23.md)
+- **Memory guardrails:**
+  - `memory/feedback_audit_every_change.md` — every scoring-path flip is audit-gated.
+  - `memory/feedback_no_individual_rules.md` — embedding is the structural answer.
+  - `memory/feedback_edhrec_hivemind.md` — EDHREC offline-only, not inference.
+  - `memory/feedback_edhrec_not_goal.md` — real goal is hidden gems.
+  - `memory/feedback_hidden_gem_metric.md` — `hidden_gem_hit_rate` is the second axis.
+  - CLAUDE.md note on reverted `card_hints`-family rules — structural-similarity failure mode warning.

--- a/docs/plans/2026-04-23-003-feat-content-embeddings-fallback-plan.md
+++ b/docs/plans/2026-04-23-003-feat-content-embeddings-fallback-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Content embeddings as zero-shot fallback"
 type: feat
-status: active
+status: landed
 date: 2026-04-23
 origin: docs/brainstorms/2026-04-21-content-embeddings-requirements.md
 ---
@@ -392,7 +392,7 @@ Output is a sorted markdown table; JSON mode mirrors
 
 ## Implementation Units
 
-- [ ] **Unit 1: Feature vectorizer (pure function)**
+- [x] **Unit 1: Feature vectorizer (pure function)**
 
 **Goal:** Hand-rolled TF-IDF + truncated-SVD vectorizer over structured
 inputs. No DB writes yet — pure function from `{card_name: feature_tokens}`
@@ -449,7 +449,7 @@ to `{card_name: ndarray(128,)}`.
 
 ---
 
-- [ ] **Unit 2: Schema, config hash, and blob store**
+- [x] **Unit 2: Schema, config hash, and blob store**
 
 **Goal:** Add the `card_embeddings` and `card_embeddings_config` tables;
 define `EmbeddingConfigInputs` NamedTuple + `compute_embedding_hash` +
@@ -528,7 +528,7 @@ define `EmbeddingConfigInputs` NamedTuple + `compute_embedding_hash` +
 
 ---
 
-- [ ] **Unit 3: Build script + CI conftest stub**
+- [x] **Unit 3: Build script + CI conftest stub**
 
 **Goal:** User-invoked `scripts/build_embeddings.py` that wires
 Unit 1 (vectorizer) + Unit 2 (store) end-to-end. Autouse conftest stub so
@@ -594,7 +594,7 @@ rebuilt.
 
 ---
 
-- [ ] **Unit 4: Commander target vector (lazy + cached)**
+- [x] **Unit 4: Commander target vector (lazy + cached)**
 
 **Goal:** `build_commander_target_vector(commander_set, vectors,
 golden_hi_syn)` that returns the L2-normalized mean of the commander's own
@@ -649,7 +649,7 @@ Module-level `functools.cache` keyed by `tuple(commander_set)`.
 
 ---
 
-- [ ] **Unit 5: Inference-path reader with graceful-fallback contract**
+- [x] **Unit 5: Inference-path reader with graceful-fallback contract**
 
 **Goal:** `load_card_embeddings(conn) -> dict[str, np.ndarray]` and
 `embedding_contribution(score, v_cmdr, vectors) -> float` that the scorer
@@ -714,7 +714,7 @@ graceful-fallback return paths before writing the function body.
 
 ---
 
-- [ ] **Unit 6: `bench.py audit --embedding-dedup` diagnostic**
+- [x] **Unit 6: `bench.py audit --embedding-dedup` diagnostic**
 
 **Goal:** New audit mode that consumes the `rule_contributions` tensor +
 `card_embeddings` and flags rule pairs whose candidate-activation sets
@@ -792,7 +792,7 @@ Survivor 1 `rule_contributions` tensor (already landed).
 
 ---
 
-- [ ] **Unit 7: The flip — plumb flag, wire scorer, render `--explain`**
+- [x] **Unit 7: The flip — plumb flag, wire scorer, render `--explain`**
 
 **Goal:** Add the three constants to `ScoringConfigInputs`, wire the
 `embedding_contribution` term into `score_all_universal`'s results loop,

--- a/docs/reviews/2026-04-23-content-embeddings-followups.md
+++ b/docs/reviews/2026-04-23-content-embeddings-followups.md
@@ -1,0 +1,164 @@
+# Content embeddings — pre-flag-flip follow-ups
+
+Deferred findings from `/ce-code-review` on branch
+`feat/content-embeddings-fallback` (run ID 20260423-213012-17f8d1eb,
+plan `docs/plans/2026-04-23-003-feat-content-embeddings-fallback-plan.md`).
+
+Current branch ships `_ENABLE_EMBEDDING_CONTRIBUTION = False`. The
+items below are pre-flag-flip work — safe to merge the current branch
+without resolving them, but they must be resolved before the audit
+sweep that flips the flag. Grouped by urgency.
+
+## Gate-blocking for the flag flip
+
+### FU-1. CLI flags `--min-df` / `--svd-dims` are broken end-to-end
+
+**Reviewer:** correctness CORR-001 (HIGH, 0.90) + CORR-002 (HIGH, 0.88),
+adversarial ADV-003 (0.85), maintainability M-003 (0.82).
+
+**Problem.** `load_card_embeddings_verified` calls
+`get_embedding_config_inputs()` which returns the CURRENT code
+defaults. If `scripts/build_embeddings.py` was run with `--min-df 3`,
+the stored `config_hash` reflects `min_df=3` but the inference recompute
+uses `min_df=2` → mismatch → silent `{}` with misleading "stale" error.
+
+Separately, `_EMBEDDING_DIM = 128` is a module-level constant in
+`store.py`. If `--svd-dims 64` is used at build time, every vector is
+silently skipped on load because `len(vector) != _EMBEDDING_DIM`.
+
+**Recommended fix.** Reconstruct `EmbeddingConfigInputs` from the stored
+`card_embeddings_config` KV rows before calling the hash comparison.
+The scorer's `ScoringConfigInputs.vectorizer_version` then serves as a
+separate freshness signal against the tensor. Remove the
+`_EMBEDDING_DIM = 128` constant; read the expected dim from the same
+KV reconstruction.
+
+**Alternative.** Restrict `--min-df` and `--svd-dims` to defaults-only
+(emit error at build time if non-default). Simpler but loses the
+planned tuning affordance.
+
+**Files:** `src/mtg_synergy_graph/embeddings/contribution.py:148`,
+`src/mtg_synergy_graph/embeddings/store.py:151`,
+`src/mtg_synergy_graph/embeddings/config.py`.
+
+## Must-fix before the flag flip
+
+### FU-2. `_render_embedding_block` re-loads all 32k vectors per `--explain` candidate
+
+**Reviewer:** performance PERF-002 (HIGH, 0.88), maintainability M-004 (0.75).
+
+**Problem.** `_render_embedding_block` calls
+`load_card_embeddings_verified(self._conn)` and
+`build_commander_target_vector(...)` per candidate. A single
+`recommend.py --explain` page with 30 rule-covered top-30 candidates
+triggers up to 30 full table scans + 30 full blob deserializations
+(~480MB of transient Python work).
+
+**Recommended fix.** Cache on the `SynergyEngine` instance (`self._emb_vectors`, `self._emb_cmdr_target`) populated on first call in
+`_render_embedding_block`. Clear the cache in `SynergyEngine._reset_score_cache` (if a similar method exists) to tie invalidation to existing cache lifecycle.
+
+**Files:** `src/mtg_synergy_graph/engine.py:542–602`.
+
+### FU-3. `functools.cache` on `sqlite3.Connection` identity — undocumented + unbounded
+
+**Reviewer:** maintainability M-005 (0.80), reliability R-005 (0.75).
+
+**Problem.** `_fetch_hi_syn_names_cached` uses `@functools.cache` with
+`sqlite3.Connection` as part of the cache key, relying on CPython's
+undocumented object-identity hashability for connections. In a
+long-running process, dead connection references accumulate — no
+production `clear_cache()` call exists.
+
+**Recommended fix.** Switch to a manual dict keyed by `(id(conn),
+commander_name, hi_syn_limit)`, with explicit size bound (e.g.,
+`functools.lru_cache(maxsize=512)` applied to a wrapper that extracts
+`id(conn)` first).
+
+**Files:** `src/mtg_synergy_graph/embeddings/commander_target.py:54`.
+
+### FU-4. NaN propagation breaks flag-off identity guarantee
+
+**Reviewer:** adversarial ADV-002 (0.92).
+
+**Problem.** `0.0 * decay * NaN = NaN` in IEEE 754. If any vector
+produces a NaN during cosine, the embedding term becomes NaN, the
+score becomes NaN, Python sort is undefined. L2-normalized inputs
+are unlikely to produce NaN but the short-circuit contract should be
+tight.
+
+**Recommended fix.** In `embedding_contribution`, add an explicit NaN
+guard on the cosine value before returning — or use `math.fsum` /
+clamp logic.
+
+**Files:** `src/mtg_synergy_graph/embeddings/contribution.py:128`.
+
+## Build-time / operational
+
+### FU-5. TF-IDF matrix memory footprint (~1.3GB before SVD; peak ~4-5GB)
+
+**Reviewer:** performance PERF-001 (0.90).
+
+**Problem.** Dense `(32k, ~5k)` float64 matrix built before
+`numpy.linalg.svd`. Peak allocation during LAPACK dense SVD is 3-4×
+that — 4-5 GB. Risks OOM on 8GB dev machines and may exceed the
+60s plan budget.
+
+**Mitigations (any one sufficient):**
+1. Cap vocabulary via `max_features` (e.g., top 3000 by IDF). Simpler.
+2. Add scipy as optional `[embeddings]` extra and use
+   `scipy.sparse.linalg.svds` on sparse TF-IDF. Lower RAM, slightly
+   slower on small corpora.
+3. Document the 16+GB machine requirement in CLAUDE.md and accept the
+   cost.
+
+**Measurement needed.** Actual vocabulary size after `min_df=2` pruning
+on the real 32k corpus — could be lower than 5k, lowering the ceiling.
+
+**Files:** `src/mtg_synergy_graph/embeddings/svd.py:61`,
+`src/mtg_synergy_graph/embeddings/vectorizer.py:213–220`.
+
+## Discretionary (P3, advisory)
+
+Bundled for awareness; address case-by-case during the audit sweep or
+subsequent maintenance:
+
+- **CLI UX polish.** `build_embeddings.py --format json`, `--check`,
+  help naming output tables; `.audit/last_dedup.md` side-effect
+  documented + honor `--output -` for stdin consumers
+  (cli-readiness CR-001/002/004/005/006).
+- **Typing consistency.** `write_vectors` → `Mapping[str, np.ndarray]`;
+  reconcile `TfidfResult` NamedTuple-with-ndarray `__eq__`
+  (kieran-python KP-001, KP-007).
+- **Hash stability.** `compute_embedding_hash` → `json.dumps(sort_keys=True)` instead of `repr(sorted(items))`
+  (kieran-python KP-003).
+- **Public API surface.** Add `EmbeddingConfigInputs` / `DedupPair`
+  to root `__init__.__all__` or mark internal
+  (api-contract AC-004).
+- **Diagnostic perf.** `_nearest_covered_neighbors` Python loop → BLAS
+  matmul; `dedup.fetchall()` → streaming group-by;
+  `build_embeddings.py` TF matrix `np.add.at` instead of double-loop
+  (performance PERF-003/004/005).
+- **FK error message.** `build_embeddings.py` should validate
+  `cards(name)` membership before bulk insert, or wrap the FK error
+  with a user-actionable hint (api-contract AC-003,
+  data-migrations DM-002).
+- **Test brittleness.** `tests/embeddings/test_commander_target.py`
+  asserts against `cache_info()` private attr (testing T-001).
+- **Dedup filter.** `min_activation` uses `len(cands)` but mean vector
+  uses `len(found)` subset — potential false positives with sparse
+  embedding coverage (correctness CORR-004).
+- **Empty-vocabulary cascade.** 32k all-zero vectors + 32k warnings
+  when `min_df` prunes everything — could log once + summary count
+  (adversarial ADV-004).
+- **Docstring fix.** `read_vector` claims `--explain` use; unused in
+  production (maintainability M-006).
+- **Dedup OOM at scale.** Current fleet safe; revisit when rule count
+  crosses ~300 (adversarial ADV-007).
+
+## References
+
+- **Review run artifact:** `.context/compound-engineering/ce-code-review/20260423-213012-17f8d1eb/`
+- **Plan:** `docs/plans/2026-04-23-003-feat-content-embeddings-fallback-plan.md`
+- **Re-pin commit:** `b887cf4` (hash-only change, Δ=+0.0000 across 100
+  commanders)
+- **First fix batch (safe_auto):** `ab8b2a3`

--- a/scripts/build_embeddings.py
+++ b/scripts/build_embeddings.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Build the ``card_embeddings`` table from structured per-card features.
+
+Standalone user-invoked build step (plan 2026-04-23-003 Unit 3). Mirrors
+``scripts/build_graph_cache.py`` — the importer does NOT invoke this;
+users run it manually after each Forge cardsfolder refresh (or when the
+vectorizer version is bumped).
+
+Pipeline:
+
+1. ``open_db(db_path)`` to apply the v1.2.2 schema (creates
+   ``card_embeddings`` + ``card_embeddings_config`` if absent).
+2. ``extract_card_tokens(conn)`` — structured feature bag per card.
+3. ``compute_tfidf(corpus, min_df=...)`` — TF-IDF over the corpus.
+4. ``truncated_svd(tfidf, k=svd_dims)`` — project to fixed dim + L2.
+5. ``write_vectors(conn, vectors, inputs)`` — one atomic transaction
+   that wipes and re-populates both embedding tables.
+
+Usage:
+
+    uv run scripts/build_embeddings.py
+    uv run scripts/build_embeddings.py --db data/synergy.db
+    uv run scripts/build_embeddings.py --min-df 3 --svd-dims 64
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+# scripts/ is not a package; the sys.path shim mirrors the precedent from
+# other scripts in this directory so ``from mtg_synergy_graph...`` imports
+# resolve when invoked as ``uv run scripts/build_embeddings.py``.
+_SRC = Path(__file__).resolve().parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from mtg_synergy_graph.db import open_db  # noqa: E402 — after sys.path shim
+from mtg_synergy_graph.embeddings import (  # noqa: E402 — after sys.path shim
+    compute_tfidf,
+    extract_card_tokens,
+    get_embedding_config_inputs,
+    truncated_svd,
+    write_vectors,
+)
+
+
+def _build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=Path("data/synergy.db"),
+        help="Path to the synergy.db. Default: data/synergy.db",
+    )
+    parser.add_argument(
+        "--min-df",
+        type=int,
+        default=2,
+        help="Minimum document frequency for TF-IDF pruning. Default: 2",
+    )
+    parser.add_argument(
+        "--svd-dims",
+        type=int,
+        default=128,
+        help="Target dimensionality after truncated SVD. Default: 128",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_argparser()
+    args = parser.parse_args(argv)
+
+    if not args.db.exists():
+        print(f"error: {args.db} does not exist", file=sys.stderr)
+        return 2
+
+    start = time.perf_counter()
+    try:
+        conn = open_db(args.db)
+        try:
+            corpus = extract_card_tokens(conn)
+            tfidf_result = compute_tfidf(corpus, min_df=args.min_df)
+            projected = truncated_svd(tfidf_result.tfidf_matrix, k=args.svd_dims)
+
+            # Pair each row with its card name. ``card_names`` is sorted
+            # ascending and matches the row order of ``projected`` by
+            # construction (see ``TfidfResult`` in embeddings.vectorizer).
+            vectors = {name: projected[i] for i, name in enumerate(tfidf_result.card_names)}
+
+            # Start from the ambient defaults, then override the two
+            # CLI-tunable knobs so the config hash reflects the actual
+            # build inputs (not the defaults).
+            inputs = get_embedding_config_inputs()._replace(
+                min_df=args.min_df,
+                svd_dims=args.svd_dims,
+            )
+            write_vectors(conn, vectors, inputs)
+
+            elapsed = time.perf_counter() - start
+            config_hash_row = conn.execute(
+                "SELECT value FROM card_embeddings_config WHERE key = 'config_hash'"
+            ).fetchone()
+            config_hash = config_hash_row[0] if config_hash_row else "?"
+            print(
+                f"embeddings: built {len(vectors)} vectors "
+                f"x {args.svd_dims} dims, "
+                f"vocabulary={len(tfidf_result.vocabulary)}, "
+                f"config_hash={config_hash[:8]}..., "
+                f"wall={elapsed:.2f}s"
+            )
+        finally:
+            conn.close()
+    except (SystemExit, KeyboardInterrupt):
+        raise
+    except Exception as exc:
+        print(f"error: build_embeddings failed: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_embeddings.py
+++ b/scripts/build_embeddings.py
@@ -45,6 +45,10 @@ from mtg_synergy_graph.embeddings import (  # noqa: E402 — after sys.path shim
     truncated_svd,
     write_vectors,
 )
+from mtg_synergy_graph.embeddings.config import (  # noqa: E402 — after sys.path shim
+    _DEFAULT_MIN_DF,
+    _DEFAULT_SVD_DIMS,
+)
 
 
 def _build_argparser() -> argparse.ArgumentParser:
@@ -58,14 +62,14 @@ def _build_argparser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--min-df",
         type=int,
-        default=2,
-        help="Minimum document frequency for TF-IDF pruning. Default: 2",
+        default=_DEFAULT_MIN_DF,
+        help=f"Minimum document frequency for TF-IDF pruning. Default: {_DEFAULT_MIN_DF}",
     )
     parser.add_argument(
         "--svd-dims",
         type=int,
-        default=128,
-        help="Target dimensionality after truncated SVD. Default: 128",
+        default=_DEFAULT_SVD_DIMS,
+        help=f"Target dimensionality after truncated SVD. Default: {_DEFAULT_SVD_DIMS}",
     )
     return parser
 

--- a/src/mtg_synergy_graph/bench/__init__.py
+++ b/src/mtg_synergy_graph/bench/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from mtg_synergy_graph.bench import cli as _cli
 from mtg_synergy_graph.bench.audit import handle_audit, run_audit
 from mtg_synergy_graph.bench.cli import main
+from mtg_synergy_graph.bench.embedding_dedup_handler import handle_embedding_dedup
 from mtg_synergy_graph.bench.fixture import (
     FixtureEntry,
     PinnedFixture,
@@ -58,6 +59,10 @@ _cli.register("trend", handle_trend_hidden_gems)
 # Plan 002 Unit 7 — Kendall τ sidecar: compare our top-N to Forge
 # CardRanker's ranking over the same candidate set.
 _cli.register("vs_forge_oracle", handle_vs_forge_oracle)
+# Plan 003 (content-embeddings) Unit 6 — rule-pair embedding dedup
+# diagnostic. Flags rule pairs whose candidate-activation sets are
+# near-parallel in embedding space.
+_cli.register("embedding_dedup", handle_embedding_dedup)
 
 __all__ = [
     "AuditReport",

--- a/src/mtg_synergy_graph/bench/_stubs.py
+++ b/src/mtg_synergy_graph/bench/_stubs.py
@@ -55,3 +55,7 @@ def trend_stub(args: argparse.Namespace) -> int:
 
 def vs_forge_oracle_stub(args: argparse.Namespace) -> int:
     _unimplemented("bench.py audit --vs-forge-oracle")
+
+
+def embedding_dedup_stub(args: argparse.Namespace) -> int:
+    _unimplemented("bench.py audit --embedding-dedup")

--- a/src/mtg_synergy_graph/bench/cli.py
+++ b/src/mtg_synergy_graph/bench/cli.py
@@ -65,6 +65,10 @@ _HANDLERS: dict[str, Callable[[Namespace], int]] = {
     "trend": _stubs.trend_stub,
     # Plan 002 Unit 7 — Forge CardRanker Kendall-τ sidecar.
     "vs_forge_oracle": _stubs.vs_forge_oracle_stub,
+    # Plan 003 (content-embeddings) Unit 6 — rule-pair embedding dedup
+    # diagnostic. Flags rule pairs whose candidate-activation sets are
+    # near-parallel in embedding space. Read-only; never mutates the DB.
+    "embedding_dedup": _stubs.embedding_dedup_stub,
 }
 
 
@@ -170,6 +174,15 @@ def _build_parser() -> argparse.ArgumentParser:
         "breakdown + top-10 divergences. Requires data/forge_oracle.db "
         "(plan 002 Unit 7). Tracking-only; does not gate commits.",
     )
+    mode.add_argument(
+        "--embedding-dedup",
+        dest="embedding_dedup",
+        action="store_true",
+        help="Flag rule pairs whose candidate-activation sets are near-"
+        "parallel in embedding space (read-only diagnostic). Requires "
+        "card_embeddings to be populated — run `scripts/build_embeddings.py` "
+        "first. See plan 2026-04-23-003 FR5.",
+    )
 
     # Shared flags.
     audit.add_argument(
@@ -259,6 +272,25 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Used by --vs-forge-oracle only. Minimum-evidence threshold used when the "
         "sidecar was built. Must match `scripts/forge_oracle.py build --min-decks`. Default: 3.",
     )
+    # --embedding-dedup flags (plan 003 Unit 6). Scoped by mode, not by
+    # argparse — argparse doesn't natively gate flags by mutex-group
+    # selection, matching how --limit / --inspect coexist today.
+    audit.add_argument(
+        "--threshold",
+        dest="threshold",
+        type=float,
+        default=0.95,
+        help="Used by --embedding-dedup only. Cosine-similarity cutoff for flagged rule pairs. Default: 0.95.",
+    )
+    audit.add_argument(
+        "--min-activation",
+        dest="min_activation",
+        type=int,
+        default=20,
+        help="Used by --embedding-dedup only. Rules with fewer than this many "
+        "distinct candidates in their activation set are dropped before "
+        "pair comparison. Default: 20.",
+    )
 
     return parser
 
@@ -284,6 +316,8 @@ def _resolve_mode(args: Namespace) -> str:
         return "trend"
     if getattr(args, "vs_forge_oracle", False):
         return "vs_forge_oracle"
+    if getattr(args, "embedding_dedup", False):
+        return "embedding_dedup"
     return "audit"
 
 

--- a/src/mtg_synergy_graph/bench/cli.py
+++ b/src/mtg_synergy_graph/bench/cli.py
@@ -364,6 +364,18 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
 
+    # ``--threshold`` / ``--min-activation`` only make sense with
+    # ``--embedding-dedup``. Mirror the ``--trend-n`` pattern: warn on
+    # stderr rather than erroring so the user sees the flag had no
+    # effect.
+    if mode != "embedding_dedup" and (
+        getattr(args, "threshold", 0.95) != 0.95 or getattr(args, "min_activation", 20) != 20
+    ):
+        print(
+            "bench.py audit: warning: --threshold and --min-activation have no effect without --embedding-dedup.",
+            file=sys.stderr,
+        )
+
     handler = _HANDLERS[mode]
     return handler(args)
 

--- a/src/mtg_synergy_graph/bench/embedding_dedup_handler.py
+++ b/src/mtg_synergy_graph/bench/embedding_dedup_handler.py
@@ -1,0 +1,226 @@
+"""``bench.py audit --embedding-dedup`` handler (plan 003 Unit 6).
+
+Glues ``embeddings.dedup.compute_embedding_dedup`` to:
+
+* the persisted ``rule_contributions`` tensor under the current
+  scoring ``config_hash``,
+* ``card_embeddings`` via
+  ``embeddings.store.load_card_embeddings`` + the strict
+  ``embeddings.config.verify_current_or_raise`` guard, and
+* a markdown / JSON renderer that writes to ``.audit/last_dedup.md``
+  as a side effect (matches ``--collinearity`` conventions).
+
+Exit-code discipline follows plan D7 (offline-strict diagnostic):
+* 0 — success; report on stdout + file.
+* 2 — precondition missing (no tensor rows / no embeddings / stale
+  embedding config). Every 2-exit path prints an actionable rebuild
+  hint to stderr.
+
+The handler never raises — any unexpected error falls into a
+top-level ``except Exception`` that logs to stderr and returns 2.
+This keeps the CLI from emitting a traceback on an audit machine.
+
+Plan: docs/plans/2026-04-23-003-feat-content-embeddings-fallback-plan.md Unit 6.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json as _json
+import sys
+from pathlib import Path
+
+from mtg_synergy_graph.bench.tensor import compute_config_hash
+from mtg_synergy_graph.db import open_db
+from mtg_synergy_graph.embeddings.config import (
+    EmbeddingConfigMissingError,
+    EmbeddingConfigStaleError,
+    get_embedding_config_inputs,
+    verify_current_or_raise,
+)
+from mtg_synergy_graph.embeddings.dedup import DedupPair, compute_embedding_dedup
+from mtg_synergy_graph.embeddings.store import load_card_embeddings
+
+#: Relative path to the side-effect markdown mirror of the report. We
+#: always write a markdown copy (even when ``--format json`` is chosen
+#: for stdout) to match ``--collinearity``'s ``.audit/last.md``
+#: convention: humans skim ``.audit/`` after each run, not stdout
+#: captures.
+_AUDIT_SIDE_EFFECT_PATH: str = ".audit/last_dedup.md"
+
+
+def _render_markdown(pairs: list[DedupPair], threshold: float, min_activation: int) -> str:
+    """Human-readable markdown table matching the ``--collinearity`` style."""
+    lines: list[str] = []
+    lines.append("# bench.py audit --embedding-dedup")
+    lines.append(f"threshold: {threshold:.3f}")
+    lines.append(f"min_activation: {min_activation}")
+    lines.append(f"pairs_flagged: {len(pairs)}")
+    lines.append("")
+
+    if not pairs:
+        lines.append(f"No rule pairs exceed cosine > {threshold:.3f}.")
+        return "\n".join(lines) + "\n"
+
+    header = f"{'rule_a':<40} {'rule_b':<40} {'cosine':>8} {'act_a':>6} {'act_b':>6}"
+    lines.append(header)
+    lines.append("-" * len(header))
+    for pair in pairs:
+        lines.append(
+            f"{pair.rule_a[:40]:<40} {pair.rule_b[:40]:<40} "
+            f"{pair.cosine:>8.4f} {pair.activation_a_size:>6d} {pair.activation_b_size:>6d}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _render_json(pairs: list[DedupPair]) -> str:
+    """Structured JSON output mirroring ``handle_collinearity``."""
+    payload = [
+        {
+            "rule_a": pair.rule_a,
+            "rule_b": pair.rule_b,
+            "cosine": pair.cosine,
+            "activation_a_size": pair.activation_a_size,
+            "activation_b_size": pair.activation_b_size,
+        }
+        for pair in pairs
+    ]
+    return _json.dumps(payload, indent=2, ensure_ascii=False)
+
+
+def _write_side_effect(markdown: str) -> None:
+    """Mirror the markdown report to ``.audit/last_dedup.md``.
+
+    Creates the parent directory if missing so a fresh checkout
+    without a prior audit run doesn't crash here. Failures to write
+    (e.g., permissions) propagate up to the top-level exception
+    handler in :func:`handle_embedding_dedup`.
+    """
+    path = Path(_AUDIT_SIDE_EFFECT_PATH)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(markdown, encoding="utf-8")
+
+
+def handle_embedding_dedup(args: argparse.Namespace) -> int:
+    """Flag rule pairs whose candidate-activation sets are near-parallel
+    in embedding space.
+
+    Exit codes:
+
+    * ``0`` — success. Report rendered on stdout + mirrored to
+      ``.audit/last_dedup.md``.
+    * ``2`` — precondition missing or unexpected failure. Every ``2``
+      path prints an actionable stderr hint.
+
+    Preconditions (checked in order):
+
+    1. ``rule_contributions`` has rows under the current scoring
+       ``config_hash`` — rebuild via ``bench.py audit --repin --yes``.
+    2. ``card_embeddings`` is populated — rebuild via
+       ``scripts/build_embeddings.py``.
+    3. ``card_embeddings_config`` hash matches the current embedding
+       config (strict: stale hash fails loud, per plan D7).
+    """
+    threshold: float = float(getattr(args, "threshold", 0.95))
+    min_activation: int = int(getattr(args, "min_activation", 20))
+
+    try:
+        conn = open_db(args.db)
+    except Exception as exc:  # pragma: no cover — DB open failure is exceptional
+        print(f"error: could not open DB at {args.db!r}: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        try:
+            # Precondition 1: tensor rows for current scoring config.
+            scoring_hash = compute_config_hash()
+            tensor_row_count = conn.execute(
+                "SELECT COUNT(*) FROM rule_contributions WHERE config_hash = ?",
+                (scoring_hash,),
+            ).fetchone()[0]
+            if tensor_row_count == 0:
+                print(
+                    "error: no rule_contributions rows for current scoring "
+                    f"config_hash={scoring_hash[:12]}.... "
+                    "Rebuild with `uv run scripts/bench.py audit --repin --yes`.",
+                    file=sys.stderr,
+                )
+                return 2
+
+            # Precondition 2: embeddings present.
+            vectors = load_card_embeddings(conn)
+            if not vectors:
+                print(
+                    "error: no card_embeddings available. Rebuild with `uv run scripts/build_embeddings.py`.",
+                    file=sys.stderr,
+                )
+                return 2
+
+            # Precondition 3: embedding config hash matches current.
+            try:
+                verify_current_or_raise(conn, get_embedding_config_inputs())
+            except (EmbeddingConfigStaleError, EmbeddingConfigMissingError) as exc:
+                # Both error messages already contain the rebuild
+                # command; printing them verbatim keeps the CLI hint
+                # in one place (the config module).
+                print(f"error: {exc}", file=sys.stderr)
+                return 2
+
+            # Tensor rows — commander/candidate/rule_id/contribution,
+            # ``contribution > 0`` so we only count positive firings.
+            # Matches the FR5 spec wording ("flags rule pairs whose
+            # candidate-activation sets are near-parallel in embedding
+            # space") — a rule that fires a zero-or-negative
+            # contribution is "not really covering the candidate".
+            rows = conn.execute(
+                "SELECT commander, candidate, rule_id, contribution "
+                "FROM rule_contributions "
+                "WHERE config_hash = ? AND contribution > 0",
+                (scoring_hash,),
+            ).fetchall()
+
+            # The cursor returns Row objects; convert to plain tuples
+            # so ``compute_embedding_dedup``'s type signature matches
+            # its unit tests (Sequence[tuple[...]]).
+            tensor_rows: list[tuple[str, str, str, float]] = [
+                (r["commander"], r["candidate"], r["rule_id"], float(r["contribution"])) for r in rows
+            ]
+        finally:
+            conn.close()
+    except Exception as exc:
+        print(
+            f"error: unexpected failure while preparing dedup inputs: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        pairs = compute_embedding_dedup(
+            tensor_rows,
+            vectors,
+            threshold=threshold,
+            min_activation=min_activation,
+        )
+
+        # Always render the markdown report (even when the user
+        # requested JSON on stdout) so ``.audit/last_dedup.md`` is a
+        # durable human-readable record. Matches the side-effect
+        # discipline in ``handle_collinearity``.
+        markdown = _render_markdown(pairs, threshold=threshold, min_activation=min_activation)
+        _write_side_effect(markdown)
+
+        fmt = getattr(args, "format", "md")
+        rendered = _render_json(pairs) if fmt == "json" else markdown
+        # stdout for the rendered output; stderr for confirmations.
+        print(rendered)
+        print(
+            f"bench.py audit --embedding-dedup: report written to {_AUDIT_SIDE_EFFECT_PATH}",
+            file=sys.stderr,
+        )
+        return 0
+    except Exception as exc:
+        print(
+            f"error: unexpected failure during dedup rendering: {exc}",
+            file=sys.stderr,
+        )
+        return 2

--- a/src/mtg_synergy_graph/bench/tensor.py
+++ b/src/mtg_synergy_graph/bench/tensor.py
@@ -74,6 +74,18 @@ def compute_config_hash() -> str:
     # each other's pinned tensor.
     h.update(b"|pathway:")
     h.update(repr(cfg.enable_pathway_rules).encode("utf-8"))
+    # Plan 2026-04-23-003 Unit 7: embedding-contribution flip flag,
+    # scaling weight, decay rate, and vectorizer version — each of
+    # these changes every candidate's ``score`` when the gate is
+    # open, so each must invalidate the pinned tensor.
+    h.update(b"|embedding_enable:")
+    h.update(repr(cfg.enable_embedding_contribution).encode("utf-8"))
+    h.update(b"|embedding_w:")
+    h.update(repr(cfg.embedding_w).encode("utf-8"))
+    h.update(b"|embedding_k:")
+    h.update(repr(cfg.embedding_k).encode("utf-8"))
+    h.update(b"|vectorizer_version:")
+    h.update(repr(cfg.vectorizer_version).encode("utf-8"))
     return h.hexdigest()
 
 

--- a/src/mtg_synergy_graph/embeddings/__init__.py
+++ b/src/mtg_synergy_graph/embeddings/__init__.py
@@ -22,6 +22,11 @@ from mtg_synergy_graph.embeddings.config import (
     get_embedding_config_inputs,
     verify_current_or_raise,
 )
+from mtg_synergy_graph.embeddings.contribution import (
+    _ENABLE_EMBEDDING_CONTRIBUTION,
+    embedding_contribution,
+    load_card_embeddings_verified,
+)
 from mtg_synergy_graph.embeddings.store import (
     load_card_embeddings,
     read_vector,
@@ -37,6 +42,7 @@ from mtg_synergy_graph.embeddings.vectorizer import (
 
 __all__ = [
     "TOKEN_FORMAT_VERSION",
+    "_ENABLE_EMBEDDING_CONTRIBUTION",
     "EmbeddingConfigError",
     "EmbeddingConfigInputs",
     "EmbeddingConfigMissingError",
@@ -46,9 +52,11 @@ __all__ = [
     "clear_cache",
     "compute_embedding_hash",
     "compute_tfidf",
+    "embedding_contribution",
     "extract_card_tokens",
     "get_embedding_config_inputs",
     "load_card_embeddings",
+    "load_card_embeddings_verified",
     "read_vector",
     "truncated_svd",
     "verify_current_or_raise",

--- a/src/mtg_synergy_graph/embeddings/__init__.py
+++ b/src/mtg_synergy_graph/embeddings/__init__.py
@@ -23,7 +23,6 @@ from mtg_synergy_graph.embeddings.config import (
     verify_current_or_raise,
 )
 from mtg_synergy_graph.embeddings.contribution import (
-    _ENABLE_EMBEDDING_CONTRIBUTION,
     embedding_contribution,
     load_card_embeddings_verified,
 )
@@ -42,7 +41,6 @@ from mtg_synergy_graph.embeddings.vectorizer import (
 
 __all__ = [
     "TOKEN_FORMAT_VERSION",
-    "_ENABLE_EMBEDDING_CONTRIBUTION",
     "EmbeddingConfigError",
     "EmbeddingConfigInputs",
     "EmbeddingConfigMissingError",

--- a/src/mtg_synergy_graph/embeddings/__init__.py
+++ b/src/mtg_synergy_graph/embeddings/__init__.py
@@ -9,6 +9,10 @@ scoring term.
 
 from __future__ import annotations
 
+from mtg_synergy_graph.embeddings.commander_target import (
+    build_commander_target_vector,
+    clear_cache,
+)
 from mtg_synergy_graph.embeddings.config import (
     EmbeddingConfigError,
     EmbeddingConfigInputs,
@@ -38,6 +42,8 @@ __all__ = [
     "EmbeddingConfigMissingError",
     "EmbeddingConfigStaleError",
     "TfidfResult",
+    "build_commander_target_vector",
+    "clear_cache",
     "compute_embedding_hash",
     "compute_tfidf",
     "extract_card_tokens",

--- a/src/mtg_synergy_graph/embeddings/__init__.py
+++ b/src/mtg_synergy_graph/embeddings/__init__.py
@@ -1,0 +1,25 @@
+"""Content-embedding substrate (plan 2026-04-23-003).
+
+Hand-rolled TF-IDF + truncated-SVD over structured per-card features.
+Unit 1 ships the pure-function vectorizer; subsequent units add DB
+persistence, commander-target caching, inference-path reader, dedup
+diagnostic, and the flag-gated scoring term.
+"""
+
+from __future__ import annotations
+
+from mtg_synergy_graph.embeddings.svd import truncated_svd
+from mtg_synergy_graph.embeddings.vectorizer import (
+    TOKEN_FORMAT_VERSION,
+    TfidfResult,
+    compute_tfidf,
+    extract_card_tokens,
+)
+
+__all__ = [
+    "TOKEN_FORMAT_VERSION",
+    "TfidfResult",
+    "compute_tfidf",
+    "extract_card_tokens",
+    "truncated_svd",
+]

--- a/src/mtg_synergy_graph/embeddings/__init__.py
+++ b/src/mtg_synergy_graph/embeddings/__init__.py
@@ -1,13 +1,28 @@
 """Content-embedding substrate (plan 2026-04-23-003).
 
 Hand-rolled TF-IDF + truncated-SVD over structured per-card features.
-Unit 1 ships the pure-function vectorizer; subsequent units add DB
-persistence, commander-target caching, inference-path reader, dedup
-diagnostic, and the flag-gated scoring term.
+Unit 1 ships the pure-function vectorizer; Unit 2 adds the schema,
+config hash, and blob store; subsequent units add commander-target
+caching, inference-path reader, dedup diagnostic, and the flag-gated
+scoring term.
 """
 
 from __future__ import annotations
 
+from mtg_synergy_graph.embeddings.config import (
+    EmbeddingConfigError,
+    EmbeddingConfigInputs,
+    EmbeddingConfigMissingError,
+    EmbeddingConfigStaleError,
+    compute_embedding_hash,
+    get_embedding_config_inputs,
+    verify_current_or_raise,
+)
+from mtg_synergy_graph.embeddings.store import (
+    load_card_embeddings,
+    read_vector,
+    write_vectors,
+)
 from mtg_synergy_graph.embeddings.svd import truncated_svd
 from mtg_synergy_graph.embeddings.vectorizer import (
     TOKEN_FORMAT_VERSION,
@@ -18,8 +33,18 @@ from mtg_synergy_graph.embeddings.vectorizer import (
 
 __all__ = [
     "TOKEN_FORMAT_VERSION",
+    "EmbeddingConfigError",
+    "EmbeddingConfigInputs",
+    "EmbeddingConfigMissingError",
+    "EmbeddingConfigStaleError",
     "TfidfResult",
+    "compute_embedding_hash",
     "compute_tfidf",
     "extract_card_tokens",
+    "get_embedding_config_inputs",
+    "load_card_embeddings",
+    "read_vector",
     "truncated_svd",
+    "verify_current_or_raise",
+    "write_vectors",
 ]

--- a/src/mtg_synergy_graph/embeddings/commander_target.py
+++ b/src/mtg_synergy_graph/embeddings/commander_target.py
@@ -60,10 +60,10 @@ def _fetch_hi_syn_names_cached(
     """Cached wrapper over ``fetch_high_synergy_top_n_ordered``.
 
     Errors from the underlying query (missing table, schema drift,
-    corrupt row) degrade to an empty tuple plus a ``DEBUG`` log, so
-    callers always get a tuple they can zip with ``vectors``. The
-    warning about *why* hi-syn is empty is the caller's responsibility
-    — this helper only owns the fetch.
+    corrupt row, disk-corruption) degrade to an empty tuple plus a
+    ``DEBUG`` log, so callers always get a tuple they can zip with
+    ``vectors``. The warning about *why* hi-syn is empty is the
+    caller's responsibility — this helper only owns the fetch.
     """
     try:
         return fetch_high_synergy_top_n_ordered(
@@ -71,9 +71,11 @@ def _fetch_hi_syn_names_cached(
             commander_name,
             limit=hi_syn_limit,
         )
-    except sqlite3.OperationalError as exc:
+    except sqlite3.DatabaseError as exc:
+        # Parent of OperationalError; also covers DatabaseError (disk
+        # corruption) and its siblings — same degradation intent.
         logger.debug(
-            "hi-syn fetch failed for %r (likely missing table or schema drift): %s",
+            "hi-syn fetch failed for %r (likely missing table, schema drift, or corruption): %s",
             commander_name,
             exc,
         )

--- a/src/mtg_synergy_graph/embeddings/commander_target.py
+++ b/src/mtg_synergy_graph/embeddings/commander_target.py
@@ -1,0 +1,173 @@
+"""Commander target vector (plan 003 Unit 4).
+
+Builds the L2-normalized mean of a commander's own port-feature vector
+and — when an EDHREC connection is provided — the vectors of its top
+high-synergy cards. Partner pairs compose by averaging over both
+commanders' own vectors plus both commanders' hi-syn lists.
+
+The commander-target composition is the structural bridge between a
+commander and the long tail of cards whose ports the rule system
+doesn't yet match. The target is consumed at inference by the scoring
+term wired in plan 003 Unit 7 — a dot product against the (already
+L2-normalized) candidate vector yields cosine similarity.
+
+Caching
+-------
+
+The hi-syn DB fetch is memoized at a per-(connection, commander,
+limit) granularity via ``functools.cache`` on the helper
+``_fetch_hi_syn_names_cached``. The SQLite ``Connection`` is hashable
+by object identity in CPython, so each test's fresh in-memory
+connection begins with a cold cache and the production bench run
+reuses a single long-lived connection.
+
+The top-level ``build_commander_target_vector`` is *not* cached —
+composing a mean of unit vectors is microseconds, and attempting to
+cache over ``Mapping[str, np.ndarray]`` would require a heavy
+identity-or-hashable contract on callers that doesn't pay for itself.
+
+Tests can call ``clear_cache()`` to reset the memoization between
+scenarios without rebuilding connections.
+
+Plan: docs/plans/2026-04-23-003-feat-content-embeddings-fallback-plan.md Unit 4.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import sqlite3
+from collections.abc import Mapping
+
+import numpy as np
+
+from mtg_synergy_graph.edhrec_helpers import fetch_high_synergy_top_n_ordered
+
+logger = logging.getLogger(__name__)
+
+#: Smallest norm treated as nonzero when L2-normalizing. Below this
+#: threshold we return ``None`` rather than a near-random unit vector
+#: obtained by dividing by float-dust.
+_NORM_EPSILON: float = 1e-12
+
+
+@functools.cache
+def _fetch_hi_syn_names_cached(
+    edhrec_conn: sqlite3.Connection,
+    commander_name: str,
+    hi_syn_limit: int,
+) -> tuple[str, ...]:
+    """Cached wrapper over ``fetch_high_synergy_top_n_ordered``.
+
+    Errors from the underlying query (missing table, schema drift,
+    corrupt row) degrade to an empty tuple plus a ``DEBUG`` log, so
+    callers always get a tuple they can zip with ``vectors``. The
+    warning about *why* hi-syn is empty is the caller's responsibility
+    — this helper only owns the fetch.
+    """
+    try:
+        return fetch_high_synergy_top_n_ordered(
+            edhrec_conn,
+            commander_name,
+            limit=hi_syn_limit,
+        )
+    except sqlite3.OperationalError as exc:
+        logger.debug(
+            "hi-syn fetch failed for %r (likely missing table or schema drift): %s",
+            commander_name,
+            exc,
+        )
+        return ()
+
+
+def clear_cache() -> None:
+    """Reset the module-level memoization.
+
+    Intended for tests that reuse a single process across multiple
+    fixture states. Production code has no reason to call this —
+    vectors stay stable between rebuilds and the cache naturally
+    scales with the golden-set size (~100 entries per partner).
+    """
+    _fetch_hi_syn_names_cached.cache_clear()
+
+
+def _l2_normalize(vec: np.ndarray) -> np.ndarray | None:
+    """Return ``vec / ||vec||`` as ``float32``, or ``None`` if near-zero.
+
+    Callers that receive ``None`` propagate it as the "skip this
+    contribution" sentinel all the way back to the scorer so downstream
+    arithmetic never sees a NaN from divide-by-zero.
+    """
+    norm = float(np.linalg.norm(vec))
+    if norm < _NORM_EPSILON:
+        return None
+    return (vec / norm).astype(np.float32)
+
+
+def build_commander_target_vector(
+    commander_names: tuple[str, ...],
+    vectors: Mapping[str, np.ndarray],
+    edhrec_conn: sqlite3.Connection | None = None,
+    *,
+    hi_syn_limit: int = 10,
+) -> np.ndarray | None:
+    """Return the L2-normalized target vector for one or more commanders.
+
+    Composition, per plan R2:
+
+    * For each commander in ``commander_names``, include the
+      commander's own port-feature vector from ``vectors`` (when
+      present).
+    * When ``edhrec_conn`` is provided, also include the vectors of
+      the commander's top-``hi_syn_limit`` hi-syn cards that appear
+      in ``vectors``. Missing hi-syn names are silently skipped.
+    * The target is ``L2-normalize(mean(all collected vectors))``.
+
+    Returns ``None`` when no vectors can be collected (all commanders
+    missing from ``vectors`` AND no hi-syn cards match), or when the
+    resulting mean is numerically zero. This is the "caller should
+    skip the embedding contribution for this (commander, candidate)"
+    sentinel — the scorer short-circuits to ``0.0`` in that case.
+
+    ``hi_syn_limit <= 0`` raises ``ValueError``: a zero-limit call
+    would degenerate to "commander's own vector only," which is
+    already expressible by passing ``edhrec_conn=None``. The explicit
+    error prevents silent misuse.
+    """
+    if hi_syn_limit <= 0:
+        raise ValueError(f"hi_syn_limit must be >= 1; got {hi_syn_limit}")
+
+    if not commander_names:
+        return None
+
+    collected: list[np.ndarray] = []
+
+    for commander_name in commander_names:
+        own_vec = vectors.get(commander_name)
+        if own_vec is not None:
+            collected.append(np.asarray(own_vec, dtype=np.float32))
+
+        if edhrec_conn is None:
+            continue
+
+        hi_syn_names = _fetch_hi_syn_names_cached(
+            edhrec_conn,
+            commander_name,
+            hi_syn_limit,
+        )
+        for name in hi_syn_names:
+            hi_vec = vectors.get(name)
+            if hi_vec is not None:
+                collected.append(np.asarray(hi_vec, dtype=np.float32))
+
+    if not collected:
+        return None
+
+    mean = np.mean(np.stack(collected, axis=0), axis=0)
+    return _l2_normalize(mean)
+
+
+__all__ = [
+    "build_commander_target_vector",
+    "clear_cache",
+]

--- a/src/mtg_synergy_graph/embeddings/config.py
+++ b/src/mtg_synergy_graph/embeddings/config.py
@@ -1,0 +1,147 @@
+"""EmbeddingConfigInputs + compute_embedding_hash + refuse-to-run contract.
+
+Mirrors ``src/mtg_synergy_graph/forge_oracle/config.py`` for the
+embedding pipeline. The meta-principle is the same — mechanically
+enforce that consumers never compare a rebuilt ``card_embeddings``
+table against inputs computed under a different vectorizer/config.
+
+Consumers:
+
+- ``scripts/build_embeddings.py`` (Unit 3) — writes the hash into
+  ``card_embeddings_config`` at the end of every build.
+- ``embeddings.store.load_card_embeddings`` (Unit 5) — soft check;
+  stale hash degrades to ``{}`` + ``logging.warning`` (inference path
+  never raises per D6).
+- ``bench.py audit --embedding-dedup`` (Unit 6) — strict consumer;
+  exits 2 on stale hash per D7.
+
+See ``docs/solutions/best-practices/offline-oracle-hash-pattern-2026-04-23.md``
+for the hybrid-hash discipline: this KV table detects on-disk drift;
+``ScoringConfigInputs`` (Unit 7) detects scorer-side drift. Both fire
+in different failure modes — keep both.
+
+Plan: docs/plans/2026-04-23-003-feat-content-embeddings-fallback-plan.md Unit 2.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from typing import NamedTuple
+
+
+class EmbeddingConfigInputs(NamedTuple):
+    """All inputs whose change must invalidate a rebuilt ``card_embeddings``.
+
+    Adding a field requires a ``vectorizer_version`` bump in callers
+    (they will see mismatches against previously-built tables until
+    rebuild). Order of fields is irrelevant — ``compute_embedding_hash``
+    sorts the ``_asdict()`` items before hashing.
+    """
+
+    #: Token grammar version (``embeddings.vectorizer.TOKEN_FORMAT_VERSION``).
+    #: Bumped when emitted token shapes change (new column, renamed
+    #: column, attr-kind vocabulary restructured).
+    token_format_version: str
+
+    #: Target dimensionality of the per-card vector after truncated SVD.
+    #: Fixed at 128 by plan D1.
+    svd_dims: int
+
+    #: Minimum document frequency for TF-IDF pruning. Tokens on fewer
+    #: than ``min_df`` cards are dropped from the vocabulary entirely.
+    min_df: int
+
+    #: Integer version stamped into ``card_embeddings.vectorizer_version``
+    #: for each row. Bumped alongside ``token_format_version`` or any
+    #: algorithmic change to the SVD / normalization pipeline.
+    vectorizer_version: int
+
+    #: Version of the port-signature vocabulary
+    #: (``port_graph.vocabulary.VOCAB_VERSION``). Bumped when the
+    #: canonical ``node_kind`` / ``subkind`` mapping changes — since
+    #: downstream rules read ``port_nodes``, a drift there can alter
+    #: the structural features the vectorizer observes.
+    port_signature_version: str
+
+
+class EmbeddingConfigError(RuntimeError):
+    """Base class for ``card_embeddings_config`` contract failures.
+
+    Catching this subsumes both the "missing hash row" and "stale hash"
+    cases. Inference-path callers (per plan D6) catch this and degrade
+    to ``{}``; strict offline consumers re-raise.
+    """
+
+
+class EmbeddingConfigMissingError(EmbeddingConfigError):
+    """Raised when ``card_embeddings_config`` has no ``config_hash`` row."""
+
+
+class EmbeddingConfigStaleError(EmbeddingConfigError):
+    """Raised when the DB's stored hash does not match the current config."""
+
+
+def compute_embedding_hash(inputs: EmbeddingConfigInputs) -> str:
+    """SHA-256 over the sorted repr of ``inputs``. Hex digest (64 chars).
+
+    Deterministic across Python releases: ``repr`` of a NamedTuple with
+    primitive fields is stable, and we sort the asdict items so field
+    order in the class definition cannot leak into the hash.
+    """
+    serialized = repr(sorted(inputs._asdict().items()))
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def get_embedding_config_inputs() -> EmbeddingConfigInputs:
+    """Build an ``EmbeddingConfigInputs`` from the current ambient config.
+
+    ``token_format_version`` comes from
+    ``embeddings.vectorizer.TOKEN_FORMAT_VERSION`` (single source of
+    truth for the emitted grammar). ``svd_dims`` / ``min_df`` /
+    ``vectorizer_version`` / ``port_signature_version`` are fixed at
+    the current defaults chosen in plan D1 and Unit 1.
+
+    Callers that want to compute a hypothetical hash (for dry-run
+    "would this require rebuild?" tests) can construct an
+    ``EmbeddingConfigInputs`` directly.
+    """
+    # Local import to avoid circular-import risk: vectorizer imports
+    # numpy + sqlite3 and may grow more consumers over time.
+    from mtg_synergy_graph.embeddings import vectorizer as emb_vectorizer
+
+    return EmbeddingConfigInputs(
+        token_format_version=emb_vectorizer.TOKEN_FORMAT_VERSION,
+        svd_dims=128,
+        min_df=2,
+        vectorizer_version=1,
+        port_signature_version="v1",
+    )
+
+
+def verify_current_or_raise(
+    conn: sqlite3.Connection,
+    inputs: EmbeddingConfigInputs,
+) -> None:
+    """Assert the DB's stored hash matches the current config.
+
+    Raises ``EmbeddingConfigMissingError`` if no ``config_hash`` row is
+    present (DB was built before Unit 2 landed, or the
+    ``card_embeddings_config`` table is empty). Raises
+    ``EmbeddingConfigStaleError`` if the hash differs — message
+    includes both hashes (truncated) plus the rebuild command.
+    """
+    row = conn.execute("SELECT value FROM card_embeddings_config WHERE key = 'config_hash'").fetchone()
+    if row is None:
+        raise EmbeddingConfigMissingError(
+            "card_embeddings_config has no config_hash row. "
+            "Rebuild with `uv run scripts/build_embeddings.py` to populate it."
+        )
+    stored = row[0]
+    current = compute_embedding_hash(inputs)
+    if stored != current:
+        raise EmbeddingConfigStaleError(
+            f"card_embeddings was built under a different config "
+            f"(stored hash {stored[:12]}..., current {current[:12]}...). "
+            f"Rebuild with `uv run scripts/build_embeddings.py` to refresh."
+        )

--- a/src/mtg_synergy_graph/embeddings/config.py
+++ b/src/mtg_synergy_graph/embeddings/config.py
@@ -29,6 +29,17 @@ import hashlib
 import sqlite3
 from typing import NamedTuple
 
+#: Default target dimensionality after truncated SVD. Single source of
+#: truth for both ``get_embedding_config_inputs()`` and the
+#: ``scripts/build_embeddings.py`` argparse ``default=``. Leading
+#: underscore indicates module-internal, but the build script imports
+#: it directly so the two defaults cannot drift.
+_DEFAULT_SVD_DIMS: int = 128
+
+#: Default minimum document frequency for TF-IDF pruning. Same
+#: single-source-of-truth rationale as ``_DEFAULT_SVD_DIMS``.
+_DEFAULT_MIN_DF: int = 2
+
 
 class EmbeddingConfigInputs(NamedTuple):
     """All inputs whose change must invalidate a rebuilt ``card_embeddings``.
@@ -112,8 +123,8 @@ def get_embedding_config_inputs() -> EmbeddingConfigInputs:
 
     return EmbeddingConfigInputs(
         token_format_version=emb_vectorizer.TOKEN_FORMAT_VERSION,
-        svd_dims=128,
-        min_df=2,
+        svd_dims=_DEFAULT_SVD_DIMS,
+        min_df=_DEFAULT_MIN_DF,
         vectorizer_version=1,
         port_signature_version="v1",
     )

--- a/src/mtg_synergy_graph/embeddings/contribution.py
+++ b/src/mtg_synergy_graph/embeddings/contribution.py
@@ -1,0 +1,184 @@
+"""Inference-path reader + ``embedding_contribution`` term (plan 003 Unit 5).
+
+This module is the "reader contract" half of plan 003. It is *not*
+yet called by the scorer — Unit 7 wires
+:func:`embedding_contribution` into ``score_all_universal`` and
+:func:`load_card_embeddings_verified` into the scoring init path.
+Until then, the module is shippable in isolation and every scoring
+invariant holds because of the flag-off default.
+
+Flipping procedure
+------------------
+
+The three module-level constants below are intentionally edit-in-place
+Python (no env var / config file). Mirrors
+``src/mtg_synergy_graph/complement_rules/pathway.py:_ENABLE_PATHWAY_RULES``:
+
+1. Edit ``_ENABLE_EMBEDDING_CONTRIBUTION`` to ``True`` (and pick a
+   non-zero ``_EMBEDDING_W``) in the working tree.
+2. Run ``uv run scripts/bench.py audit --repin --yes`` to pin a new
+   fixture under the new config hash.
+3. Run ``uv run scripts/bench.py audit`` and record the aggregate NDCG
+   delta + ``hidden_gem_hit_rate`` delta (see
+   ``memory/feedback_hidden_gem_metric.md`` for the non-negotiable gate).
+4. Commit flip + pinned fixture together (mirrors the ``pathway``
+   plan 001 Unit 6 flip commit pattern).
+
+Test-time override
+------------------
+
+Tests toggle via ``monkeypatch.setattr(contribution,
+"_ENABLE_EMBEDDING_CONTRIBUTION", True)`` or
+``unittest.mock.patch.object(contribution, "_EMBEDDING_W", 0.5)``.
+The module default stays safe; tests never mutate the global process
+state.
+
+Graceful-fallback contract
+--------------------------
+
+:func:`embedding_contribution` returns ``0.0`` on every missing-input
+short-circuit (flag off, ``v_cmdr`` None, candidate absent from
+``vectors``). :func:`load_card_embeddings_verified` returns ``{}`` on
+every config-hash failure mode. Neither function raises from the
+inference path — see plan D6 and
+``src/mtg_synergy_graph/forge_oracle/gap_weight.py:load_forge_signals``
+for the shared taxonomy.
+
+Plan: docs/plans/2026-04-23-003-feat-content-embeddings-fallback-plan.md Unit 5.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import sqlite3
+from collections.abc import Mapping
+
+import numpy as np
+
+from mtg_synergy_graph.embeddings import config as emb_config
+from mtg_synergy_graph.embeddings import store as emb_store
+
+logger = logging.getLogger(__name__)
+
+#: Master flag for the embedding contribution term. Default ``False``
+#: — the reader is shippable in isolation; the scorer wire-up in
+#: Unit 7 and the audit-gated flip to ``True`` are separate commits.
+#: Tests toggle via ``monkeypatch.setattr``; production edit-in-place.
+_ENABLE_EMBEDDING_CONTRIBUTION: bool = False
+
+#: Scaling constant ``w_emb`` for the ``w * decay * cosine`` term.
+#: Initial ``0.0`` means even a ``True`` flag produces bitwise-identity
+#: output — the flip and the weight tune are independently audited.
+_EMBEDDING_W: float = 0.0
+
+#: Exponential decay rate ``k`` applied to ``N_rules`` (the count of
+#: rules already firing on the ``(commander, candidate)`` pair).
+#: Larger ``k`` = embeddings fade faster as rule coverage grows.
+#: ``0.8`` is the plan-prescribed starting point.
+_EMBEDDING_K: float = 0.8
+
+
+def embedding_contribution(
+    *,
+    candidate_name: str,
+    n_rules: int,
+    v_cmdr: np.ndarray | None,
+    vectors: Mapping[str, np.ndarray],
+) -> float:
+    """Return the additive embedding term for one ``(commander, candidate)`` pair.
+
+    Formula:
+        ``_EMBEDDING_W * exp(-_EMBEDDING_K * n_rules) * cosine(v_cand, v_cmdr)``
+
+    Cosine is computed as a raw dot product — both inputs are expected
+    to be L2-normalized by construction (the vectorizer in Unit 1 and
+    the commander-target builder in Unit 4 both emit unit vectors).
+
+    Short-circuits (all return ``0.0``):
+
+    * ``not _ENABLE_EMBEDDING_CONTRIBUTION`` — default gate.
+    * ``v_cmdr is None`` — commander has no port vector and no
+      golden-set hi-syn matches.
+    * ``candidate_name`` not in ``vectors`` — card was pruned by
+      min_df, or its DB row was absent at build time.
+
+    Keyword-only args prevent positional misuse when Unit 7 wires this
+    into ``score_all_universal``'s results loop. No side effects; no
+    mutation of ``v_cmdr`` or ``vectors``. No logging — this is the
+    hot-path function called once per candidate; Unit 7 logs once per
+    scoring run.
+    """
+    if not _ENABLE_EMBEDDING_CONTRIBUTION:
+        return 0.0
+
+    if v_cmdr is None:
+        return 0.0
+
+    v_cand = vectors.get(candidate_name)
+    if v_cand is None:
+        return 0.0
+
+    # Both inputs are L2-normalized; dot product == cosine. Cast to
+    # Python float at the boundary — the scorer sums the result with
+    # other floats, so keeping numpy scalars would leak dtype
+    # sensitivity into downstream arithmetic.
+    cosine = float(v_cand @ v_cmdr)
+    decay = math.exp(-_EMBEDDING_K * n_rules)
+    return _EMBEDDING_W * decay * cosine
+
+
+def load_card_embeddings_verified(conn: sqlite3.Connection) -> dict[str, np.ndarray]:
+    """Load ``card_embeddings`` only when the config hash matches.
+
+    This is the inference-path-specific consumer described in plan D6.
+    The offline handlers
+    (``bench.py audit --embedding-dedup`` in Unit 6 and
+    ``scripts/build_embeddings.py`` in Unit 3) perform their own
+    stricter checks that re-raise on stale hash; this wrapper degrades
+    to an empty dict so the scorer never crashes on a pre-rebuild
+    cardsfolder refresh.
+
+    Flow:
+
+    1. Delegate to ``store.load_card_embeddings`` — returns ``{}``
+       (with its own warning) on missing table, DB error, or empty
+       table.
+    2. If empty, pass it through — no point verifying a hash against
+       no vectors, and the store has already warned.
+    3. Call ``verify_current_or_raise``: on
+       ``EmbeddingConfigMissingError`` or
+       ``EmbeddingConfigStaleError``, log a warning with the
+       exception's message (which includes the rebuild hint) and
+       return ``{}``. Any other unexpected exception is caught and
+       logged at warning level — the scorer's graceful fallback is
+       the whole contract.
+    4. On success, return the loaded vectors dict.
+    """
+    # ``store.load_card_embeddings`` owns the "missing table / DB
+    # error / empty table / malformed row" taxonomy and returns ``{}``
+    # on every failure, never raises. We trust that contract here and
+    # wrap only the config-hash verify, which *does* raise by design.
+    vectors = emb_store.load_card_embeddings(conn)
+    if not vectors:
+        # Store has already logged about missing/empty/corrupt table;
+        # skip the hash check to avoid a misleading "stale" message
+        # on top of the real "table missing" one.
+        return {}
+
+    try:
+        emb_config.verify_current_or_raise(conn, emb_config.get_embedding_config_inputs())
+    except emb_config.EmbeddingConfigError as exc:
+        logger.warning("card_embeddings config verification failed: %s", exc)
+        return {}
+    except sqlite3.DatabaseError as exc:
+        logger.warning("card_embeddings config read failed: %s", exc)
+        return {}
+
+    return vectors
+
+
+__all__ = [
+    "embedding_contribution",
+    "load_card_embeddings_verified",
+]

--- a/src/mtg_synergy_graph/embeddings/contribution.py
+++ b/src/mtg_synergy_graph/embeddings/contribution.py
@@ -174,6 +174,13 @@ def load_card_embeddings_verified(conn: sqlite3.Connection) -> dict[str, np.ndar
     except sqlite3.DatabaseError as exc:
         logger.warning("card_embeddings config read failed: %s", exc)
         return {}
+    except Exception as exc:
+        # Catch-all safety net: ``get_embedding_config_inputs`` has
+        # transitive imports that could raise ImportError/AttributeError
+        # on partial environments. The module docstring guarantees
+        # "never raises from the inference path" — honor that.
+        logger.warning("unexpected error verifying embedding config: %s", exc)
+        return {}
 
     return vectors
 

--- a/src/mtg_synergy_graph/embeddings/dedup.py
+++ b/src/mtg_synergy_graph/embeddings/dedup.py
@@ -1,0 +1,159 @@
+"""Rule-pair embedding-dedup diagnostic (plan 2026-04-23-003 Unit 6).
+
+Pure numpy / pure-Python logic that consumes:
+
+1. Tensor rows ``(commander, candidate, rule_id, contribution)`` already
+   filtered to ``contribution > 0`` by the caller — one row per rule
+   firing on a ``(commander, candidate)`` pair.
+2. A ``vectors`` mapping ``card_name -> L2-normalized float32 vector``
+   already loaded via ``embeddings.store.load_card_embeddings``.
+
+and returns a sorted list of ``DedupPair`` rows for every pair of rules
+whose mean activation-set embedding vectors have cosine similarity
+above the threshold.
+
+The algorithm is the numpy-matrix template from
+``src/mtg_synergy_graph/bench/collinearity.py`` — build the activation
+dict, filter by ``min_activation``, compute a per-rule mean vector, L2-
+normalize, take pairwise dot products. No SQL here; the handler is
+responsible for loading rows and vectors.
+
+Why separate from the handler: this function is unit-testable without
+a DB or argparse, matches the FR5 "read-only diagnostic" contract, and
+mirrors ``bench/collinearity.py`` vs ``bench/handlers.py:handle_collinearity``.
+
+Plan: docs/plans/2026-04-23-003-feat-content-embeddings-fallback-plan.md Unit 6.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from itertools import combinations
+
+import numpy as np
+
+#: Guard for the per-rule mean-vector L2 norm. If the activation cards'
+#: vectors happen to sum to (approximately) zero — possible when they
+#: land on opposite directions in the SVD subspace — we can't L2-
+#: normalize without blowing up. Below this threshold the rule is
+#: silently excluded from the comparison (not an error — rare numeric
+#: edge case).
+_MIN_NORM: float = 1e-12
+
+
+@dataclass(frozen=True)
+class DedupPair:
+    """One flagged rule pair.
+
+    Immutable record matching the ``CollinearPair`` style in
+    ``bench/collinearity.py``. ``cosine`` is the dot product of the
+    two rules' L2-normalized mean activation vectors; equals cosine
+    similarity by construction. ``activation_*_size`` records the
+    number of distinct candidates in each rule's activation set so
+    callers can tell a tiny-set false positive from a broadly-firing
+    pair at a glance.
+    """
+
+    rule_a: str
+    rule_b: str
+    cosine: float
+    activation_a_size: int
+    activation_b_size: int
+
+
+def compute_embedding_dedup(
+    tensor_rows: Sequence[tuple[str, str, str, float]],
+    vectors: Mapping[str, np.ndarray],
+    *,
+    threshold: float = 0.95,
+    min_activation: int = 20,
+) -> list[DedupPair]:
+    """Flag rule pairs whose mean activation vectors exceed ``threshold``.
+
+    Parameters
+    ----------
+    tensor_rows:
+        Sequence of ``(commander, candidate, rule_id, contribution)``
+        tuples. Callers must have already filtered to
+        ``contribution > 0``; this function does not re-check. The
+        ``commander`` field is unused here (it's part of the tensor
+        primary key but the dedup signal is per-candidate only).
+    vectors:
+        ``{card_name: ndarray(128,)}`` mapping. Each vector is assumed
+        L2-normalized (the store guarantees this post-Unit 2). Cards
+        absent from this mapping are silently excluded from the
+        per-rule mean — matching the graceful-fallback posture of
+        ``embeddings.store.load_card_embeddings``.
+    threshold:
+        Cosine similarity cutoff. Pairs with ``cosine > threshold``
+        are flagged. Default 0.95 per plan FR5.
+    min_activation:
+        Rules whose activation set has fewer than this many distinct
+        candidates are dropped entirely — suppresses the "two tiny
+        sets happen to lie near each other" false-positive class
+        called out in the Risks table.
+
+    Returns
+    -------
+    list[DedupPair]
+        Sorted by cosine descending; lexicographic ``(rule_a, rule_b)``
+        as the stable tiebreaker. Each rule pair appears at most once
+        (``combinations``, not ``permutations``).
+    """
+    # Step 1: group tensor rows into per-rule activation sets of
+    # distinct candidate names. Ignore the commander + contribution
+    # fields — the dedup signal is purely "does rule X fire on
+    # candidate Y at all, across any commander?".
+    activation: dict[str, set[str]] = {}
+    for _commander, candidate, rule_id, _contribution in tensor_rows:
+        activation.setdefault(rule_id, set()).add(candidate)
+
+    # Step 2: drop rules whose activation set is below the floor. Keep
+    # the dict immutable-in-spirit by building a new one rather than
+    # mutating in place — matches the "no mutation" posture in the
+    # common coding-style rules.
+    filtered_activation = {rule_id: cands for rule_id, cands in activation.items() if len(cands) >= min_activation}
+
+    # Step 3: compute a per-rule L2-normalized mean vector. Any rule
+    # whose cards are all missing from ``vectors`` (or sum to a near-
+    # zero vector) is silently excluded — consumer docs call this out
+    # as a graceful-fallback behavior rather than an error.
+    mean_vecs: dict[str, np.ndarray] = {}
+    sizes: dict[str, int] = {}
+    for rule_id, cands in filtered_activation.items():
+        found = [vectors[c] for c in cands if c in vectors]
+        if not found:
+            continue
+        stacked = np.stack(found, axis=0)
+        mean_vec = stacked.sum(axis=0) / len(found)
+        norm = float(np.linalg.norm(mean_vec))
+        if norm < _MIN_NORM:
+            continue
+        mean_vecs[rule_id] = (mean_vec / norm).astype(np.float32, copy=False)
+        sizes[rule_id] = len(cands)
+
+    # Step 4: pairwise cosine similarity over ``combinations`` so
+    # ``(a, b)`` and ``(b, a)`` are treated as the same pair. Sort the
+    # rule ids first so the output order is reproducible and stable
+    # under caller insertion order.
+    sorted_rule_ids = sorted(mean_vecs)
+    pairs: list[DedupPair] = []
+    for rule_a, rule_b in combinations(sorted_rule_ids, 2):
+        cos = float(np.dot(mean_vecs[rule_a], mean_vecs[rule_b]))
+        if cos > threshold:
+            pairs.append(
+                DedupPair(
+                    rule_a=rule_a,
+                    rule_b=rule_b,
+                    cosine=cos,
+                    activation_a_size=sizes[rule_a],
+                    activation_b_size=sizes[rule_b],
+                )
+            )
+
+    # Step 5: sort by -cosine with lexicographic tiebreaker. The
+    # tiebreaker ensures identical cosines (rare but possible in
+    # synthetic tests) render in a deterministic order.
+    pairs.sort(key=lambda p: (-p.cosine, p.rule_a, p.rule_b))
+    return pairs

--- a/src/mtg_synergy_graph/embeddings/store.py
+++ b/src/mtg_synergy_graph/embeddings/store.py
@@ -71,7 +71,8 @@ def write_vectors(
         rows = [
             (
                 name,
-                np.asarray(vector, dtype=np.float32).tobytes(),
+                # '<f4' = little-endian float32 for cross-arch portability (plan 003 DM-001)
+                np.asarray(vector, dtype="<f4").tobytes(),
                 int(inputs.vectorizer_version),
                 now_iso,
             )
@@ -113,7 +114,8 @@ def read_vector(conn: sqlite3.Connection, name: str) -> np.ndarray | None:
     if row is None:
         return None
     blob = row[0]
-    return np.frombuffer(blob, dtype=np.float32).copy()
+    # '<f4' = little-endian float32 for cross-arch portability (plan 003 DM-001)
+    return np.frombuffer(blob, dtype="<f4").copy()
 
 
 def load_card_embeddings(conn: sqlite3.Connection) -> dict[str, np.ndarray]:
@@ -147,7 +149,12 @@ def load_card_embeddings(conn: sqlite3.Connection) -> dict[str, np.ndarray]:
 
     out: dict[str, np.ndarray] = {}
     for name, blob in rows:
-        vector = np.frombuffer(blob, dtype=np.float32).copy()
+        try:
+            # '<f4' = little-endian float32 for cross-arch portability (plan 003 DM-001)
+            vector = np.frombuffer(blob, dtype="<f4").copy()
+        except (ValueError, TypeError) as exc:
+            logger.warning("skipping %s: blob decode failed: %s", name, exc)
+            continue
         if len(vector) != _EMBEDDING_DIM:
             logger.warning(
                 "skipping %s: vector length %d != expected %d",

--- a/src/mtg_synergy_graph/embeddings/store.py
+++ b/src/mtg_synergy_graph/embeddings/store.py
@@ -1,0 +1,163 @@
+"""Blob round-trip helpers for ``card_embeddings`` (plan 003 Unit 2).
+
+Writes a full vector corpus into SQLite under a single transaction
+(replace-all semantics: a rebuild is always wholesale; incremental
+updates would leave ``vectorizer_version`` drift hazards on old rows).
+
+Reads follow the graceful-fallback contract from
+``src/mtg_synergy_graph/forge_oracle/gap_weight.py:load_forge_signals``:
+
+* Missing table / ``sqlite3.DatabaseError`` / empty table / all-zero
+  blobs / wrong-length blobs → excluded from the result (with
+  ``logging.warning``).
+* Never raises from the inference path.
+
+The config-hash check is delegated to
+``embeddings.config.verify_current_or_raise``. The store helpers
+themselves do not verify — that's the caller's responsibility so
+offline strict consumers (Unit 6) can re-raise while the inference
+reader (Unit 5) can degrade.
+
+Plan: docs/plans/2026-04-23-003-feat-content-embeddings-fallback-plan.md Unit 2.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import UTC, datetime
+
+import numpy as np
+
+from mtg_synergy_graph.embeddings.config import (
+    EmbeddingConfigInputs,
+    compute_embedding_hash,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Fixed dimensionality of every persisted vector. Matches
+#: ``EmbeddingConfigInputs.svd_dims``. A rebuild that changes this must
+#: also bump ``vectorizer_version`` so the hash invalidates.
+_EMBEDDING_DIM: int = 128
+
+
+def write_vectors(
+    conn: sqlite3.Connection,
+    vectors: dict[str, np.ndarray],
+    inputs: EmbeddingConfigInputs,
+) -> None:
+    """Replace-all write of ``vectors`` + config KV rows in one transaction.
+
+    Steps (inside ``with conn:`` so the whole write is atomic):
+
+    1. ``DELETE FROM card_embeddings`` — wholesale rebuild. No incremental
+       path; a partial rebuild would leave ``vectorizer_version`` drift on
+       old rows.
+    2. Insert one ``card_embeddings`` row per ``(name, vector)``. Vectors
+       are cast to ``float32`` before ``.tobytes()`` so storage is
+       deterministic regardless of the caller's dtype.
+    3. ``DELETE FROM card_embeddings_config`` + insert ``config_hash``
+       plus one diagnostic row per ``EmbeddingConfigInputs`` field.
+
+    Raises on any failure; the ``with conn:`` block rolls back so the
+    DB is left untouched.
+    """
+    now_iso = datetime.now(UTC).isoformat()
+    hash_value = compute_embedding_hash(inputs)
+
+    with conn:
+        conn.execute("DELETE FROM card_embeddings")
+        rows = [
+            (
+                name,
+                np.asarray(vector, dtype=np.float32).tobytes(),
+                int(inputs.vectorizer_version),
+                now_iso,
+            )
+            for name, vector in vectors.items()
+        ]
+        conn.executemany(
+            "INSERT INTO card_embeddings (card_name, vector, vectorizer_version, built_at) VALUES (?, ?, ?, ?)",
+            rows,
+        )
+
+        conn.execute("DELETE FROM card_embeddings_config")
+        kv_rows: list[tuple[str, str]] = [
+            ("config_hash", hash_value),
+            ("token_format_version", inputs.token_format_version),
+            ("svd_dims", str(inputs.svd_dims)),
+            ("min_df", str(inputs.min_df)),
+            ("vectorizer_version", str(inputs.vectorizer_version)),
+            ("port_signature_version", inputs.port_signature_version),
+            ("built_at", now_iso),
+        ]
+        conn.executemany(
+            "INSERT INTO card_embeddings_config(key, value) VALUES (?, ?)",
+            kv_rows,
+        )
+
+
+def read_vector(conn: sqlite3.Connection, name: str) -> np.ndarray | None:
+    """Return the ``float32`` vector for ``name``, or ``None`` if absent.
+
+    Does not validate length or zero-ness — callers that need those
+    guarantees should use ``load_card_embeddings``. This helper is a
+    thin single-row lookup primarily for tests and the ``--explain``
+    nearest-neighbor renderer (Unit 7).
+    """
+    row = conn.execute(
+        "SELECT vector FROM card_embeddings WHERE card_name = ?",
+        (name,),
+    ).fetchone()
+    if row is None:
+        return None
+    blob = row[0]
+    return np.frombuffer(blob, dtype=np.float32).copy()
+
+
+def load_card_embeddings(conn: sqlite3.Connection) -> dict[str, np.ndarray]:
+    """Return ``{card_name: ndarray(128,)}``; never raises.
+
+    Graceful-fallback contract (mirrors
+    ``forge_oracle/gap_weight.py:load_forge_signals``):
+
+    * Missing table (``sqlite3.OperationalError``) → ``{}`` + warning.
+    * ``sqlite3.DatabaseError`` on read → ``{}`` + warning.
+    * Empty table → ``{}`` + warning.
+    * Per-row: all-zero blob → skipped + warning.
+    * Per-row: wrong-length blob (not 128 × 4 bytes) → skipped + warning.
+
+    Vectors are returned as **writable** ``float32`` arrays
+    (``np.frombuffer(...).copy()``) so callers that want to add noise or
+    rescale in-place don't trip the read-only-buffer restriction.
+    """
+    try:
+        rows = conn.execute("SELECT card_name, vector FROM card_embeddings").fetchall()
+    except sqlite3.OperationalError as exc:
+        logger.warning("card_embeddings table missing; returning empty dict: %s", exc)
+        return {}
+    except sqlite3.DatabaseError as exc:
+        logger.warning("card_embeddings read failed: %s", exc)
+        return {}
+
+    if not rows:
+        logger.warning("card_embeddings table is empty; returning empty dict")
+        return {}
+
+    out: dict[str, np.ndarray] = {}
+    for name, blob in rows:
+        vector = np.frombuffer(blob, dtype=np.float32).copy()
+        if len(vector) != _EMBEDDING_DIM:
+            logger.warning(
+                "skipping %s: vector length %d != expected %d",
+                name,
+                len(vector),
+                _EMBEDDING_DIM,
+            )
+            continue
+        if not vector.any():
+            logger.warning("skipping %s: all-zero vector", name)
+            continue
+        out[name] = vector
+    return out

--- a/src/mtg_synergy_graph/embeddings/svd.py
+++ b/src/mtg_synergy_graph/embeddings/svd.py
@@ -1,0 +1,85 @@
+"""Truncated SVD + row-wise L2 normalization (Unit 1).
+
+Given a dense TF-IDF matrix, produce a fixed-dimension per-row
+embedding by taking the top-``k`` left singular vectors scaled by the
+corresponding singular values, then L2-normalizing each row. The
+normalization means later cosine-similarity lookups reduce to a dot
+product (see the Unit 5 inference-path reader).
+
+No sklearn / scipy dependency — ``numpy.linalg.svd(full_matrices=False)``
+is sufficient at the 32k × ~5k scale this codebase targets. If profiling
+later shows this path is the bottleneck, an optional ``scipy.sparse``
+path can be added behind a dependency extra; today's default is pure
+numpy.
+
+Plan: ``docs/plans/2026-04-23-003-feat-content-embeddings-fallback-plan.md``
+Unit 1.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+#: Guard against division-by-zero during L2 normalization. A row with
+#: zero norm (e.g., a card with zero tokens) stays all-zeros after the
+#: divide instead of becoming ``inf`` / ``NaN``. Picked to be well below
+#: float32 precision so it never subtly rescales a legitimate row.
+_ZERO_NORM_EPSILON: float = 1e-12
+
+
+def truncated_svd(tfidf: np.ndarray, k: int = 128) -> np.ndarray:
+    """Project ``tfidf`` to ``k`` dimensions via SVD and L2-normalize rows.
+
+    Returns an ``(n_rows, k)`` ``float64`` array where each row has unit
+    L2 norm (or is all-zeros if the input row had no tokens).
+
+    Behavior notes:
+
+    * ``k`` is clamped to ``min(k, n_rows, n_cols)``; a small corpus
+      where ``min(n_rows, n_cols) < k`` still produces a valid (but
+      lower-rank) embedding rather than raising.
+    * Zero-norm rows survive the normalization as all-zeros; callers
+      that skip them should check ``np.linalg.norm(row)`` themselves.
+    * Deterministic: ``numpy.linalg.svd`` is a deterministic LAPACK
+      call, so the same input bytes produce the same output bytes
+      within a numpy build.
+    """
+    if tfidf.ndim != 2:
+        raise ValueError(f"tfidf must be 2-D; got shape {tfidf.shape}")
+    n_rows, n_cols = tfidf.shape
+    if n_rows == 0 or n_cols == 0:
+        # Degenerate corpus — return an (n_rows, k) zero matrix so
+        # downstream callers get a consistent shape.
+        return np.zeros((n_rows, max(k, 0)), dtype=np.float64)
+
+    effective_k = min(k, n_rows, n_cols)
+    if effective_k < 1:
+        return np.zeros((n_rows, max(k, 0)), dtype=np.float64)
+
+    # full_matrices=False gives the thin SVD: U is (n_rows, r),
+    # s is (r,), Vt is (r, n_cols) where r = min(n_rows, n_cols).
+    u, s, _vt = np.linalg.svd(tfidf, full_matrices=False)
+
+    # Take the top-k left singular vectors scaled by the singular
+    # values. The result is an (n_rows, k) matrix whose rows are the
+    # card embeddings prior to normalization.
+    embedding = u[:, :effective_k] * s[:effective_k]
+
+    # If effective_k < k, pad with zero columns so downstream code
+    # always sees the requested dimension (fixed-size vectors simplify
+    # the storage schema).
+    if effective_k < k:
+        pad = np.zeros((n_rows, k - effective_k), dtype=embedding.dtype)
+        embedding = np.concatenate([embedding, pad], axis=1)
+
+    # Row-wise L2 normalization. ``max(norm, eps)`` keeps zero-norm
+    # rows at zero instead of producing NaN.
+    norms = np.linalg.norm(embedding, axis=1, keepdims=True)
+    safe_norms = np.maximum(norms, _ZERO_NORM_EPSILON)
+    normalized = embedding / safe_norms
+    # Force the eps-divided zero rows back to true zero — otherwise
+    # they'd carry tiny residuals from floating-point arithmetic.
+    zero_mask = (norms <= _ZERO_NORM_EPSILON).ravel()
+    if zero_mask.any():
+        normalized[zero_mask] = 0.0
+    return normalized

--- a/src/mtg_synergy_graph/embeddings/vectorizer.py
+++ b/src/mtg_synergy_graph/embeddings/vectorizer.py
@@ -46,10 +46,10 @@ TOKEN_FORMAT_VERSION: str = "v1"  # noqa: S105 — not a secret; version tag
 
 
 #: Columns from ``card_ports`` that are emitted as ``<column>:<value>``
-#: tokens when non-null. ``port_type`` is always non-null (``NOT NULL``)
-#: so is handled separately; the rest are optional.
+#: tokens when non-null. ``port_type`` and ``event_class`` are both
+#: ``NOT NULL`` per ``schema.sql`` §4.2 and are handled separately
+#: (guaranteed emitted); the columns below are nullable.
 _OPTIONAL_PORT_TOKEN_COLUMNS: tuple[str, ...] = (
-    "event_class",
     "zone_origin",
     "zone_destination",
     "counter_type",
@@ -116,8 +116,11 @@ def extract_card_tokens(conn: sqlite3.Connection) -> dict[str, tuple[str, ...]]:
         bag = tokens[card_name]
         port_type = row[2]
         bag.append(f"port_type:{port_type}")
-        # ``event_class`` is NOT NULL per schema, but guard anyway.
-        values = (row[3], row[4], row[5], row[6], row[7])
+        # ``event_class`` is NOT NULL per schema.sql §4.2 — always emit.
+        event_class = row[3]
+        bag.append(f"event_class:{event_class}")
+        # Remaining columns are nullable; skip when NULL / empty.
+        values = (row[4], row[5], row[6], row[7])
         for col, val in zip(_OPTIONAL_PORT_TOKEN_COLUMNS, values, strict=True):
             if val is not None and val != "":
                 bag.append(f"{col}:{val}")

--- a/src/mtg_synergy_graph/embeddings/vectorizer.py
+++ b/src/mtg_synergy_graph/embeddings/vectorizer.py
@@ -1,0 +1,228 @@
+"""Hand-rolled TF-IDF feature-bag builder for content embeddings (Unit 1).
+
+Pure-function pipeline from a SQLite connection to a ``{card_name:
+feature_tokens}`` corpus, and from that corpus to a TF-IDF matrix.
+No sklearn, no scipy — numpy + stdlib only.
+
+Feature-token grammar (version ``TOKEN_FORMAT_VERSION``):
+
+* ``port_type:<v>`` — every row in ``card_ports`` contributes one.
+* ``event_class:<v>`` — every row (column is ``NOT NULL``).
+* ``zone_origin:<v>``, ``zone_destination:<v>``, ``counter_type:<v>``,
+  ``branch_kind:<v>`` — emitted only when the column is non-null.
+* ``attr:<attr_kind>:<attr_value>`` — one per ``port_attributes`` row
+  (pre-exploded by ``attributes.explode_filter`` at importer time, so
+  the vectorizer does NOT re-parse ``valid_filter``).
+* ``keyword:<kw>`` — one per element of the JSON-decoded
+  ``cards.keywords`` array.
+
+Duplicate tokens on the same card are retained (raw term counts feed
+TF-IDF). The corpus returns a ``tuple`` for each card because the
+downstream caller may iterate multiple times; tuples hash quickly if
+callers memoize.
+
+Plan: ``docs/plans/2026-04-23-003-feat-content-embeddings-fallback-plan.md``
+Unit 1.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import sqlite3
+from typing import NamedTuple
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+#: Token-format version. Bump this when the emitted token grammar
+#: changes (new field added, old field renamed, attr-kind vocabulary
+#: restructured). Flows into ``EmbeddingConfigInputs`` so a change
+#: invalidates both the pinned audit tensor and the on-disk
+#: ``card_embeddings`` table.
+TOKEN_FORMAT_VERSION: str = "v1"  # noqa: S105 — not a secret; version tag
+
+
+#: Columns from ``card_ports`` that are emitted as ``<column>:<value>``
+#: tokens when non-null. ``port_type`` is always non-null (``NOT NULL``)
+#: so is handled separately; the rest are optional.
+_OPTIONAL_PORT_TOKEN_COLUMNS: tuple[str, ...] = (
+    "event_class",
+    "zone_origin",
+    "zone_destination",
+    "counter_type",
+    "branch_kind",
+)
+
+
+class TfidfResult(NamedTuple):
+    """TF-IDF output — matrix, ordered card names, and vocabulary.
+
+    Fields:
+
+    * ``tfidf_matrix`` — ``(n_cards, n_tokens)`` ``float64``. Row ``i``
+      is the TF-IDF vector for ``card_names[i]``; column ``j`` is the
+      term ``vocabulary[j]``.
+    * ``card_names`` — cards sorted by name (deterministic).
+    * ``vocabulary`` — surviving tokens (after ``min_df`` prune)
+      sorted ascending (deterministic).
+    """
+
+    tfidf_matrix: np.ndarray
+    card_names: list[str]
+    vocabulary: list[str]
+
+
+def extract_card_tokens(conn: sqlite3.Connection) -> dict[str, tuple[str, ...]]:
+    """Build the ``{card_name: feature_tokens}`` corpus from SQLite.
+
+    Reads:
+
+    * ``card_ports`` — port-row categorical fields (see module docstring
+      for the grammar).
+    * ``port_attributes`` — pre-exploded attribute rows keyed by port_id.
+    * ``cards.keywords`` — JSON array; each keyword becomes one token.
+
+    Cards with no ports and no keywords still appear in the output with
+    an empty tuple, so every row in ``cards`` gets a feature vector
+    (possibly zero) downstream.
+    """
+    tokens: dict[str, list[str]] = {}
+
+    # Seed every card with an empty bag so cards with zero ports/keywords
+    # still show up (zero-token cards are an explicit edge case the
+    # downstream SVD / L2-normalization handles).
+    for row in conn.execute("SELECT name FROM cards"):
+        tokens[row[0]] = []
+
+    # Port-row tokens. We read id + card_name so port_attributes can be
+    # joined downstream without another N+1.
+    port_id_to_card: dict[int, str] = {}
+    for row in conn.execute(
+        "SELECT id, card_name, port_type, event_class, "
+        "zone_origin, zone_destination, counter_type, branch_kind "
+        "FROM card_ports"
+    ):
+        port_id = int(row[0])
+        card_name = row[1]
+        port_id_to_card[port_id] = card_name
+        if card_name not in tokens:
+            # Orphan port (card_name not in cards) — skip silently; the
+            # importer guarantees a FK, but defensive handling keeps the
+            # vectorizer robust against partial test fixtures.
+            continue
+        bag = tokens[card_name]
+        port_type = row[2]
+        bag.append(f"port_type:{port_type}")
+        # ``event_class`` is NOT NULL per schema, but guard anyway.
+        values = (row[3], row[4], row[5], row[6], row[7])
+        for col, val in zip(_OPTIONAL_PORT_TOKEN_COLUMNS, values, strict=True):
+            if val is not None and val != "":
+                bag.append(f"{col}:{val}")
+
+    # port_attributes rows (pre-exploded). Empty fixtures may omit the
+    # table; be defensive.
+    try:
+        for row in conn.execute("SELECT port_id, attr_kind, attr_value FROM port_attributes"):
+            port_id = int(row[0])
+            card_name = port_id_to_card.get(port_id)
+            if card_name is None or card_name not in tokens:
+                continue
+            tokens[card_name].append(f"attr:{row[1]}:{row[2]}")
+    except sqlite3.OperationalError:
+        # No port_attributes table in this DB (e.g., minimal test
+        # fixture). Skip silently — the corpus is simply sparser.
+        logger.debug("port_attributes table missing; skipping attr tokens")
+
+    # Keyword tokens from cards.keywords JSON array.
+    for row in conn.execute("SELECT name, keywords FROM cards"):
+        card_name = row[0]
+        raw = row[1]
+        if raw is None or raw == "":
+            continue
+        try:
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            logger.debug("cards.keywords not JSON for %s; skipping", card_name)
+            continue
+        if not isinstance(parsed, list):
+            continue
+        bag = tokens[card_name]
+        for kw in parsed:
+            if isinstance(kw, str) and kw:
+                bag.append(f"keyword:{kw}")
+
+    return {name: tuple(bag) for name, bag in tokens.items()}
+
+
+def compute_tfidf(
+    corpus: dict[str, tuple[str, ...]],
+    min_df: int = 2,
+) -> TfidfResult:
+    """TF-IDF over the corpus with smoothed IDF and min-df pruning.
+
+    Term-frequency is raw count (no sublinear scaling); IDF is
+    ``ln((1 + N) / (1 + df)) + 1`` — the smoothed form commonly used by
+    IR libraries to avoid division-by-zero when ``df == N``. Tokens
+    present on fewer than ``min_df`` cards are pruned from the
+    vocabulary entirely. Rows are **not** L2-normalized here; SVD +
+    normalization happens in ``embeddings.svd.truncated_svd``.
+
+    Determinism:
+
+    * ``card_names`` are sorted ascending, so row ``i`` is reproducible.
+    * ``vocabulary`` is sorted ascending.
+    * No random sampling; no seed needed.
+    """
+    if min_df < 1:
+        raise ValueError(f"min_df must be >= 1; got {min_df}")
+
+    card_names = sorted(corpus.keys())
+    n_cards = len(card_names)
+
+    # Document frequency (how many cards contain each token at least once).
+    document_frequency: dict[str, int] = {}
+    for name in card_names:
+        for token in set(corpus[name]):
+            document_frequency[token] = document_frequency.get(token, 0) + 1
+
+    # Prune tokens below min_df, then sort deterministically.
+    vocabulary = sorted(token for token, df in document_frequency.items() if df >= min_df)
+    vocab_index: dict[str, int] = {token: i for i, token in enumerate(vocabulary)}
+
+    if not vocabulary:
+        # All tokens pruned (or corpus empty). Return an empty matrix
+        # with the correct row count so downstream SVD still sees a
+        # 2-D array.
+        return TfidfResult(
+            tfidf_matrix=np.zeros((n_cards, 0), dtype=np.float64),
+            card_names=card_names,
+            vocabulary=vocabulary,
+        )
+
+    # IDF vector (smoothed) — computed once per run.
+    idf = np.zeros(len(vocabulary), dtype=np.float64)
+    for token, df in document_frequency.items():
+        idx = vocab_index.get(token)
+        if idx is None:
+            continue
+        idf[idx] = math.log((1.0 + n_cards) / (1.0 + df)) + 1.0
+
+    # TF matrix — raw counts per (card, token).
+    tf = np.zeros((n_cards, len(vocabulary)), dtype=np.float64)
+    for i, name in enumerate(card_names):
+        for token in corpus[name]:
+            idx = vocab_index.get(token)
+            if idx is None:
+                continue
+            tf[i, idx] += 1.0
+
+    tfidf = tf * idf  # row-wise broadcast: each column scaled by its IDF
+
+    return TfidfResult(
+        tfidf_matrix=tfidf,
+        card_names=card_names,
+        vocabulary=vocabulary,
+    )

--- a/src/mtg_synergy_graph/engine.py
+++ b/src/mtg_synergy_graph/engine.py
@@ -17,6 +17,7 @@ returns every legal card; ``offset=500, limit=100`` returns rank 501-600.
 from __future__ import annotations
 
 import datetime as _dt
+import math
 import sqlite3
 from collections.abc import Sequence
 from dataclasses import dataclass, field
@@ -220,7 +221,22 @@ class SynergyEngine:
         else:
             scores = us.to_legacy_buckets()
 
-        explanation = self._render_explanation(card, scores, us) if include_explanation else None
+        # Rule-covered names derived from the cached universal scores;
+        # cheap because the score dict is already in-memory.
+        rule_covered_names: set[str] = {
+            name for name, u in universal.items() if u is not None and len(u.distinct_rules) >= 1
+        }
+        explanation = (
+            self._render_explanation(
+                card,
+                scores,
+                us,
+                commander_set=cmdr_set,
+                rule_covered_names=rule_covered_names,
+            )
+            if include_explanation
+            else None
+        )
 
         return Recommendation(
             rank=0,
@@ -398,9 +414,25 @@ class SynergyEngine:
         total = len(ranked)
         window = ranked[offset : offset + limit]
 
+        # Plan 2026-04-23-003 Unit 7 — rule-covered candidate set fed
+        # to _render_explanation so the embedding-nearest-neighbor
+        # lookup filters to structurally-meaningful peers only. Built
+        # once per page(), not per candidate.
+        rule_covered_names: set[str] = {cand for cand, _buckets, us in ranked if len(us.distinct_rules) >= 1}
+
         items: list[Recommendation] = []
         for i, (cand, buckets, us) in enumerate(window):
-            explanation = self._render_explanation(cand, buckets, us) if include_explanations else None
+            explanation = (
+                self._render_explanation(
+                    cand,
+                    buckets,
+                    us,
+                    commander_set=cmdr_set,
+                    rule_covered_names=rule_covered_names,
+                )
+                if include_explanations
+                else None
+            )
             items.append(
                 Recommendation(
                     rank=offset + i + 1,
@@ -447,6 +479,9 @@ class SynergyEngine:
         card: str,
         scores: dict[str, float],
         universal_score: UniversalScore | None = None,
+        *,
+        commander_set: Sequence[str] | None = None,
+        rule_covered_names: set[str] | None = None,
     ) -> list[str]:
         """Plain-English narrator (§8) — optional, for debug surfaces.
 
@@ -454,6 +489,13 @@ class SynergyEngine:
         metadata from ``PortComplement.path_info`` alongside the
         bucket-summary prose (currently: one ``self_bridging_cascade:``
         line per firing).
+
+        When ``universal_score.embedding_contribution > 0`` and both
+        ``commander_set`` + ``rule_covered_names`` are supplied, renders
+        an extra ``embedding_contribution:`` line decomposed into
+        ``decay × cosine``, plus a ``nearest covered neighbors:`` line
+        with the top-3 rule-covered cards by cosine similarity. Plan
+        2026-04-23-003 Unit 7 / FR6.
         """
         lines: list[str] = []
         if scores.get("port_match", 0):
@@ -481,4 +523,105 @@ class SynergyEngine:
                     continue
                 seen_paths.add(c.path_info)
                 lines.append(f"self_bridging_cascade: {c.path_info}")
+            # Plan 2026-04-23-003 Unit 7 — render the embedding
+            # contribution decomposition + nearest covered neighbors
+            # when the term fired. Silently skip if vectors /
+            # commander target cannot be rebuilt at render time
+            # (graceful-fallback per plan D6).
+            if universal_score.embedding_contribution > 0 and commander_set is not None:
+                lines.extend(
+                    self._render_embedding_block(
+                        card=card,
+                        universal_score=universal_score,
+                        commander_set=commander_set,
+                        rule_covered_names=rule_covered_names or set(),
+                    )
+                )
         return lines or [f"No mechanical synergy detected for {card}."]
+
+    def _render_embedding_block(
+        self,
+        *,
+        card: str,
+        universal_score: UniversalScore,
+        commander_set: Sequence[str],
+        rule_covered_names: set[str],
+    ) -> list[str]:
+        """Render the ``embedding_contribution:`` + neighbors lines.
+
+        Re-loads vectors + commander-target lazily here instead of
+        threading them through ``page()`` (plan design decision:
+        Option 2 re-load, not Option 1 pass-through — keeps the
+        scoring path data-free of render concerns). Silently returns
+        ``[]`` if vectors or target are unavailable — the scorer has
+        already computed the contribution value, so the score line
+        never surprises the user even when the decomposition can't
+        be rendered.
+        """
+        # Local imports — embeddings subpackage is cold on the import
+        # path unless actually rendering an embedding explanation.
+        from .embeddings.commander_target import build_commander_target_vector
+        from .embeddings.contribution import (
+            _EMBEDDING_K,
+            load_card_embeddings_verified,
+        )
+
+        try:
+            vectors = load_card_embeddings_verified(self._conn)
+        except Exception:
+            # Never raise from --explain: the scorer has already computed
+            # the contribution value, so the score line never surprises
+            # the user even when the decomposition cannot be rendered.
+            return []
+        cand_vec = vectors.get(card)
+        if cand_vec is None:
+            return []
+        cmdr_target = build_commander_target_vector(
+            tuple(commander_set),
+            vectors,
+            edhrec_conn=None,
+        )
+        if cmdr_target is None:
+            return []
+
+        cosine = float(cand_vec @ cmdr_target)
+        decay = math.exp(-_EMBEDDING_K * len(universal_score.distinct_rules))
+        out: list[str] = [
+            f"  embedding_contribution: +{universal_score.embedding_contribution:.3f} "
+            f"(decay × cosine = {decay:.2f} × {cosine:.3f})"  # noqa: RUF001 — multiplication-sign glyph is the user-facing explain format.
+        ]
+        neighbors = _nearest_covered_neighbors(
+            cand_vec,
+            vectors,
+            rule_covered_names=rule_covered_names - {card},
+            k=3,
+        )
+        if neighbors:
+            rendered = ", ".join(f"{n} (cosine {s:.2f})" for n, s in neighbors)
+            out.append(f"    nearest covered neighbors: {rendered}")
+        return out
+
+
+def _nearest_covered_neighbors(
+    vec: Any,
+    vectors: dict[str, Any],
+    *,
+    rule_covered_names: set[str],
+    k: int = 3,
+) -> list[tuple[str, float]]:
+    """Return the top-``k`` ``(name, cosine)`` pairs from ``vectors``
+    filtered to ``rule_covered_names``.
+
+    All vectors are L2-normalized by construction (plan R1 + Unit 4),
+    so cosine == dot product. When ``rule_covered_names`` is empty or
+    no name in it has a vector, returns ``[]``.
+    """
+    scored: list[tuple[str, float]] = []
+    for name in rule_covered_names:
+        v = vectors.get(name)
+        if v is None:
+            continue
+        cosine = float(v @ vec)
+        scored.append((name, cosine))
+    scored.sort(key=lambda t: -t[1])
+    return scored[:k]

--- a/src/mtg_synergy_graph/schema.sql
+++ b/src/mtg_synergy_graph/schema.sql
@@ -285,3 +285,32 @@ CREATE INDEX IF NOT EXISTS idx_rules_active ON rules(active);
 -- schema.sql executescript — applying the DDL in two places risked
 -- silent drift when rule migrations add CASE branches.
 -- ---------------------------------------------------------------------------
+
+-- ---------------------------------------------------------------------------
+-- card_embeddings: per-card 128-dim content embedding blob (plan
+-- 2026-04-23-003 Unit 2). Populated by scripts/build_embeddings.py from
+-- TF-IDF + truncated-SVD over structured port/keyword features. Blob is a
+-- numpy float32 array of fixed shape (128,). Read at inference time by
+-- embeddings.store.load_card_embeddings; graceful fallback on missing /
+-- empty / corrupt rows. Vector rebuild is wholesale (replace-all
+-- semantics) whenever the cardsfolder or vectorizer_version changes.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS card_embeddings (
+    card_name          TEXT PRIMARY KEY REFERENCES cards(name),
+    vector             BLOB NOT NULL,
+    vectorizer_version INTEGER NOT NULL,
+    built_at           TEXT NOT NULL
+);
+
+-- ---------------------------------------------------------------------------
+-- card_embeddings_config: KV store for EmbeddingConfigInputs + derived
+-- config_hash (plan 2026-04-23-003 Unit 2). Keys include
+-- token_format_version, svd_dims, min_df, vectorizer_version,
+-- port_signature_version, config_hash. The config_hash row gates
+-- verify_current_or_raise in embeddings.config; individual input rows
+-- are written for human diagnostics.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS card_embeddings_config (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);

--- a/src/mtg_synergy_graph/universal_scorer.py
+++ b/src/mtg_synergy_graph/universal_scorer.py
@@ -242,6 +242,24 @@ class ScoringConfigInputs(NamedTuple):
     #: ``compute_config_hash`` catches the flip without a second
     #: check-site.
     enable_pathway_rules: bool
+    #: Plan 2026-04-23-003 Unit 7: the embedding-contribution gate
+    #: (``embeddings.contribution._ENABLE_EMBEDDING_CONTRIBUTION``).
+    #: Flipping this changes every candidate's ``score`` (even with
+    #: ``embedding_w=0.0`` because the field is summed unconditionally
+    #: once the gate is open), so it must invalidate the pinned tensor.
+    enable_embedding_contribution: bool
+    #: Plan 2026-04-23-003 Unit 7: the embedding-contribution weight
+    #: ``_EMBEDDING_W``. Tuning it changes scores — catch drift here.
+    embedding_w: float
+    #: Plan 2026-04-23-003 Unit 7: the embedding-contribution decay
+    #: rate ``_EMBEDDING_K``. Tuning it changes scores — catch drift
+    #: here.
+    embedding_k: float
+    #: Plan 2026-04-23-003 Unit 7: vectorizer version read from
+    #: ``embeddings.config.get_embedding_config_inputs()``. A rebuild
+    #: under a new token grammar bumps this and invalidates the tensor
+    #: even when the flip flag + w + k are unchanged.
+    vectorizer_version: int
 
 
 def get_scoring_config_inputs() -> ScoringConfigInputs:
@@ -253,14 +271,22 @@ def get_scoring_config_inputs() -> ScoringConfigInputs:
     """
     # Local import: complement_rules imports universal_scorer for
     # _RULE_TO_BUCKET at module import time, so pulling pathway here
-    # at function-call time avoids the cycle.
+    # at function-call time avoids the cycle. Same rationale for the
+    # embeddings modules — they import numpy + sqlite3 and have no
+    # reason to be pulled in at scorer-module import.
     from .complement_rules import pathway
+    from .embeddings import contribution as emb_contribution
+    from .embeddings.config import get_embedding_config_inputs as _get_emb_cfg
 
     return ScoringConfigInputs(
         rule_quality_multiplier=_RULE_QUALITY_MULTIPLIER,
         flat_weight_overrides=_FLAT_WEIGHT_OVERRIDES,
         synergy_pairs=_SYNERGY_PAIRS,
         enable_pathway_rules=pathway._ENABLE_PATHWAY_RULES,
+        enable_embedding_contribution=emb_contribution._ENABLE_EMBEDDING_CONTRIBUTION,
+        embedding_w=emb_contribution._EMBEDDING_W,
+        embedding_k=emb_contribution._EMBEDDING_K,
+        vectorizer_version=_get_emb_cfg().vectorizer_version,
     )
 
 
@@ -284,6 +310,13 @@ class UniversalScore:
     circuit_bonus: float = 0.0
     cmc_bonus: float = 0.0
     rank_bonus: float = 0.0
+    #: Plan 2026-04-23-003 Unit 7: deterministic content-embedding
+    #: contribution. When ``_ENABLE_EMBEDDING_CONTRIBUTION`` is False
+    #: (module default), this stays ``0.0`` for every candidate —
+    #: ``score`` is bitwise-identical to pre-plan baseline. When the
+    #: audit-gated flip lands, this carries
+    #: ``w * exp(-k * n_rules) * cosine(v_cand, v_cmdr)``.
+    embedding_contribution: float = 0.0
 
     @cached_property
     def score(self) -> float:
@@ -334,6 +367,7 @@ class UniversalScore:
             base += 0.02 * min(n_rules - 1, 4)
         base += _compute_pair_bonus(self.distinct_rules)
         base += self.circuit_bonus + self.cmc_bonus + self.rank_bonus
+        base += self.embedding_contribution
         return base
 
     @cached_property
@@ -376,6 +410,7 @@ class UniversalScore:
             total += 0.02 * min(n_rules - 1, 4)
         total += _compute_pair_bonus(self.distinct_rules)
         total += self.circuit_bonus + self.cmc_bonus + self.rank_bonus
+        total += self.embedding_contribution
         buckets["total"] = total
         return buckets
 
@@ -901,6 +936,35 @@ def score_all_universal(
     for c in complements:
         by_candidate[c.candidate].append(c)
 
+    # Plan 2026-04-23-003 Unit 7 — embedding contribution wire.
+    # Resolve the commander target + per-card vector lookup ONCE per
+    # scoring call. When the flag is off (module default), both land on
+    # empty / None and the per-candidate call in the results loop below
+    # short-circuits to 0.0 — the scorer remains bitwise-identical to
+    # pre-plan baseline. Local imports keep the embeddings subpackage
+    # off the scorer's hot import path.
+    from .embeddings.commander_target import build_commander_target_vector
+    from .embeddings.contribution import (
+        _ENABLE_EMBEDDING_CONTRIBUTION,
+        embedding_contribution,
+        load_card_embeddings_verified,
+    )
+
+    if _ENABLE_EMBEDDING_CONTRIBUTION:
+        _emb_vectors = load_card_embeddings_verified(conn)
+        _emb_cmdr_target = (
+            build_commander_target_vector(
+                tuple(commander_set),
+                _emb_vectors,
+                edhrec_conn=None,
+            )
+            if _emb_vectors
+            else None
+        )
+    else:
+        _emb_vectors = {}
+        _emb_cmdr_target = None
+
     # Compute staple bonuses
     cmdr_row = conn.execute(
         "SELECT color_identity FROM cards WHERE name = ?",
@@ -940,6 +1004,18 @@ def score_all_universal(
         bonus = 0.01 if name in staple_names else 0.0
         cmc = cmc_data.get(name, 99.0)
         rank = rank_data.get(name, 99999)
+        # Plan 2026-04-23-003 Unit 7 — n_rules is the count of distinct
+        # rules firing positively for this candidate. Matches
+        # ``UniversalScore.distinct_rules`` by construction, but
+        # inlined here because ``distinct_rules`` is a
+        # ``@cached_property`` on the object we're about to build.
+        n_rules_syn = len({c.rule_id for c in comps if c.direction == "synergy"})
+        emb_contrib = embedding_contribution(
+            candidate_name=name,
+            n_rules=n_rules_syn,
+            v_cmdr=_emb_cmdr_target,
+            vectors=_emb_vectors,
+        )
         results[name] = UniversalScore(
             complements=comps,
             staple_bonus=bonus,
@@ -947,16 +1023,29 @@ def score_all_universal(
             circuit_bonus=0.05 if name in circuit_candidates else 0.0,
             cmc_bonus=0.01 * max(0.0, (7.0 - cmc)) / 7.0,
             rank_bonus=0.005 * max(0.0, 1.0 - rank / 30000.0),
+            embedding_contribution=emb_contrib,
         )
     for name in staple_names:
         if name not in results and name not in set(commander_set):
             cmc = cmc_data.get(name, 99.0)
             rank = rank_data.get(name, 99999)
+            # Staple-only candidates never accumulate complements, so
+            # ``n_rules=0`` — the embedding term (if flag on) is the
+            # undampened ``w_emb * cosine``. This is the intended
+            # behavior: cold-start / unrepresented-rule candidates are
+            # exactly where the embedding fallback is supposed to fire.
+            emb_contrib = embedding_contribution(
+                candidate_name=name,
+                n_rules=0,
+                v_cmdr=_emb_cmdr_target,
+                vectors=_emb_vectors,
+            )
             results[name] = UniversalScore(
                 staple_bonus=0.01,
                 idf_weights=idf,
                 cmc_bonus=0.01 * max(0.0, (7.0 - cmc)) / 7.0,
                 rank_bonus=0.005 * max(0.0, 1.0 - rank / 30000.0),
+                embedding_contribution=emb_contrib,
             )
 
     if tensor_sink is not None:

--- a/src/mtg_synergy_graph/universal_scorer.py
+++ b/src/mtg_synergy_graph/universal_scorer.py
@@ -244,9 +244,12 @@ class ScoringConfigInputs(NamedTuple):
     enable_pathway_rules: bool
     #: Plan 2026-04-23-003 Unit 7: the embedding-contribution gate
     #: (``embeddings.contribution._ENABLE_EMBEDDING_CONTRIBUTION``).
-    #: Flipping this changes every candidate's ``score`` (even with
-    #: ``embedding_w=0.0`` because the field is summed unconditionally
-    #: once the gate is open), so it must invalidate the pinned tensor.
+    #: Flipping this field invalidates the pinned tensor via
+    #: ``compute_config_hash`` because the hash input set changes.
+    #: Scores are only affected when ``embedding_w`` is also non-zero
+    #: — with ``_EMBEDDING_W=0.0`` (current default), the short-circuit
+    #: in ``embedding_contribution()`` returns ``0.0`` regardless of
+    #: this flag.
     enable_embedding_contribution: bool
     #: Plan 2026-04-23-003 Unit 7: the embedding-contribution weight
     #: ``_EMBEDDING_W``. Tuning it changes scores — catch drift here.
@@ -411,6 +414,11 @@ class UniversalScore:
         total += _compute_pair_bonus(self.distinct_rules)
         total += self.circuit_bonus + self.cmc_bonus + self.rank_bonus
         total += self.embedding_contribution
+        # Expose embedding contribution under a named bucket key so the
+        # ``sum(named_bucket_values) == total`` invariant holds when the
+        # flag is on. Alongside ``circuit_bonus``/``cmc_bonus``/
+        # ``rank_bonus`` — these are additive non-rule terms.
+        buckets["embedding"] = self.embedding_contribution
         buckets["total"] = total
         return buckets
 

--- a/src/mtg_synergy_graph/universal_scorer.py
+++ b/src/mtg_synergy_graph/universal_scorer.py
@@ -8,6 +8,7 @@ candidates satisfy is worth more than one 2000 candidates satisfy.
 
 from __future__ import annotations
 
+import logging
 import math
 import sqlite3
 from collections import defaultdict
@@ -25,6 +26,8 @@ from .scoring import BUCKETS
 
 if TYPE_CHECKING:
     from .penalties import CandidateCache
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -960,15 +963,26 @@ def score_all_universal(
 
     if _ENABLE_EMBEDDING_CONTRIBUTION:
         _emb_vectors = load_card_embeddings_verified(conn)
-        _emb_cmdr_target = (
-            build_commander_target_vector(
-                tuple(commander_set),
-                _emb_vectors,
-                edhrec_conn=None,
+        try:
+            _emb_cmdr_target = (
+                build_commander_target_vector(
+                    tuple(commander_set),
+                    _emb_vectors,
+                    edhrec_conn=None,
+                )
+                if _emb_vectors
+                else None
             )
-            if _emb_vectors
-            else None
-        )
+        except Exception as exc:
+            # Reliability R-004: the scoring init path must never raise.
+            # Any failure in commander-target composition degrades to
+            # "no embedding contribution for this run" so the rule-based
+            # scorer continues unaffected.
+            logger.warning(
+                "build_commander_target_vector failed; disabling embedding contribution for this run: %s",
+                exc,
+            )
+            _emb_cmdr_target = None
     else:
         _emb_vectors = {}
         _emb_cmdr_target = None

--- a/tests/bench/test_embedding_dedup_handler.py
+++ b/tests/bench/test_embedding_dedup_handler.py
@@ -1,0 +1,434 @@
+"""``bench.py audit --embedding-dedup`` handler tests (plan 003 Unit 6).
+
+Covers:
+
+* Happy path: populated tensor + populated embeddings + matching config
+  → markdown output on stdout, ``.audit/last_dedup.md`` written.
+* Preconditions:
+  - Missing tensor rows (no rows for current scoring config_hash).
+  - Missing / empty ``card_embeddings``.
+  - Stale ``card_embeddings_config`` hash.
+* Flag handling: ``--format json``, ``--threshold``, ``--min-activation``.
+* Mutex group: ``--embedding-dedup`` + ``--collinearity`` rejected.
+
+Mirrors ``tests/bench/test_handle_unknowns.py`` for the per-test
+argparse.Namespace shape and the ``tmp_path`` DB construction.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from mtg_synergy_graph.bench.embedding_dedup_handler import handle_embedding_dedup
+from mtg_synergy_graph.bench.tensor import compute_config_hash
+from mtg_synergy_graph.db import open_db
+from mtg_synergy_graph.embeddings import config as emb_config
+from mtg_synergy_graph.embeddings import store as emb_store
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _args(
+    db_path: Path,
+    *,
+    threshold: float = 0.95,
+    min_activation: int = 3,
+    format_: str = "md",
+) -> argparse.Namespace:
+    """Minimal ``Namespace`` matching the audit-parser flag shape."""
+    return argparse.Namespace(
+        db=str(db_path),
+        threshold=threshold,
+        min_activation=min_activation,
+        format=format_,
+    )
+
+
+def _unit_vector(*components: float, dim: int = 128) -> np.ndarray:
+    """Build a deterministic L2-normalized float32 vector for tests.
+
+    Same helper as ``test_dedup.py`` — duplicated locally because the
+    two test modules should not share a conftest (the dedup-logic
+    tests must not depend on SQLite fixtures).
+    """
+    vec = np.zeros(dim, dtype=np.float32)
+    for i, c in enumerate(components):
+        vec[i] = c
+    norm = float(np.linalg.norm(vec))
+    if norm == 0.0:
+        return vec
+    return (vec / norm).astype(np.float32)
+
+
+def _insert_tensor_rows(
+    conn: sqlite3.Connection,
+    rows: list[tuple[str, str, str, float]],
+    config_hash: str,
+) -> None:
+    """Insert ``(cmdr, cand, rule_id, contribution)`` rows under ``config_hash``."""
+    conn.executemany(
+        "INSERT INTO rule_contributions "
+        "(commander, candidate, rule_id, contribution, idf_weight, raw_count, "
+        "config_hash, computed_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        [(c, cand, rid, contrib, 0.1, 1, config_hash, "2026-04-23T00:00:00") for c, cand, rid, contrib in rows],
+    )
+    conn.commit()
+
+
+def _populate_synthetic_audit_db(tmp_path: Path) -> Path:
+    """Create a tmp DB with:
+
+    * Real schema via ``open_db``.
+    * 25+ synthetic ``rule_contributions`` rows under the current
+      scoring ``config_hash`` so the handler's precondition checks pass.
+    * A ``card_embeddings`` population with matching
+      ``card_embeddings_config`` — the ``write_vectors`` call inside
+      one transaction.
+
+    The fixture DB is self-contained: no dependency on
+    ``data/synergy.db`` or a live importer run.
+    """
+    db_path = tmp_path / "synergy.db"
+    conn = open_db(db_path)
+    try:
+        h = compute_config_hash()
+
+        # Two rules with heavy overlap (cards c1..c10), one rule with
+        # distinct cards (c11..c20). Overlapping rules should flag;
+        # distinct rule should not pair under any reasonable threshold.
+        overlap_cards = [f"card_{i}" for i in range(10)]
+        distinct_cards = [f"dcard_{i}" for i in range(10)]
+
+        # Insert cards first so the card_embeddings FK is satisfied.
+        for name in overlap_cards + distinct_cards:
+            conn.execute(
+                "INSERT INTO cards(name, card_types, color_identity, legal_commander) VALUES (?, 'Creature', 'G', 1)",
+                (name,),
+            )
+        conn.commit()
+
+        rule_a_rows = [("CmdrA", c, "rule_alpha", 1.0) for c in overlap_cards]
+        rule_b_rows = [("CmdrA", c, "rule_beta", 1.0) for c in overlap_cards]
+        rule_c_rows = [("CmdrA", c, "rule_gamma", 1.0) for c in distinct_cards]
+        _insert_tensor_rows(conn, rule_a_rows + rule_b_rows + rule_c_rows, h)
+
+        # Every overlap card points in direction e_0; every distinct
+        # card points in e_1 → orthogonal mean vectors → (alpha, beta)
+        # pair should flag with cosine 1, (alpha, gamma) and
+        # (beta, gamma) pairs should NOT flag.
+        vectors = {c: _unit_vector(1.0, 0.0) for c in overlap_cards}
+        vectors.update({c: _unit_vector(0.0, 1.0) for c in distinct_cards})
+        emb_store.write_vectors(conn, vectors, emb_config.get_embedding_config_inputs())
+    finally:
+        conn.close()
+    return db_path
+
+
+@pytest.fixture()
+def _run_from_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Run each handler call with cwd=``tmp_path`` so ``.audit/`` side
+    effects land there and are discarded on teardown."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_emits_markdown_and_writes_audit_file(
+    tmp_path: Path,
+    _run_from_tmp: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    db_path = _populate_synthetic_audit_db(tmp_path)
+
+    rc = handle_embedding_dedup(_args(db_path, threshold=0.95, min_activation=5))
+
+    assert rc == 0
+    out = capsys.readouterr()
+    assert "bench.py audit --embedding-dedup" in out.out
+    # Two rules with identical activation sets → flagged.
+    assert "rule_alpha" in out.out
+    assert "rule_beta" in out.out
+    # rule_gamma has orthogonal mean vector → should NOT pair with
+    # alpha or beta under threshold=0.95 and cosine ≈ 0.
+    # (It appears in neither activation line of a flagged pair.)
+
+    audit_file = _run_from_tmp / ".audit" / "last_dedup.md"
+    assert audit_file.exists(), "handler must mirror the report to .audit/last_dedup.md"
+    file_text = audit_file.read_text()
+    assert "rule_alpha" in file_text
+    assert "rule_beta" in file_text
+
+
+def test_happy_path_json_format(
+    tmp_path: Path,
+    _run_from_tmp: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    db_path = _populate_synthetic_audit_db(tmp_path)
+
+    rc = handle_embedding_dedup(_args(db_path, threshold=0.95, min_activation=5, format_="json"))
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out.strip())
+    assert isinstance(payload, list)
+    assert len(payload) >= 1
+    entry = payload[0]
+    assert entry["rule_a"] == "rule_alpha"
+    assert entry["rule_b"] == "rule_beta"
+    assert entry["cosine"] == pytest.approx(1.0, rel=1e-6)
+    assert entry["activation_a_size"] == 10
+    assert entry["activation_b_size"] == 10
+
+
+# ---------------------------------------------------------------------------
+# Precondition failures
+# ---------------------------------------------------------------------------
+
+
+def test_missing_tensor_rows_exits_2_with_repin_hint(
+    tmp_path: Path,
+    _run_from_tmp: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """No ``rule_contributions`` rows under the current scoring hash."""
+    db_path = tmp_path / "synergy.db"
+    conn = open_db(db_path)
+    try:
+        # Insert the FK target first so the card_embeddings FK is
+        # satisfied. Then populate card_embeddings so that step passes;
+        # rule_contributions stays empty — that's the failure mode
+        # under test.
+        conn.execute(
+            "INSERT INTO cards(name, card_types, color_identity, legal_commander) "
+            "VALUES ('card_x', 'Creature', 'G', 1)",
+        )
+        conn.commit()
+        emb_store.write_vectors(
+            conn,
+            {"card_x": _unit_vector(1.0)},
+            emb_config.get_embedding_config_inputs(),
+        )
+    finally:
+        conn.close()
+
+    rc = handle_embedding_dedup(_args(db_path))
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "no rule_contributions rows" in err
+    assert "--repin" in err
+
+
+def test_missing_card_embeddings_exits_2_with_build_hint(
+    tmp_path: Path,
+    _run_from_tmp: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``card_embeddings`` table has zero rows → exit 2."""
+    db_path = tmp_path / "synergy.db"
+    conn = open_db(db_path)
+    try:
+        h = compute_config_hash()
+        conn.execute(
+            "INSERT INTO cards(name, card_types, color_identity, legal_commander) "
+            "VALUES ('card_1', 'Creature', 'G', 1)",
+        )
+        conn.commit()
+        _insert_tensor_rows(conn, [("CmdrA", "card_1", "r1", 1.0)], h)
+    finally:
+        conn.close()
+
+    # Bypass the autouse conftest stub: the empty-embeddings case is
+    # exactly what we're testing, and the stub would mask it by
+    # returning synthetic rows. Force the real ``load_card_embeddings``
+    # by monkeypatching the module-level reference.
+    from mtg_synergy_graph.bench import embedding_dedup_handler as handler_module
+
+    monkeypatch.setattr(handler_module, "load_card_embeddings", lambda _conn: {})
+
+    rc = handle_embedding_dedup(_args(db_path))
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "no card_embeddings" in err
+    assert "build_embeddings.py" in err
+
+
+def test_stale_embeddings_config_exits_2_with_rebuild_hint(
+    tmp_path: Path,
+    _run_from_tmp: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``card_embeddings_config.config_hash`` differs from current → exit 2."""
+    db_path = tmp_path / "synergy.db"
+    conn = open_db(db_path)
+    try:
+        h = compute_config_hash()
+        conn.execute(
+            "INSERT INTO cards(name, card_types, color_identity, legal_commander) "
+            "VALUES ('card_1', 'Creature', 'G', 1)",
+        )
+        conn.commit()
+        _insert_tensor_rows(conn, [("CmdrA", "card_1", "r1", 1.0)], h)
+
+        # Write vectors under the current config, then deliberately
+        # overwrite the stored hash so ``verify_current_or_raise`` fires.
+        emb_store.write_vectors(
+            conn,
+            {"card_1": _unit_vector(1.0)},
+            emb_config.get_embedding_config_inputs(),
+        )
+        conn.execute("UPDATE card_embeddings_config SET value = 'bogus_stale_hash_1234' WHERE key = 'config_hash'")
+        conn.commit()
+    finally:
+        conn.close()
+
+    rc = handle_embedding_dedup(_args(db_path))
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    # The EmbeddingConfigStaleError message includes "different config"
+    # and the rebuild command "scripts/build_embeddings.py".
+    assert "build_embeddings.py" in err
+
+
+# ---------------------------------------------------------------------------
+# Flag plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_threshold_flag_changes_output(
+    tmp_path: Path,
+    _run_from_tmp: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Loose threshold flags the pair; strict threshold does not."""
+    db_path = _populate_synthetic_audit_db(tmp_path)
+
+    # Under 0.95 the identical-activation pair flags (cosine == 1).
+    rc_loose = handle_embedding_dedup(_args(db_path, threshold=0.95, min_activation=5))
+    loose_out = capsys.readouterr().out
+    assert rc_loose == 0
+    assert "rule_alpha" in loose_out and "rule_beta" in loose_out
+
+    # Bump threshold to 1.5 (impossibly strict) — no pair should flag.
+    rc_strict = handle_embedding_dedup(_args(db_path, threshold=1.5, min_activation=5))
+    strict_out = capsys.readouterr().out
+    assert rc_strict == 0
+    # Marker line from the markdown renderer when no pairs flag.
+    assert "No rule pairs exceed" in strict_out
+
+
+def test_min_activation_flag_prunes_rules(
+    tmp_path: Path,
+    _run_from_tmp: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--min-activation`` above every rule's set size → empty output."""
+    db_path = _populate_synthetic_audit_db(tmp_path)
+
+    rc = handle_embedding_dedup(_args(db_path, threshold=0.5, min_activation=100))
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "No rule pairs exceed" in out
+    # pairs_flagged counter is zero.
+    assert "pairs_flagged: 0" in out
+
+
+# ---------------------------------------------------------------------------
+# Mutex-group / CLI dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_cli_dispatch_registers(
+    tmp_path: Path,
+    _run_from_tmp: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """argparse CLI routes ``--embedding-dedup`` to handle_embedding_dedup."""
+    # Ensure handlers register (import side-effect).
+    import mtg_synergy_graph.bench  # noqa: F401
+    from mtg_synergy_graph.bench.cli import main
+
+    db_path = _populate_synthetic_audit_db(tmp_path)
+
+    rc = main(
+        [
+            "audit",
+            "--embedding-dedup",
+            "--db",
+            str(db_path),
+            "--threshold",
+            "0.95",
+            "--min-activation",
+            "5",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "bench.py audit --embedding-dedup" in out
+
+
+def test_mutex_with_collinearity_rejected() -> None:
+    """``--embedding-dedup`` + ``--collinearity`` → argparse SystemExit."""
+    from mtg_synergy_graph.bench.cli import main
+
+    with pytest.raises(SystemExit):
+        main(["audit", "--embedding-dedup", "--collinearity"])
+
+
+def test_help_lists_embedding_dedup_flag(capsys: pytest.CaptureFixture[str]) -> None:
+    """``bench.py audit --help`` renders the ``--embedding-dedup`` entry."""
+    from mtg_synergy_graph.bench.cli import main
+
+    with pytest.raises(SystemExit):
+        main(["audit", "--help"])
+    out = capsys.readouterr().out
+    assert "--embedding-dedup" in out
+    assert "--threshold" in out
+    assert "--min-activation" in out
+
+
+# ---------------------------------------------------------------------------
+# Defensive: handler never raises
+# ---------------------------------------------------------------------------
+
+
+def test_handler_returns_2_on_unexpected_exception(
+    tmp_path: Path,
+    _run_from_tmp: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unexpected exceptions inside ``compute_embedding_dedup`` are caught,
+    stderr logged, exit 2."""
+    db_path = _populate_synthetic_audit_db(tmp_path)
+
+    def _boom(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("simulated internal failure")
+
+    from mtg_synergy_graph.bench import embedding_dedup_handler as handler_module
+
+    monkeypatch.setattr(handler_module, "compute_embedding_dedup", _boom)
+
+    rc = handle_embedding_dedup(_args(db_path, min_activation=5))
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "simulated internal failure" in err

--- a/tests/bench/test_universal_scorer_identity.py
+++ b/tests/bench/test_universal_scorer_identity.py
@@ -221,6 +221,13 @@ def test_embedding_contribution_field_defaults_to_zero_when_flag_off(
     """
     from mtg_synergy_graph.embeddings import contribution as emb_contribution
 
+    # Lock both safety layers: if ``_EMBEDDING_W`` drifts from 0.0 while
+    # the flag stays False the short-circuit masks it and the flag-off
+    # assertion becomes vacuous. Pin ``_EMBEDDING_K`` too against its
+    # documented default (0.8) so any tune drift is caught here as well.
+    assert emb_contribution._EMBEDDING_W == 0.0
+    assert emb_contribution._EMBEDDING_K == 0.8
+
     # Belt-and-suspenders: the plan forbids flipping the default in this
     # unit. If a future edit sets True as the default here the audit
     # sweep owns that flip, not this test — fail loud if it drifts.

--- a/tests/bench/test_universal_scorer_identity.py
+++ b/tests/bench/test_universal_scorer_identity.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from mtg_synergy_graph.db import open_db
@@ -197,3 +198,88 @@ def test_sink_matches_legacy_buckets(scoring_fixture: sqlite3.Connection) -> Non
         assert sink_contrib == pytest.approx(expected, abs=1e-12), (
             f"sink contribution for ({cand}, {rule_id}) = {sink_contrib}, but legacy computation = {expected}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Plan 003 Unit 7 — embedding contribution flag-off identity invariant.
+# ---------------------------------------------------------------------------
+
+
+def test_embedding_contribution_field_defaults_to_zero_when_flag_off(
+    scoring_fixture: sqlite3.Connection,
+) -> None:
+    """R7/Unit7: ``_ENABLE_EMBEDDING_CONTRIBUTION=False`` (module default)
+    → every ``UniversalScore`` carries ``embedding_contribution == 0.0``
+    exactly, so ``score`` totals are bitwise-identical to the pre-plan
+    path (no embedding term contributes).
+
+    This is the flag-off identity guardrail required by the plan's
+    Execution note for Unit 7: before field plumbing landed this test
+    failed with ``AttributeError`` (no such field); after plumbing it
+    must pass trivially because every short-circuit in the scorer wire
+    lands on 0.0 when the flag is off.
+    """
+    from mtg_synergy_graph.embeddings import contribution as emb_contribution
+
+    # Belt-and-suspenders: the plan forbids flipping the default in this
+    # unit. If a future edit sets True as the default here the audit
+    # sweep owns that flip, not this test — fail loud if it drifts.
+    assert emb_contribution._ENABLE_EMBEDDING_CONTRIBUTION is False
+
+    scores = score_all_universal(scoring_fixture, ["Test Commander"])
+
+    for name, score_obj in scores.items():
+        assert score_obj.embedding_contribution == 0.0, (
+            f"{name}: embedding_contribution must be exactly 0.0 when flag "
+            f"is off, got {score_obj.embedding_contribution}"
+        )
+
+
+def test_embedding_contribution_nonzero_when_flag_on(
+    scoring_fixture: sqlite3.Connection,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Flag on + w_emb=0.5 + populated ``card_embeddings`` → at least one
+    candidate has a nonzero embedding contribution.
+
+    Complements the flag-off identity test: proves the wire is actually
+    live (not a dead branch) when the gate opens. Uses a synthetic
+    deterministic vector per candidate so the cosine math is testable.
+    """
+    from mtg_synergy_graph.embeddings import commander_target as ct
+    from mtg_synergy_graph.embeddings import config as emb_config
+    from mtg_synergy_graph.embeddings import contribution as emb_contribution
+    from mtg_synergy_graph.embeddings import store as emb_store
+
+    # Flip the flag + enable a nonzero weight. Module-level defaults are
+    # restored at teardown by pytest's monkeypatch.
+    monkeypatch.setattr(emb_contribution, "_ENABLE_EMBEDDING_CONTRIBUTION", True)
+    monkeypatch.setattr(emb_contribution, "_EMBEDDING_W", 0.5)
+    # Ensure commander-target cache is cold for this scenario.
+    ct.clear_cache()
+
+    # Populate card_embeddings on the same connection the scorer uses.
+    # Every card in the fixture gets a deterministic L2-normalized vector.
+    def _seeded(seed: int) -> np.ndarray:
+        rng = np.random.default_rng(seed)
+        v = rng.standard_normal(128).astype(np.float32)
+        return (v / np.linalg.norm(v)).astype(np.float32)
+
+    vectors = {
+        "Test Commander": _seeded(1),
+        "Token Maker": _seeded(2),
+        "Counter Doubler": _seeded(3),
+        "Generic Creature": _seeded(4),
+    }
+    emb_store.write_vectors(
+        scoring_fixture,
+        vectors,
+        emb_config.get_embedding_config_inputs(),
+    )
+
+    scores = score_all_universal(scoring_fixture, ["Test Commander"])
+
+    assert any(s.embedding_contribution != 0.0 for s in scores.values()), (
+        "With flag on + populated vectors, at least one candidate should have a nonzero embedding contribution"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,6 +115,15 @@ def _seed_card_embeddings_when_absent(monkeypatch: pytest.MonkeyPatch) -> None:
     real function — the per-call guard inside the stub delegates to the
     real ``load_card_embeddings`` whenever the connection's
     ``card_embeddings`` table has rows.
+
+    Stub contract: consumers that bind ``load_card_embeddings`` at the
+    module top (``from mtg_synergy_graph.embeddings.store import
+    load_card_embeddings``) will NOT see this stub — the monkeypatch
+    replaces the attribute on ``embeddings.store`` and on the
+    ``embeddings`` package re-export, but a third top-level binding
+    captures the original function at import time. Any new consumer
+    must either import via attribute access (``emb_store.load_card_embeddings(...)``)
+    OR add a manual ``monkeypatch.setattr`` in its own test.
     """
     real_db = Path(__file__).resolve().parent.parent / "data" / "synergy.db"
     should_stub = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import sqlite3
 import sys
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 # scripts/ is not a package but test files import gap_report / forge_oracle /
@@ -62,6 +63,113 @@ def _stub_forge_sha_when_checkout_absent(monkeypatch: pytest.MonkeyPatch) -> Non
         return pinned_sha
 
     monkeypatch.setattr(fo_version, "read_current_forge_sha", _stub)
+
+
+# ---------------------------------------------------------------------------
+# Content embeddings (plan 003) — CI-friendly shim
+# ---------------------------------------------------------------------------
+#
+# ``scripts/build_embeddings.py`` populates ``card_embeddings`` /
+# ``card_embeddings_config`` but is NOT invoked by the importer (plan D4:
+# users run it manually after cardsfolder refresh). On fresh checkouts /
+# CI runners, the real ``data/synergy.db`` either doesn't exist yet or
+# has empty embedding tables. Downstream tests that call
+# ``load_card_embeddings`` against an in-memory DB without populated
+# tables would otherwise get ``{}`` silently; the shim below returns a
+# deterministic 5-card synthetic dict instead so consumer tests get
+# predictable content.
+#
+# The shim activates only when the *real* production DB
+# (``data/synergy.db``) is missing or has zero rows in
+# ``card_embeddings``. When a developer has run
+# ``scripts/build_embeddings.py`` locally, the real load path runs —
+# production failure modes are never masked. Tests that populate
+# ``card_embeddings`` on their own in-memory connection bypass the stub
+# via the empty-table guard inside ``_stub`` below.
+
+
+def _make_stub_embedding_vector(seed: int) -> np.ndarray:
+    """Deterministic 128-dim L2-normalized float32 vector for a given seed."""
+    rng = np.random.default_rng(seed)
+    vec = rng.standard_normal(128).astype(np.float32)
+    norm = float(np.linalg.norm(vec))
+    if norm == 0.0:
+        return vec
+    return (vec / norm).astype(np.float32)
+
+
+_SYNTHETIC_CARD_EMBEDDINGS: dict[str, np.ndarray] = {
+    f"__stub_card_{letter}": _make_stub_embedding_vector(seed=seed) for seed, letter in enumerate("abcde", start=1)
+}
+
+
+@pytest.fixture(autouse=True)
+def _seed_card_embeddings_when_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub ``load_card_embeddings`` when the real DB has no vectors.
+
+    Mirrors the ``_stub_forge_sha_when_checkout_absent`` precedent: the
+    stub fires only when the real production asset is missing / empty,
+    so dev machines that have already run
+    ``scripts/build_embeddings.py`` exercise the real path. Tests that
+    populate ``card_embeddings`` on their own connection still get the
+    real function — the per-call guard inside the stub delegates to the
+    real ``load_card_embeddings`` whenever the connection's
+    ``card_embeddings`` table has rows.
+    """
+    real_db = Path(__file__).resolve().parent.parent / "data" / "synergy.db"
+    should_stub = True
+    if real_db.exists():
+        probe: sqlite3.Connection | None = None
+        try:
+            probe_uri = f"file:{real_db}?mode=ro"
+            probe = sqlite3.connect(probe_uri, uri=True)
+            row = probe.execute("SELECT COUNT(*) FROM card_embeddings").fetchone()
+            if row is not None and row[0] > 0:
+                should_stub = False
+        except sqlite3.Error:
+            # Missing table, corrupt DB, permission issue — treat as
+            # absent so the stub activates.
+            pass
+        finally:
+            if probe is not None:
+                probe.close()
+    if not should_stub:
+        return
+
+    from mtg_synergy_graph import embeddings as emb_pkg
+    from mtg_synergy_graph.embeddings import store as emb_store
+
+    real_load = emb_store.load_card_embeddings
+
+    def _stub(conn: sqlite3.Connection) -> dict[str, np.ndarray]:
+        # Narrow the stub to consumer-shaped tests only: a real
+        # inference-path call comes with a full schema (``cards`` +
+        # ``card_embeddings`` + friends). Bare-schema test DBs that
+        # only set up the two embedding tables (as in
+        # ``tests/embeddings/test_store.py``) are exercising the real
+        # graceful-fallback contract — skip the stub there.
+        try:
+            conn.execute("SELECT 1 FROM cards LIMIT 1").fetchone()
+        except sqlite3.Error:
+            return real_load(conn)
+
+        # If the caller has already populated card_embeddings on this
+        # connection, exercise the real loader. The stub only fills the
+        # gap for empty-table consumer tests.
+        try:
+            row = conn.execute("SELECT COUNT(*) FROM card_embeddings").fetchone()
+        except sqlite3.Error:
+            return real_load(conn)
+        if row is not None and row[0] > 0:
+            return real_load(conn)
+        return {name: vec.copy() for name, vec in _SYNTHETIC_CARD_EMBEDDINGS.items()}
+
+    # Patch on both the defining module and the package-level re-export,
+    # because ``from mtg_synergy_graph.embeddings import load_card_embeddings``
+    # binds a reference that does NOT track later monkeypatching on
+    # ``embeddings.store``.
+    monkeypatch.setattr(emb_store, "load_card_embeddings", _stub)
+    monkeypatch.setattr(emb_pkg, "load_card_embeddings", _stub)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/embeddings/test_build_script.py
+++ b/tests/embeddings/test_build_script.py
@@ -1,0 +1,357 @@
+"""Unit 3 tests — scripts/build_embeddings.py end-to-end pipeline.
+
+Tests the build script by invoking ``main()`` directly (no subprocess)
+so coverage is collected and failures surface inline. A separate
+integration test exercises the ``__main__`` entry-point via subprocess
+to prove the standalone invocation contract.
+
+The test DB is a 50-card fixture built via ``open_db()`` (real schema)
++ inline ``INSERT`` statements — ensures ``card_embeddings`` +
+``card_embeddings_config`` are created by the schema, not hand-rolled.
+
+Covers:
+
+* 50 rows populated by a single run; ``config_hash`` present.
+* Post-build ``verify_current_or_raise`` passes.
+* Re-run replaces (not appends) — row count stays at 50.
+* Same inputs → same ``config_hash`` (deterministic).
+* Different ``--min-df`` → different ``config_hash``.
+* Stdout summary line contains expected fields (via ``capsys``).
+* Subprocess ``--help`` invocation succeeds.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import build_embeddings  # type: ignore[import-not-found]
+import pytest
+
+from mtg_synergy_graph.db import open_db
+from mtg_synergy_graph.embeddings import (
+    compute_embedding_hash,
+    get_embedding_config_inputs,
+    verify_current_or_raise,
+)
+
+# ``build_embeddings`` is importable because ``tests/conftest.py`` inserts
+# ``scripts/`` on ``sys.path`` for in-process testing of script entry-points.
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "build_embeddings.py"
+
+
+def _seed_50_card_fixture(db_path: Path) -> None:
+    """Populate ``db_path`` with 50 diverse cards via the real schema.
+
+    Applies the full ``schema.sql`` via ``open_db`` so
+    ``card_embeddings`` + ``card_embeddings_config`` exist before the
+    build script runs. Seeds a spread of ``card_ports`` +
+    ``port_attributes`` rows so TF-IDF has a non-trivial vocabulary.
+    """
+    conn = open_db(db_path)
+    try:
+        port_types = ("trigger", "effect", "keyword")
+        event_classes = ("ETB", "SpellCast", "Draw", "Sacrifice", "Attack")
+        keywords_pool = (
+            ["Flying"],
+            ["Haste"],
+            ["Trample"],
+            ["Flying", "Vigilance"],
+            ["Deathtouch"],
+        )
+
+        with conn:
+            for i in range(50):
+                name = f"Card_{i:03d}"
+                kws = keywords_pool[i % len(keywords_pool)]
+                conn.execute(
+                    "INSERT INTO cards (name, keywords) VALUES (?, ?)",
+                    (name, json.dumps(kws)),
+                )
+                # One port per card; vary port_type + event_class so
+                # TF-IDF has tokens with df >= 2 that survive pruning.
+                port_type = port_types[i % len(port_types)]
+                event_class = event_classes[i % len(event_classes)]
+                cur = conn.execute(
+                    "INSERT INTO card_ports "
+                    "(card_name, port_type, event_class, zone_origin, "
+                    "zone_destination, counter_type, branch_kind) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        name,
+                        port_type,
+                        event_class,
+                        "Hand" if i % 2 == 0 else None,
+                        "Battlefield" if i % 3 == 0 else None,
+                        "P1P1" if i % 5 == 0 else None,
+                        "root" if i % 7 == 0 else None,
+                    ),
+                )
+                port_id = int(cur.lastrowid or 0)
+                # Add a couple of port_attributes per card so the attr:
+                # token family populates the vocabulary.
+                conn.execute(
+                    "INSERT INTO port_attributes (port_id, attr_kind, attr_value) VALUES (?, ?, ?)",
+                    (port_id, "type", "Creature" if i % 2 == 0 else "Instant"),
+                )
+                conn.execute(
+                    "INSERT INTO port_attributes (port_id, attr_kind, attr_value) VALUES (?, ?, ?)",
+                    (port_id, "subtype", "Goblin" if i % 3 == 0 else "Elf"),
+                )
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Happy-path scenarios
+# ---------------------------------------------------------------------------
+
+
+def test_build_populates_50_rows(tmp_path: Path) -> None:
+    db_path = tmp_path / "synergy.db"
+    _seed_50_card_fixture(db_path)
+
+    rc = build_embeddings.main(["--db", str(db_path)])
+    assert rc == 0
+
+    conn = open_db(db_path)
+    try:
+        count = conn.execute("SELECT COUNT(*) FROM card_embeddings").fetchone()[0]
+        assert count == 50
+    finally:
+        conn.close()
+
+
+def test_build_writes_config_hash_and_per_field_rows(tmp_path: Path) -> None:
+    db_path = tmp_path / "synergy.db"
+    _seed_50_card_fixture(db_path)
+
+    rc = build_embeddings.main(["--db", str(db_path)])
+    assert rc == 0
+
+    conn = open_db(db_path)
+    try:
+        rows = dict(conn.execute("SELECT key, value FROM card_embeddings_config").fetchall())
+        assert "config_hash" in rows
+        assert len(rows["config_hash"]) == 64
+        # Per-field diagnostics present.
+        assert rows["token_format_version"] == "v1"  # noqa: S105 — version tag
+        assert rows["svd_dims"] == "128"
+        assert rows["min_df"] == "2"
+        assert rows["vectorizer_version"] == "1"
+        assert rows["port_signature_version"] == "v1"
+        assert "built_at" in rows
+    finally:
+        conn.close()
+
+
+def test_build_post_state_verifies_current(tmp_path: Path) -> None:
+    db_path = tmp_path / "synergy.db"
+    _seed_50_card_fixture(db_path)
+
+    rc = build_embeddings.main(["--db", str(db_path)])
+    assert rc == 0
+
+    conn = open_db(db_path)
+    try:
+        # No exception = verification passed.
+        inputs = get_embedding_config_inputs()
+        verify_current_or_raise(conn, inputs)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Re-run / determinism / sensitivity
+# ---------------------------------------------------------------------------
+
+
+def test_rerun_overwrites_rows_not_appends(tmp_path: Path) -> None:
+    db_path = tmp_path / "synergy.db"
+    _seed_50_card_fixture(db_path)
+
+    assert build_embeddings.main(["--db", str(db_path)]) == 0
+    assert build_embeddings.main(["--db", str(db_path)]) == 0
+
+    conn = open_db(db_path)
+    try:
+        count = conn.execute("SELECT COUNT(*) FROM card_embeddings").fetchone()[0]
+        assert count == 50
+
+        # Config keys exist exactly once each — no duplicates from the
+        # second run layering on top of the first.
+        keys = [row[0] for row in conn.execute("SELECT key FROM card_embeddings_config").fetchall()]
+        assert len(keys) == len(set(keys))
+    finally:
+        conn.close()
+
+
+def test_rerun_same_inputs_produces_same_config_hash(tmp_path: Path) -> None:
+    db_path = tmp_path / "synergy.db"
+    _seed_50_card_fixture(db_path)
+
+    assert build_embeddings.main(["--db", str(db_path)]) == 0
+    conn = open_db(db_path)
+    try:
+        hash_1 = conn.execute("SELECT value FROM card_embeddings_config WHERE key = 'config_hash'").fetchone()[0]
+    finally:
+        conn.close()
+
+    assert build_embeddings.main(["--db", str(db_path)]) == 0
+    conn = open_db(db_path)
+    try:
+        hash_2 = conn.execute("SELECT value FROM card_embeddings_config WHERE key = 'config_hash'").fetchone()[0]
+    finally:
+        conn.close()
+
+    assert hash_1 == hash_2
+
+
+def test_different_min_df_produces_different_config_hash(tmp_path: Path) -> None:
+    db_path = tmp_path / "synergy.db"
+    _seed_50_card_fixture(db_path)
+
+    assert build_embeddings.main(["--db", str(db_path), "--min-df", "2"]) == 0
+    conn = open_db(db_path)
+    try:
+        hash_min_df_2 = conn.execute("SELECT value FROM card_embeddings_config WHERE key = 'config_hash'").fetchone()[0]
+    finally:
+        conn.close()
+
+    assert build_embeddings.main(["--db", str(db_path), "--min-df", "3"]) == 0
+    conn = open_db(db_path)
+    try:
+        hash_min_df_3 = conn.execute("SELECT value FROM card_embeddings_config WHERE key = 'config_hash'").fetchone()[0]
+    finally:
+        conn.close()
+
+    assert hash_min_df_2 != hash_min_df_3
+
+
+def test_config_hash_matches_computed_from_inputs(tmp_path: Path) -> None:
+    db_path = tmp_path / "synergy.db"
+    _seed_50_card_fixture(db_path)
+
+    assert build_embeddings.main(["--db", str(db_path), "--min-df", "3", "--svd-dims", "64"]) == 0
+
+    expected_inputs = get_embedding_config_inputs()._replace(
+        min_df=3,
+        svd_dims=64,
+    )
+    expected_hash = compute_embedding_hash(expected_inputs)
+
+    conn = open_db(db_path)
+    try:
+        stored = conn.execute("SELECT value FROM card_embeddings_config WHERE key = 'config_hash'").fetchone()[0]
+    finally:
+        conn.close()
+
+    assert stored == expected_hash
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_build_on_small_fixture_db_is_no_op_friendly(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """DB with fewer than 10 cards prints summary without warnings."""
+    db_path = tmp_path / "tiny.db"
+    conn = open_db(db_path)
+    try:
+        with conn:
+            for i in range(3):
+                conn.execute(
+                    "INSERT INTO cards (name, keywords) VALUES (?, ?)",
+                    (f"Tiny_{i}", json.dumps(["Flying"])),
+                )
+                conn.execute(
+                    "INSERT INTO card_ports (card_name, port_type, event_class) VALUES (?, ?, ?)",
+                    (f"Tiny_{i}", "trigger", "ETB"),
+                )
+    finally:
+        conn.close()
+
+    rc = build_embeddings.main(["--db", str(db_path)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "embeddings: built" in out
+    # No "warning" token in the summary path.
+    assert "warning" not in out.lower()
+
+
+def test_build_missing_db_returns_error(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    missing = tmp_path / "does_not_exist.db"
+    rc = build_embeddings.main(["--db", str(missing)])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "does not exist" in err
+
+
+def test_stdout_summary_contains_expected_fields(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    db_path = tmp_path / "synergy.db"
+    _seed_50_card_fixture(db_path)
+
+    rc = build_embeddings.main(["--db", str(db_path)])
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "built 50 vectors" in out
+    assert "x 128 dims" in out
+    assert "vocabulary=" in out
+    assert "config_hash=" in out
+    assert "wall=" in out
+    assert out.rstrip().endswith("s")
+
+
+# ---------------------------------------------------------------------------
+# Subprocess integration test — proves ``__main__`` entry-point works
+# ---------------------------------------------------------------------------
+
+
+def test_help_invocation_succeeds() -> None:
+    """``python scripts/build_embeddings.py --help`` exits 0 with usage text."""
+    result = subprocess.run(  # noqa: S603 — hard-coded interpreter + script path
+        [sys.executable, str(_SCRIPT_PATH), "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "--db" in result.stdout
+    assert "--min-df" in result.stdout
+    assert "--svd-dims" in result.stdout
+
+
+def test_subprocess_invocation_populates_rows(tmp_path: Path) -> None:
+    """End-to-end via subprocess — the standalone CLI contract."""
+    db_path = tmp_path / "synergy.db"
+    _seed_50_card_fixture(db_path)
+
+    result = subprocess.run(  # noqa: S603 — hard-coded interpreter + script path
+        [sys.executable, str(_SCRIPT_PATH), "--db", str(db_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "built 50 vectors" in result.stdout
+
+    conn = open_db(db_path)
+    try:
+        count = conn.execute("SELECT COUNT(*) FROM card_embeddings").fetchone()[0]
+        assert count == 50
+    finally:
+        conn.close()

--- a/tests/embeddings/test_commander_target.py
+++ b/tests/embeddings/test_commander_target.py
@@ -1,0 +1,425 @@
+"""Unit 4 tests — commander target vector + hi-syn cache.
+
+Covers:
+
+* Happy path: single commander + EDHREC hi-syn list composes mean.
+* Happy path: no EDHREC connection — target equals normalized
+  commander vector.
+* Happy path: partner pair — target composes both commanders' own
+  vectors plus both commanders' hi-syn contributions.
+* Happy path: ``hi_syn_limit`` honored — passing a smaller limit
+  fetches only that many rows even when more exist.
+* Edge case: commander absent from ``vectors`` but hi-syn matches
+  present → target computed from hi-syn alone.
+* Edge case: commander present but no hi-syn matches → target is
+  commander vector, normalized.
+* Edge case: empty ``commander_names`` tuple → ``None``.
+* Edge case: all inputs missing → ``None``.
+* Cache semantics: repeat call with same args hits the ``functools``
+  cache; ``clear_cache()`` resets it.
+* Error paths: missing table on EDHREC conn degrades to empty
+  hi-syn; ``hi_syn_limit <= 0`` raises ``ValueError``.
+* Integration: L2-normalized output is unit-length; hand-computed
+  mean matches within 1e-6.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import numpy as np
+import pytest
+
+from mtg_synergy_graph.embeddings import commander_target as ct
+from mtg_synergy_graph.validate import commander_to_slug
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_vector(seed: int, dim: int = 128) -> np.ndarray:
+    """Deterministic L2-normalized float32 vector of a given dim."""
+    rng = np.random.default_rng(seed)
+    vec = rng.standard_normal(dim).astype(np.float32)
+    norm = float(np.linalg.norm(vec))
+    assert norm > 0.0
+    return (vec / norm).astype(np.float32)
+
+
+def _make_edhrec_db(
+    rows: list[tuple[str, str, str, float]],
+) -> sqlite3.Connection:
+    """Build an in-memory ``edhrec_card_synergy`` table.
+
+    Rows are ``(commander_slug, section, card_name, synergy)`` — the
+    shape ``fetch_high_synergy_top_n_ordered`` consumes. Only the
+    ``'High Synergy Cards'`` section is relevant to these tests.
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        """
+        CREATE TABLE edhrec_card_synergy (
+            commander_slug TEXT NOT NULL,
+            section        TEXT NOT NULL,
+            card_name      TEXT NOT NULL,
+            synergy        REAL NOT NULL
+        );
+        """
+    )
+    conn.executemany(
+        "INSERT INTO edhrec_card_synergy(commander_slug, section, card_name, synergy) VALUES (?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+    return conn
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache() -> None:
+    """Reset the module-level ``functools.cache`` before every test.
+
+    The cache retains ``sqlite3.Connection`` objects as keys across
+    tests; clearing before each test prevents a retained reference from
+    keeping a previous test's in-memory DB alive past its scope.
+    """
+    ct.clear_cache()
+    yield
+    ct.clear_cache()
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_golden_set_commander_target_matches_hand_computed_mean() -> None:
+    """With EDHREC hi-syn, target = L2(mean(v_cmdr + hi-syn vectors))."""
+    commander = "Korvold, Fae-Cursed King"
+    slug = commander_to_slug(commander)
+    vectors = {
+        commander: _make_vector(seed=1),
+        "Dockside Extortionist": _make_vector(seed=2),
+        "Mayhem Devil": _make_vector(seed=3),
+    }
+    edhrec_rows = [
+        (slug, "High Synergy Cards", "Dockside Extortionist", 0.9),
+        (slug, "High Synergy Cards", "Mayhem Devil", 0.8),
+    ]
+    edhrec_conn = _make_edhrec_db(edhrec_rows)
+
+    target = ct.build_commander_target_vector((commander,), vectors, edhrec_conn)
+
+    expected = np.mean(
+        np.stack(
+            [
+                vectors[commander],
+                vectors["Dockside Extortionist"],
+                vectors["Mayhem Devil"],
+            ],
+            axis=0,
+        ),
+        axis=0,
+    )
+    expected = expected / np.linalg.norm(expected)
+
+    assert target is not None
+    np.testing.assert_allclose(target, expected, atol=1e-6)
+    # L2 norm ≈ 1.
+    assert float(np.linalg.norm(target)) == pytest.approx(1.0, abs=1e-6)
+
+
+def test_non_golden_set_commander_falls_back_to_commander_vector() -> None:
+    """Without an EDHREC connection, target is L2-normalized commander vector."""
+    commander = "Obscure Partner, Unknown"
+    v = _make_vector(seed=7)
+    vectors = {commander: v}
+
+    target = ct.build_commander_target_vector((commander,), vectors, edhrec_conn=None)
+
+    assert target is not None
+    # v was already unit-norm, so L2-normalize returns v bitwise.
+    np.testing.assert_allclose(target, v, atol=1e-7)
+
+
+def test_partner_pair_composes_both_commanders_and_their_hi_syn() -> None:
+    """Partner pair averages own vectors + both commanders' hi-syn matches."""
+    a_name = "Halana, Kessig Ranger"
+    b_name = "Alena, Kessig Trapper"
+    a_slug = commander_to_slug(a_name)
+    b_slug = commander_to_slug(b_name)
+    vectors = {
+        a_name: _make_vector(seed=11),
+        b_name: _make_vector(seed=12),
+        "Shared Hi Syn": _make_vector(seed=13),
+        "Alena Only Hi Syn": _make_vector(seed=14),
+    }
+    edhrec_rows = [
+        (a_slug, "High Synergy Cards", "Shared Hi Syn", 0.9),
+        (b_slug, "High Synergy Cards", "Shared Hi Syn", 0.9),
+        (b_slug, "High Synergy Cards", "Alena Only Hi Syn", 0.8),
+    ]
+    edhrec_conn = _make_edhrec_db(edhrec_rows)
+
+    target = ct.build_commander_target_vector(
+        (a_name, b_name),
+        vectors,
+        edhrec_conn,
+    )
+
+    # Expected: 4 vectors collected — both commanders + Shared twice +
+    # Alena Only.  Shared counts once per commander query (the plan
+    # spells this out: "each commander's hi-syn cards are all averaged
+    # together", so double-counting when both partners share a hi-syn
+    # is intentional, not a bug).
+    expected = np.mean(
+        np.stack(
+            [
+                vectors[a_name],
+                vectors[b_name],
+                vectors["Shared Hi Syn"],  # from a's query
+                vectors["Shared Hi Syn"],  # from b's query
+                vectors["Alena Only Hi Syn"],
+            ],
+            axis=0,
+        ),
+        axis=0,
+    )
+    expected = expected / np.linalg.norm(expected)
+
+    assert target is not None
+    np.testing.assert_allclose(target, expected, atol=1e-6)
+
+
+def test_hi_syn_limit_is_honored() -> None:
+    """Passing ``hi_syn_limit=2`` fetches only the top-2 hi-syn rows."""
+    commander = "Muldrotha, the Gravetide"
+    slug = commander_to_slug(commander)
+    vectors = {
+        commander: _make_vector(seed=21),
+        "HiSyn 1": _make_vector(seed=22),
+        "HiSyn 2": _make_vector(seed=23),
+        "HiSyn 3": _make_vector(seed=24),
+        "HiSyn 4": _make_vector(seed=25),
+        "HiSyn 5": _make_vector(seed=26),
+    }
+    edhrec_rows = [(slug, "High Synergy Cards", f"HiSyn {i}", 1.0 - i * 0.1) for i in range(1, 6)]
+    edhrec_conn = _make_edhrec_db(edhrec_rows)
+
+    target = ct.build_commander_target_vector(
+        (commander,),
+        vectors,
+        edhrec_conn,
+        hi_syn_limit=2,
+    )
+
+    expected = np.mean(
+        np.stack(
+            [
+                vectors[commander],
+                vectors["HiSyn 1"],
+                vectors["HiSyn 2"],
+            ],
+            axis=0,
+        ),
+        axis=0,
+    )
+    expected = expected / np.linalg.norm(expected)
+
+    assert target is not None
+    np.testing.assert_allclose(target, expected, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — missing vectors / empty inputs
+# ---------------------------------------------------------------------------
+
+
+def test_commander_missing_but_hi_syn_present_uses_hi_syn_alone() -> None:
+    """Commander absent from ``vectors`` still yields a target from hi-syn."""
+    commander = "Day Zero Commander"
+    slug = commander_to_slug(commander)
+    vectors = {
+        "Some Hi Syn Card": _make_vector(seed=31),
+    }
+    edhrec_conn = _make_edhrec_db([(slug, "High Synergy Cards", "Some Hi Syn Card", 0.9)])
+
+    target = ct.build_commander_target_vector((commander,), vectors, edhrec_conn)
+
+    assert target is not None
+    # Only one collected vector, so target ≈ that vector (it was already unit).
+    np.testing.assert_allclose(target, vectors["Some Hi Syn Card"], atol=1e-7)
+
+
+def test_commander_present_but_no_hi_syn_matches_uses_commander_only() -> None:
+    """Hi-syn names that aren't in ``vectors`` are silently skipped."""
+    commander = "Kess, Dissident Mage"
+    slug = commander_to_slug(commander)
+    vectors = {
+        commander: _make_vector(seed=41),
+        # Notably missing: "Mystical Tutor" below.
+    }
+    edhrec_conn = _make_edhrec_db([(slug, "High Synergy Cards", "Mystical Tutor", 0.9)])
+
+    target = ct.build_commander_target_vector((commander,), vectors, edhrec_conn)
+
+    assert target is not None
+    # Target equals normalized commander vector (only collected one).
+    np.testing.assert_allclose(target, vectors[commander], atol=1e-7)
+
+
+def test_no_vectors_at_all_returns_none() -> None:
+    """Neither commander nor hi-syn match → returns ``None``."""
+    commander = "Nonexistent Commander"
+    slug = commander_to_slug(commander)
+    edhrec_conn = _make_edhrec_db([(slug, "High Synergy Cards", "Also Missing Card", 0.9)])
+    vectors: dict[str, np.ndarray] = {}  # nothing populated
+
+    target = ct.build_commander_target_vector((commander,), vectors, edhrec_conn)
+
+    assert target is None
+
+
+def test_empty_commander_names_returns_none() -> None:
+    target = ct.build_commander_target_vector(
+        commander_names=(),
+        vectors={"Any Card": _make_vector(seed=99)},
+        edhrec_conn=None,
+    )
+    assert target is None
+
+
+# ---------------------------------------------------------------------------
+# Cache semantics
+# ---------------------------------------------------------------------------
+
+
+def test_functools_cache_hits_on_repeated_call() -> None:
+    """Calling twice with the same conn/commander/limit hits the cache."""
+    commander = "Korvold, Fae-Cursed King"
+    slug = commander_to_slug(commander)
+    edhrec_conn = _make_edhrec_db([(slug, "High Synergy Cards", "Dockside Extortionist", 0.9)])
+    vectors = {
+        commander: _make_vector(seed=51),
+        "Dockside Extortionist": _make_vector(seed=52),
+    }
+
+    before = ct._fetch_hi_syn_names_cached.cache_info()
+
+    ct.build_commander_target_vector((commander,), vectors, edhrec_conn)
+    after_first = ct._fetch_hi_syn_names_cached.cache_info()
+    assert after_first.misses == before.misses + 1, "first call must miss"
+
+    ct.build_commander_target_vector((commander,), vectors, edhrec_conn)
+    after_second = ct._fetch_hi_syn_names_cached.cache_info()
+    assert after_second.hits == after_first.hits + 1, "second call must hit"
+    assert after_second.misses == after_first.misses, "second call must not miss"
+
+
+def test_clear_cache_resets_cache_info() -> None:
+    commander = "Any, Cached Commander"
+    slug = commander_to_slug(commander)
+    edhrec_conn = _make_edhrec_db([(slug, "High Synergy Cards", "HS", 0.9)])
+    vectors = {commander: _make_vector(seed=61), "HS": _make_vector(seed=62)}
+
+    ct.build_commander_target_vector((commander,), vectors, edhrec_conn)
+    assert ct._fetch_hi_syn_names_cached.cache_info().currsize > 0
+
+    ct.clear_cache()
+    info = ct._fetch_hi_syn_names_cached.cache_info()
+    assert info.hits == 0
+    assert info.misses == 0
+    assert info.currsize == 0
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_missing_table_degrades_to_commander_vector() -> None:
+    """A DB without the table logs at DEBUG and falls back to commander vec."""
+    commander = "Broken DB Commander"
+    vectors = {commander: _make_vector(seed=71)}
+
+    # Connection with no edhrec_card_synergy table at all.
+    broken_conn = sqlite3.connect(":memory:")
+
+    target = ct.build_commander_target_vector(
+        (commander,),
+        vectors,
+        broken_conn,
+    )
+
+    assert target is not None
+    np.testing.assert_allclose(target, vectors[commander], atol=1e-7)
+
+
+def test_hi_syn_limit_zero_raises() -> None:
+    with pytest.raises(ValueError, match="hi_syn_limit must be >= 1"):
+        ct.build_commander_target_vector(
+            ("Any",),
+            {},
+            edhrec_conn=None,
+            hi_syn_limit=0,
+        )
+
+
+def test_hi_syn_limit_negative_raises() -> None:
+    with pytest.raises(ValueError, match="hi_syn_limit must be >= 1"):
+        ct.build_commander_target_vector(
+            ("Any",),
+            {},
+            edhrec_conn=None,
+            hi_syn_limit=-3,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration
+# ---------------------------------------------------------------------------
+
+
+def test_full_pipeline_korvold_10_hi_syn_target_is_unit_length() -> None:
+    """End-to-end: 10 hi-syn rows + own vector → unit-length deterministic target."""
+    commander = "Korvold, Fae-Cursed King"
+    slug = commander_to_slug(commander)
+    hi_syn_names = [f"HS Card {i}" for i in range(1, 11)]
+    vectors = {commander: _make_vector(seed=100)}
+    vectors.update({name: _make_vector(seed=200 + i) for i, name in enumerate(hi_syn_names)})
+    rows = [(slug, "High Synergy Cards", name, 1.0 - i * 0.05) for i, name in enumerate(hi_syn_names)]
+    edhrec_conn = _make_edhrec_db(rows)
+
+    target_a = ct.build_commander_target_vector((commander,), vectors, edhrec_conn, hi_syn_limit=10)
+    # Clear cache and recompute — determinism check.
+    ct.clear_cache()
+    target_b = ct.build_commander_target_vector((commander,), vectors, edhrec_conn, hi_syn_limit=10)
+
+    assert target_a is not None and target_b is not None
+    np.testing.assert_array_equal(target_a, target_b)
+    assert float(np.linalg.norm(target_a)) == pytest.approx(1.0, abs=1e-6)
+
+
+def test_commander_name_case_sensitivity_is_deterministic() -> None:
+    """Cache is keyed by exact commander name string.
+
+    The cache does not normalize names — calling with different cases
+    produces independent cache entries. Tests confirm both calls land
+    (same fetch path, different slugs).
+    """
+    a = "Korvold, Fae-Cursed King"
+    b = "korvold, fae-cursed king"
+    vectors = {a: _make_vector(seed=301), b: _make_vector(seed=302)}
+    # Both slugs happen to be identical, because commander_to_slug
+    # lowercases; the underlying SQL will return the same rows. But
+    # from the cache's perspective, different string keys = different
+    # entries.
+    edhrec_conn = _make_edhrec_db([(commander_to_slug(a), "High Synergy Cards", "Side Card", 0.9)])
+    vectors["Side Card"] = _make_vector(seed=303)
+
+    ct.build_commander_target_vector((a,), vectors, edhrec_conn)
+    ct.build_commander_target_vector((b,), vectors, edhrec_conn)
+
+    info = ct._fetch_hi_syn_names_cached.cache_info()
+    # Two distinct commander-name keys → two misses.
+    assert info.misses == 2

--- a/tests/embeddings/test_config.py
+++ b/tests/embeddings/test_config.py
@@ -1,0 +1,192 @@
+"""Unit 2 tests — EmbeddingConfigInputs + hash + verify_current_or_raise.
+
+Mirrors ``tests/test_forge_oracle_config_hash.py`` for the embedding
+pipeline. The meta-principle carried over from
+``docs/solutions/best-practices/offline-oracle-hash-pattern-2026-04-23.md``
+is: mechanically enforce the subsystem invariant via a hash that
+refuses stale comparisons.
+
+Covers:
+
+* ``compute_embedding_hash`` — determinism across repeated calls,
+  sensitivity to each field, stability across positional vs kwargs
+  construction.
+* ``verify_current_or_raise`` — passes on match, raises Stale on
+  mismatch (with rebuild-command text), raises Missing on absent row.
+* ``get_embedding_config_inputs`` — keeps ``token_format_version`` in
+  sync with ``embeddings.vectorizer.TOKEN_FORMAT_VERSION``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from mtg_synergy_graph.embeddings import config as emb_config
+from mtg_synergy_graph.embeddings import vectorizer as emb_vectorizer
+
+
+def _make_inputs(**overrides: object) -> emb_config.EmbeddingConfigInputs:
+    """Helper: build a valid ``EmbeddingConfigInputs`` with defaults."""
+    base: dict[str, object] = {
+        "token_format_version": "v1",
+        "svd_dims": 128,
+        "min_df": 2,
+        "vectorizer_version": 1,
+        "port_signature_version": "v1",
+    }
+    base.update(overrides)
+    return emb_config.EmbeddingConfigInputs(**base)  # type: ignore[arg-type]
+
+
+def _make_kv_db(tmp_path: Path) -> sqlite3.Connection:
+    """Open an in-memory-like DB with the minimal KV table."""
+    db_path = tmp_path / "emb.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript("CREATE TABLE card_embeddings_config (key TEXT PRIMARY KEY, value TEXT NOT NULL);")
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# compute_embedding_hash — determinism + sensitivity
+# ---------------------------------------------------------------------------
+
+
+def test_hash_is_deterministic_across_calls() -> None:
+    inputs = _make_inputs()
+    h1 = emb_config.compute_embedding_hash(inputs)
+    h2 = emb_config.compute_embedding_hash(inputs)
+    assert h1 == h2
+    # SHA-256 hex digest is 64 chars.
+    assert len(h1) == 64
+
+
+def test_hash_flips_when_token_format_version_changes() -> None:
+    base = _make_inputs()
+    bumped = base._replace(token_format_version="v2")  # noqa: S106 — version tag, not a secret
+    assert emb_config.compute_embedding_hash(base) != emb_config.compute_embedding_hash(bumped)
+
+
+def test_hash_flips_when_svd_dims_changes() -> None:
+    base = _make_inputs()
+    bumped = base._replace(svd_dims=64)
+    assert emb_config.compute_embedding_hash(base) != emb_config.compute_embedding_hash(bumped)
+
+
+def test_hash_flips_when_min_df_changes() -> None:
+    base = _make_inputs()
+    bumped = base._replace(min_df=3)
+    assert emb_config.compute_embedding_hash(base) != emb_config.compute_embedding_hash(bumped)
+
+
+def test_hash_flips_when_vectorizer_version_changes() -> None:
+    base = _make_inputs()
+    bumped = base._replace(vectorizer_version=2)
+    assert emb_config.compute_embedding_hash(base) != emb_config.compute_embedding_hash(bumped)
+
+
+def test_hash_flips_when_port_signature_version_changes() -> None:
+    base = _make_inputs()
+    bumped = base._replace(port_signature_version="v2")
+    assert emb_config.compute_embedding_hash(base) != emb_config.compute_embedding_hash(bumped)
+
+
+def test_hash_stable_across_positional_vs_kwargs_construction() -> None:
+    """Sorting ``_asdict()`` items guarantees field-order-independence.
+
+    Construct the tuple two ways — positional and kwargs — and verify
+    both produce the same hash. This locks in the sort-before-hash
+    invariant that protects against accidental field-order changes in
+    the NamedTuple definition.
+    """
+    positional = emb_config.EmbeddingConfigInputs(
+        "v1",  # token_format_version
+        128,  # svd_dims
+        2,  # min_df
+        1,  # vectorizer_version
+        "v1",  # port_signature_version
+    )
+    kwargs = emb_config.EmbeddingConfigInputs(
+        port_signature_version="v1",
+        vectorizer_version=1,
+        min_df=2,
+        svd_dims=128,
+        token_format_version="v1",  # noqa: S106 — version tag, not a secret
+    )
+    assert emb_config.compute_embedding_hash(positional) == emb_config.compute_embedding_hash(kwargs)
+
+
+# ---------------------------------------------------------------------------
+# verify_current_or_raise — refuse-to-run contract
+# ---------------------------------------------------------------------------
+
+
+def test_verify_passes_when_hash_matches(tmp_path: Path) -> None:
+    conn = _make_kv_db(tmp_path)
+    try:
+        inputs = _make_inputs()
+        expected = emb_config.compute_embedding_hash(inputs)
+        conn.execute(
+            "INSERT INTO card_embeddings_config(key, value) VALUES ('config_hash', ?)",
+            (expected,),
+        )
+        conn.commit()
+        # Must not raise.
+        emb_config.verify_current_or_raise(conn, inputs)
+    finally:
+        conn.close()
+
+
+def test_verify_raises_stale_on_hash_mismatch(tmp_path: Path) -> None:
+    conn = _make_kv_db(tmp_path)
+    try:
+        conn.execute("INSERT INTO card_embeddings_config(key, value) VALUES ('config_hash', 'stale_value_xxxx')")
+        conn.commit()
+        inputs = _make_inputs()
+        with pytest.raises(emb_config.EmbeddingConfigStaleError) as exc_info:
+            emb_config.verify_current_or_raise(conn, inputs)
+        message = str(exc_info.value)
+        # Message must include both stored and current hashes + rebuild cmd.
+        assert "stale_value" in message
+        current_hash = emb_config.compute_embedding_hash(inputs)
+        assert current_hash[:12] in message
+        assert "uv run scripts/build_embeddings.py" in message
+    finally:
+        conn.close()
+
+
+def test_verify_raises_missing_when_hash_row_absent(tmp_path: Path) -> None:
+    conn = _make_kv_db(tmp_path)
+    try:
+        inputs = _make_inputs()
+        with pytest.raises(emb_config.EmbeddingConfigMissingError):
+            emb_config.verify_current_or_raise(conn, inputs)
+    finally:
+        conn.close()
+
+
+def test_stale_and_missing_inherit_from_common_base() -> None:
+    """Catching the base class subsumes both failure modes.
+
+    Inference-path callers rely on this to degrade gracefully without
+    type-matching every subclass.
+    """
+    assert issubclass(emb_config.EmbeddingConfigStaleError, emb_config.EmbeddingConfigError)
+    assert issubclass(emb_config.EmbeddingConfigMissingError, emb_config.EmbeddingConfigError)
+
+
+# ---------------------------------------------------------------------------
+# get_embedding_config_inputs — ambient-config helper
+# ---------------------------------------------------------------------------
+
+
+def test_get_embedding_config_inputs_matches_vectorizer_version() -> None:
+    inputs = emb_config.get_embedding_config_inputs()
+    assert inputs.token_format_version == emb_vectorizer.TOKEN_FORMAT_VERSION
+    # Defaults from plan D1 + Unit 1.
+    assert inputs.svd_dims == 128
+    assert inputs.min_df == 2
+    assert inputs.vectorizer_version == 1
+    assert inputs.port_signature_version == "v1"

--- a/tests/embeddings/test_contribution.py
+++ b/tests/embeddings/test_contribution.py
@@ -1,0 +1,437 @@
+"""Unit 5 tests — inference-path reader + graceful-fallback contract.
+
+Covers the ``embedding_contribution`` pure-function contract and the
+``load_card_embeddings_verified`` wrapper's failure-mode taxonomy:
+
+* Flag gating — default ``False`` always returns ``0.0``; only when
+  toggled ON do the downstream computations run.
+* Happy paths — cosine * decay * w_emb math with known inputs.
+* Short-circuit edge cases — ``v_cmdr is None`` / candidate missing
+  from vectors → ``0.0``.
+* Exponential decay — N_rules≥large → contribution dampens toward
+  zero (no discontinuity).
+* Verified loader — config-hash match returns vectors; missing hash /
+  stale hash / missing table / DB error → ``{}`` + warning, never
+  raises.
+* Integration — end-to-end wiring from populated DB through verified
+  load → commander target → contribution.
+
+Plan: docs/plans/2026-04-23-003-feat-content-embeddings-fallback-plan.md Unit 5.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import sqlite3
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from mtg_synergy_graph.embeddings import config as emb_config
+from mtg_synergy_graph.embeddings import contribution as emb_contribution
+from mtg_synergy_graph.embeddings import store as emb_store
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_unit_vector(seed: int, dim: int = 128) -> np.ndarray:
+    """Deterministic L2-normalized float32 vector of a given dim."""
+    rng = np.random.default_rng(seed)
+    vec = rng.standard_normal(dim).astype(np.float32)
+    norm = float(np.linalg.norm(vec))
+    assert norm > 0.0
+    return (vec / norm).astype(np.float32)
+
+
+def _make_parallel_pair(seed: int, cosine: float, dim: int = 128) -> tuple[np.ndarray, np.ndarray]:
+    """Return two L2-unit vectors whose dot product equals ``cosine``.
+
+    Constructed by mixing a shared direction with an orthogonal
+    correction — exact cosine (within float32 eps), no Gram-Schmidt
+    surprises.
+    """
+    rng = np.random.default_rng(seed)
+    base = rng.standard_normal(dim).astype(np.float32)
+    base /= np.linalg.norm(base)
+
+    other = rng.standard_normal(dim).astype(np.float32)
+    # Remove the component of other along base.
+    other -= float(other @ base) * base
+    other /= np.linalg.norm(other)
+    # Now base and other are orthonormal. Build target = c*base + sqrt(1-c^2)*other.
+    target = cosine * base + math.sqrt(1.0 - cosine * cosine) * other
+    target = target.astype(np.float32)
+    target /= np.linalg.norm(target)
+    return base, target
+
+
+def _make_store_db(tmp_path: Path) -> sqlite3.Connection:
+    """Open a connection with only the two embedding tables applied."""
+    db_path = tmp_path / "emb.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE card_embeddings (
+            card_name          TEXT PRIMARY KEY,
+            vector             BLOB NOT NULL,
+            vectorizer_version INTEGER NOT NULL,
+            built_at           TEXT NOT NULL
+        );
+        CREATE TABLE card_embeddings_config (
+            key   TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        """
+    )
+    return conn
+
+
+def _make_inputs_matching_current() -> emb_config.EmbeddingConfigInputs:
+    """Build inputs that match ``get_embedding_config_inputs()`` exactly.
+
+    This ensures ``verify_current_or_raise`` passes post-write.
+    """
+    return emb_config.get_embedding_config_inputs()
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_contribution_flag_on_w_zero_returns_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Flag on + w_emb=0.0 → 0.0 regardless of cosine/decay.
+
+    Scales the flip knob independently of the gate — this test guards
+    the audit sweep's ability to land ``_ENABLE_EMBEDDING_CONTRIBUTION
+    = True`` with ``w_emb = 0.0`` as an identity-preserving step.
+    """
+    monkeypatch.setattr(emb_contribution, "_ENABLE_EMBEDDING_CONTRIBUTION", True)
+    monkeypatch.setattr(emb_contribution, "_EMBEDDING_W", 0.0)
+    monkeypatch.setattr(emb_contribution, "_EMBEDDING_K", 0.8)
+
+    v_cmdr = _make_unit_vector(seed=1)
+    v_cand = _make_unit_vector(seed=2)
+
+    result = emb_contribution.embedding_contribution(
+        candidate_name="X",
+        n_rules=0,
+        v_cmdr=v_cmdr,
+        vectors={"X": v_cand},
+    )
+
+    assert result == 0.0
+
+
+def test_contribution_flag_on_n_rules_zero_returns_w_times_cosine(monkeypatch: pytest.MonkeyPatch) -> None:
+    """N_rules=0 → decay = 1.0 → contribution = w_emb * cosine."""
+    monkeypatch.setattr(emb_contribution, "_ENABLE_EMBEDDING_CONTRIBUTION", True)
+    monkeypatch.setattr(emb_contribution, "_EMBEDDING_W", 0.5)
+    monkeypatch.setattr(emb_contribution, "_EMBEDDING_K", 0.8)
+
+    v_cmdr, v_cand = _make_parallel_pair(seed=3, cosine=0.5)
+
+    result = emb_contribution.embedding_contribution(
+        candidate_name="X",
+        n_rules=0,
+        v_cmdr=v_cmdr,
+        vectors={"X": v_cand},
+    )
+
+    # decay = exp(0) = 1.0; result = 0.5 * 1.0 * 0.5 = 0.25.
+    assert result == pytest.approx(0.25, abs=1e-5)
+
+
+def test_contribution_flag_on_n_rules_five_dampened(monkeypatch: pytest.MonkeyPatch) -> None:
+    """N_rules=5 → decay ~ exp(-4) → contribution dampened ~50×."""
+    monkeypatch.setattr(emb_contribution, "_ENABLE_EMBEDDING_CONTRIBUTION", True)
+    monkeypatch.setattr(emb_contribution, "_EMBEDDING_W", 0.5)
+    monkeypatch.setattr(emb_contribution, "_EMBEDDING_K", 0.8)
+
+    v_cmdr, v_cand = _make_parallel_pair(seed=4, cosine=0.5)
+
+    result = emb_contribution.embedding_contribution(
+        candidate_name="X",
+        n_rules=5,
+        v_cmdr=v_cmdr,
+        vectors={"X": v_cand},
+    )
+
+    expected = 0.5 * math.exp(-0.8 * 5) * 0.5
+    assert result == pytest.approx(expected, abs=1e-5)
+    # Sanity: well below the N_rules=0 contribution.
+    assert abs(result) < 0.01
+
+
+def test_contribution_default_flag_off_returns_zero() -> None:
+    """Module default is flag=False, w=0.0 → always returns 0.0.
+
+    No monkeypatching — exercise the shipped module state directly to
+    prove the safety contract of Unit 5 (the function is shippable in
+    isolation; all short-circuit paths return 0.0 until Unit 7's
+    audit-gated flip).
+    """
+    assert emb_contribution._ENABLE_EMBEDDING_CONTRIBUTION is False
+    v_cmdr = _make_unit_vector(seed=5)
+    v_cand = _make_unit_vector(seed=6)
+
+    result = emb_contribution.embedding_contribution(
+        candidate_name="X",
+        n_rules=0,
+        v_cmdr=v_cmdr,
+        vectors={"X": v_cand},
+    )
+
+    assert result == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Short-circuit edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_contribution_v_cmdr_none_returns_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """v_cmdr=None (no golden-set commander) → 0.0."""
+    monkeypatch.setattr(emb_contribution, "_ENABLE_EMBEDDING_CONTRIBUTION", True)
+    monkeypatch.setattr(emb_contribution, "_EMBEDDING_W", 0.5)
+    monkeypatch.setattr(emb_contribution, "_EMBEDDING_K", 0.8)
+
+    v_cand = _make_unit_vector(seed=7)
+    result = emb_contribution.embedding_contribution(
+        candidate_name="X",
+        n_rules=2,
+        v_cmdr=None,
+        vectors={"X": v_cand},
+    )
+    assert result == 0.0
+
+
+def test_contribution_candidate_not_in_vectors_returns_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Candidate name not in vectors dict → 0.0."""
+    monkeypatch.setattr(emb_contribution, "_ENABLE_EMBEDDING_CONTRIBUTION", True)
+    monkeypatch.setattr(emb_contribution, "_EMBEDDING_W", 0.5)
+    monkeypatch.setattr(emb_contribution, "_EMBEDDING_K", 0.8)
+
+    v_cmdr = _make_unit_vector(seed=8)
+    result = emb_contribution.embedding_contribution(
+        candidate_name="X",
+        n_rules=0,
+        v_cmdr=v_cmdr,
+        vectors={},
+    )
+    assert result == 0.0
+
+
+def test_contribution_n_rules_large_dampens_to_near_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """N_rules=20 → exp(-0.8*20) ~ 1.1e-7 → near-zero contribution."""
+    monkeypatch.setattr(emb_contribution, "_ENABLE_EMBEDDING_CONTRIBUTION", True)
+    monkeypatch.setattr(emb_contribution, "_EMBEDDING_W", 1.0)
+    monkeypatch.setattr(emb_contribution, "_EMBEDDING_K", 0.8)
+
+    v_cmdr, v_cand = _make_parallel_pair(seed=9, cosine=1.0)
+
+    result = emb_contribution.embedding_contribution(
+        candidate_name="X",
+        n_rules=20,
+        v_cmdr=v_cmdr,
+        vectors={"X": v_cand},
+    )
+    assert abs(result) < 1e-5
+
+
+# ---------------------------------------------------------------------------
+# load_card_embeddings_verified tests
+# ---------------------------------------------------------------------------
+
+
+def test_load_verified_happy_path(tmp_path: Path) -> None:
+    """Populated DB with matching config_hash → full vectors dict."""
+    conn = _make_store_db(tmp_path)
+    try:
+        inputs = _make_inputs_matching_current()
+        vectors = {
+            "A": _make_unit_vector(seed=10),
+            "B": _make_unit_vector(seed=11),
+        }
+        emb_store.write_vectors(conn, vectors, inputs)
+
+        loaded = emb_contribution.load_card_embeddings_verified(conn)
+
+        assert set(loaded.keys()) == {"A", "B"}
+        np.testing.assert_array_equal(loaded["A"], vectors["A"])
+        np.testing.assert_array_equal(loaded["B"], vectors["B"])
+    finally:
+        conn.close()
+
+
+def test_load_verified_missing_config_returns_empty(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """DB has vectors but no config_hash row → {} + warning."""
+    conn = _make_store_db(tmp_path)
+    try:
+        # Insert vectors directly without touching card_embeddings_config.
+        valid_vec = _make_unit_vector(seed=12)
+        conn.execute(
+            "INSERT INTO card_embeddings(card_name, vector, vectorizer_version, built_at) VALUES (?, ?, ?, ?)",
+            ("A", valid_vec.tobytes(), 1, "2026-04-23T00:00:00+00:00"),
+        )
+        conn.commit()
+
+        with caplog.at_level(logging.WARNING, logger="mtg_synergy_graph.embeddings.contribution"):
+            result = emb_contribution.load_card_embeddings_verified(conn)
+
+        assert result == {}
+        # Warning message mentions the config KV table / rebuild hint.
+        combined = " ".join(rec.getMessage() for rec in caplog.records)
+        assert "config_hash" in combined or "card_embeddings_config" in combined
+    finally:
+        conn.close()
+
+
+def test_load_verified_stale_config_returns_empty(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """DB has vectors + wrong config_hash → {} + warning."""
+    conn = _make_store_db(tmp_path)
+    try:
+        # Write with one set of inputs, then corrupt the stored hash so
+        # the next verify treats it as stale.
+        inputs = _make_inputs_matching_current()
+        emb_store.write_vectors(conn, {"A": _make_unit_vector(seed=13)}, inputs)
+
+        conn.execute("UPDATE card_embeddings_config SET value = 'not_the_real_hash' WHERE key = 'config_hash'")
+        conn.commit()
+
+        with caplog.at_level(logging.WARNING, logger="mtg_synergy_graph.embeddings.contribution"):
+            result = emb_contribution.load_card_embeddings_verified(conn)
+
+        assert result == {}
+        # Warning includes hash truncation and / or rebuild command.
+        combined = " ".join(rec.getMessage() for rec in caplog.records)
+        assert ("not_the_real" in combined) or ("build_embeddings" in combined) or ("Rebuild" in combined)
+    finally:
+        conn.close()
+
+
+def test_load_verified_missing_table_returns_empty(tmp_path: Path) -> None:
+    """DB without card_embeddings table → {} (already handled by store)."""
+    db_path = tmp_path / "bare.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        result = emb_contribution.load_card_embeddings_verified(conn)
+        assert result == {}
+    finally:
+        conn.close()
+
+
+def test_load_verified_never_raises_on_db_error(tmp_path: Path) -> None:
+    """Pathological DB (closed connection) → {} with no exception escaping."""
+    conn = _make_store_db(tmp_path)
+    # Write + commit some data so the store sees rows, then close the
+    # connection to induce DatabaseError on subsequent reads.
+    emb_store.write_vectors(
+        conn,
+        {"A": _make_unit_vector(seed=14)},
+        _make_inputs_matching_current(),
+    )
+    conn.close()
+
+    # load_card_embeddings_verified on a closed connection must not
+    # raise — graceful degradation is the whole contract.
+    result = emb_contribution.load_card_embeddings_verified(conn)
+    assert result == {}
+
+
+def test_load_verified_database_error_on_verify_returns_empty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """sqlite3.DatabaseError raised by verify_current_or_raise → {} + warning.
+
+    Exercises the defensive catch in ``load_card_embeddings_verified``
+    — the store happy-path returns vectors, then verify trips a
+    ``DatabaseError`` (simulated via monkeypatch) and must degrade.
+    """
+    conn = _make_store_db(tmp_path)
+    try:
+        emb_store.write_vectors(
+            conn,
+            {"A": _make_unit_vector(seed=15)},
+            _make_inputs_matching_current(),
+        )
+
+        def exploding_verify(*_args: object, **_kwargs: object) -> None:
+            raise sqlite3.DatabaseError("simulated verify DB error")
+
+        monkeypatch.setattr(
+            "mtg_synergy_graph.embeddings.contribution.emb_config.verify_current_or_raise",
+            exploding_verify,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="mtg_synergy_graph.embeddings.contribution"):
+            result = emb_contribution.load_card_embeddings_verified(conn)
+
+        assert result == {}
+        combined = " ".join(rec.getMessage() for rec in caplog.records)
+        assert "simulated verify DB error" in combined
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Integration
+# ---------------------------------------------------------------------------
+
+
+def test_contribution_end_to_end(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Populated DB → verified load → commander target → contribution (flag ON)."""
+    from mtg_synergy_graph.embeddings import commander_target as ct
+
+    monkeypatch.setattr(emb_contribution, "_ENABLE_EMBEDDING_CONTRIBUTION", True)
+    monkeypatch.setattr(emb_contribution, "_EMBEDDING_W", 0.5)
+    monkeypatch.setattr(emb_contribution, "_EMBEDDING_K", 0.8)
+
+    conn = _make_store_db(tmp_path)
+    try:
+        inputs = _make_inputs_matching_current()
+        commander = "Korvold, Fae-Cursed King"
+        candidate = "Dockside Extortionist"
+        vectors_on_disk = {
+            commander: _make_unit_vector(seed=20),
+            candidate: _make_unit_vector(seed=21),
+            "Unrelated Card": _make_unit_vector(seed=22),
+        }
+        emb_store.write_vectors(conn, vectors_on_disk, inputs)
+
+        # Verified load.
+        vectors = emb_contribution.load_card_embeddings_verified(conn)
+        assert commander in vectors
+        assert candidate in vectors
+
+        # Commander target without EDHREC conn — falls back to cmdr vec.
+        ct.clear_cache()
+        v_cmdr = ct.build_commander_target_vector(
+            (commander,),
+            vectors,
+            edhrec_conn=None,
+        )
+        assert v_cmdr is not None
+
+        result = emb_contribution.embedding_contribution(
+            candidate_name=candidate,
+            n_rules=2,
+            v_cmdr=v_cmdr,
+            vectors=vectors,
+        )
+
+        # Expected shape: w_emb * exp(-k*n) * cosine(v_cand, v_cmdr).
+        # With L2-normalized random vectors, cosine is bounded in [-1, 1];
+        # the final contribution is in [-0.5 * decay, 0.5 * decay].
+        decay = math.exp(-0.8 * 2)
+        assert -0.5 * decay <= result <= 0.5 * decay
+        # Not exactly zero (independent random seeds → nonzero cosine).
+        assert result != 0.0
+    finally:
+        conn.close()

--- a/tests/embeddings/test_dedup.py
+++ b/tests/embeddings/test_dedup.py
@@ -1,0 +1,254 @@
+"""Unit 6 (plan 2026-04-23-003) — embedding dedup pure-logic tests.
+
+Covers:
+
+* Activation-set grouping, ``min_activation`` filter, ``threshold``
+  override.
+* Numeric correctness: identical activation sets → cosine ≈ 1;
+  orthogonal sets → cosine ≈ 0; partial overlap → intermediate.
+* Edge cases: missing vectors, empty input, single rule.
+* Ranking: output is sorted by cosine desc with lexicographic
+  tiebreak.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+import pytest
+
+from mtg_synergy_graph.embeddings.dedup import DedupPair, compute_embedding_dedup
+
+
+def _unit_vector(*components: float, dim: int = 128) -> np.ndarray:
+    """Build a deterministic L2-normalized float32 vector for tests.
+
+    The non-zero components are placed at the first ``len(components)``
+    positions; remaining dims are zero. ``_unit_vector(1.0)`` gives
+    ``e_0``; ``_unit_vector(0.0, 1.0)`` gives ``e_1``; etc. Callers
+    can use this to construct trivially-orthogonal or trivially-
+    parallel vectors without random noise.
+    """
+    vec = np.zeros(dim, dtype=np.float32)
+    for i, c in enumerate(components):
+        vec[i] = c
+    norm = float(np.linalg.norm(vec))
+    if norm == 0.0:
+        return vec
+    return (vec / norm).astype(np.float32)
+
+
+def _tensor_rows(activations: dict[str, Sequence[str]]) -> list[tuple[str, str, str, float]]:
+    """Shape ``{rule_id: [candidate, ...]}`` into tensor-row tuples."""
+    rows: list[tuple[str, str, str, float]] = []
+    for rule_id, cands in activations.items():
+        for cand in cands:
+            # Commander name is unused by the dedup algorithm; any
+            # stable string is fine. Contribution must be positive
+            # since the handler filters on ``> 0`` upstream — use 1.0.
+            rows.append(("CmdrA", cand, rule_id, 1.0))
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_identical_activation_sets_produce_cosine_one() -> None:
+    """Two rules with the same activation cards → cosine ≈ 1 → one pair."""
+    cards = [f"c{i}" for i in range(25)]
+    vectors = {c: _unit_vector(1.0, 0.0) for c in cards}
+    rows = _tensor_rows({"rule_a": cards, "rule_b": cards})
+
+    pairs = compute_embedding_dedup(rows, vectors, threshold=0.95, min_activation=5)
+
+    assert len(pairs) == 1
+    assert pairs[0].rule_a == "rule_a"
+    assert pairs[0].rule_b == "rule_b"
+    assert pairs[0].cosine == pytest.approx(1.0, rel=1e-6)
+    assert pairs[0].activation_a_size == 25
+    assert pairs[0].activation_b_size == 25
+
+
+def test_orthogonal_activation_sets_do_not_flag() -> None:
+    """Two rules with disjoint cards mapped to orthogonal unit vectors →
+    cosine ≈ 0 → not flagged."""
+    cards_a = [f"a{i}" for i in range(25)]
+    cards_b = [f"b{i}" for i in range(25)]
+    vectors = {**{c: _unit_vector(1.0, 0.0) for c in cards_a}, **{c: _unit_vector(0.0, 1.0) for c in cards_b}}
+    rows = _tensor_rows({"rule_a": cards_a, "rule_b": cards_b})
+
+    pairs = compute_embedding_dedup(rows, vectors, threshold=0.5, min_activation=5)
+    assert pairs == []
+
+
+def test_overlapping_sets_produce_cosine_below_one() -> None:
+    """80% overlap → high cosine but strictly below 1.0."""
+    # Rule A's activation: cards 0..24 (all on direction e_0).
+    # Rule B's activation: cards 5..24 (same direction) + 25..29 (orthogonal).
+    # Both mean vectors lean heavily on e_0 since 20/25 overlap, so
+    # cosine should be high but < 1.
+    e0_cards = [f"e0_{i}" for i in range(25)]
+    orth_cards = [f"orth_{i}" for i in range(5)]
+    vectors = {**{c: _unit_vector(1.0, 0.0) for c in e0_cards}, **{c: _unit_vector(0.0, 1.0) for c in orth_cards}}
+    rows = _tensor_rows({"rule_a": e0_cards, "rule_b": e0_cards[5:] + orth_cards})
+
+    pairs = compute_embedding_dedup(rows, vectors, threshold=0.5, min_activation=5)
+    assert len(pairs) == 1
+    assert 0.5 < pairs[0].cosine < 1.0
+
+
+# ---------------------------------------------------------------------------
+# min_activation threshold
+# ---------------------------------------------------------------------------
+
+
+def test_min_activation_drops_tiny_activation_sets() -> None:
+    """A rule with 2 cards is dropped when ``min_activation=3``."""
+    vectors = {c: _unit_vector(1.0, 0.0) for c in ("a", "b", "c", "d")}
+    rows = _tensor_rows({"big_rule": ["a", "b", "c", "d"], "tiny_rule": ["a", "b"]})
+
+    pairs = compute_embedding_dedup(rows, vectors, threshold=0.5, min_activation=3)
+    # ``tiny_rule`` is dropped → only ``big_rule`` remains → no pair
+    # possible (need ≥2 rules for a pair).
+    assert pairs == []
+
+
+def test_min_activation_high_prunes_all() -> None:
+    """A very high ``min_activation`` prunes every rule → empty output."""
+    vectors = {c: _unit_vector(1.0, 0.0) for c in ("a", "b", "c")}
+    rows = _tensor_rows({"r1": ["a", "b", "c"], "r2": ["a", "b", "c"]})
+
+    pairs = compute_embedding_dedup(rows, vectors, threshold=0.5, min_activation=100)
+    assert pairs == []
+
+
+# ---------------------------------------------------------------------------
+# threshold override
+# ---------------------------------------------------------------------------
+
+
+def test_threshold_override_lower_flags_pair() -> None:
+    """At threshold=0.5 a borderline pair flags; at 0.95 it does not."""
+    # Both rules have 5 cards on direction e_0; rule_b adds 5 on e_1.
+    # Mean cosine comes out around 0.707 → flagged at 0.5, not at 0.95.
+    e0_cards = [f"e0_{i}" for i in range(5)]
+    e1_cards = [f"e1_{i}" for i in range(5)]
+    vectors = {**{c: _unit_vector(1.0, 0.0) for c in e0_cards}, **{c: _unit_vector(0.0, 1.0) for c in e1_cards}}
+    rows = _tensor_rows({"rule_a": e0_cards, "rule_b": e0_cards + e1_cards})
+
+    pairs_loose = compute_embedding_dedup(rows, vectors, threshold=0.5, min_activation=3)
+    pairs_strict = compute_embedding_dedup(rows, vectors, threshold=0.95, min_activation=3)
+
+    assert len(pairs_loose) == 1
+    assert pairs_strict == []
+
+
+# ---------------------------------------------------------------------------
+# Missing vectors / degenerate inputs
+# ---------------------------------------------------------------------------
+
+
+def test_rule_with_no_vector_hits_is_silently_excluded() -> None:
+    """Rule whose cards aren't in ``vectors`` at all → excluded; no KeyError."""
+    vectors = {c: _unit_vector(1.0, 0.0) for c in ("a", "b", "c")}
+    rows = _tensor_rows(
+        {
+            "known_rule": ["a", "b", "c"],
+            "ghost_rule": ["missing_1", "missing_2", "missing_3"],
+        }
+    )
+
+    # Should not raise KeyError; only known_rule makes it through but
+    # needs a partner so no pairs. Use min_activation=3 so both rules
+    # clear the activation floor.
+    pairs = compute_embedding_dedup(rows, vectors, threshold=0.5, min_activation=3)
+    assert pairs == []
+
+
+def test_empty_tensor_rows_returns_empty_list() -> None:
+    """No rows → no pairs, no errors."""
+    vectors = {"a": _unit_vector(1.0)}
+    pairs = compute_embedding_dedup([], vectors, threshold=0.5, min_activation=1)
+    assert pairs == []
+
+
+def test_single_rule_returns_empty_list() -> None:
+    """One rule → no possible pair → empty output (no single-rule self-pair)."""
+    cards = ["a", "b", "c"]
+    vectors = {c: _unit_vector(1.0) for c in cards}
+    rows = _tensor_rows({"only_rule": cards})
+
+    pairs = compute_embedding_dedup(rows, vectors, threshold=0.5, min_activation=1)
+    assert pairs == []
+
+
+# ---------------------------------------------------------------------------
+# Ranking / sort order
+# ---------------------------------------------------------------------------
+
+
+def test_output_sorted_by_cosine_descending_with_tiebreak() -> None:
+    """5 rules with known pairwise cosines render in descending-cosine order."""
+    # Build five rules with 5 cards each, all unit vectors along e_0 so
+    # every pair has cosine 1.0 — deterministic tiebreak ordering
+    # exercises the ``(rule_a, rule_b)`` lexicographic secondary key.
+    vectors: dict[str, np.ndarray] = {}
+    activations: dict[str, list[str]] = {}
+    for rule_letter in "abcde":
+        cards = [f"{rule_letter}_{i}" for i in range(5)]
+        for c in cards:
+            vectors[c] = _unit_vector(1.0)
+        activations[f"rule_{rule_letter}"] = cards
+
+    pairs = compute_embedding_dedup(_tensor_rows(activations), vectors, threshold=0.5, min_activation=3)
+
+    # C(5,2) = 10 pairs, all cosine 1.0.
+    assert len(pairs) == 10
+    # All cosines equal → sort should be lexicographic on rule names.
+    rendered_pairs = [(p.rule_a, p.rule_b) for p in pairs]
+    assert rendered_pairs == sorted(rendered_pairs)
+
+
+def test_output_sort_with_distinct_cosines() -> None:
+    """When cosines differ, larger comes first."""
+    # rule_a + rule_b → cosine 1 (both on e_0).
+    # rule_a + rule_c → cosine ≈ 0.707 (e_0 vs 45° rotated).
+    e0_cards = [f"e0_{i}" for i in range(5)]
+    rotated_cards = [f"rot_{i}" for i in range(5)]
+    vectors = {**{c: _unit_vector(1.0, 0.0) for c in e0_cards}, **{c: _unit_vector(1.0, 1.0) for c in rotated_cards}}
+    rows = _tensor_rows(
+        {
+            "rule_a": e0_cards,
+            "rule_b": e0_cards,
+            "rule_c": rotated_cards,
+        }
+    )
+
+    pairs = compute_embedding_dedup(rows, vectors, threshold=0.5, min_activation=3)
+
+    assert len(pairs) == 3
+    # Highest cosine (rule_a / rule_b) should lead.
+    assert pairs[0].rule_a == "rule_a"
+    assert pairs[0].rule_b == "rule_b"
+    assert pairs[0].cosine == pytest.approx(1.0, rel=1e-6)
+    # Remaining two pairs share cosine ≈ 0.707 → lexicographic
+    # tiebreak: (rule_a, rule_c) before (rule_b, rule_c).
+    assert pairs[1].rule_a == "rule_a"
+    assert pairs[1].rule_b == "rule_c"
+    assert pairs[2].rule_a == "rule_b"
+    assert pairs[2].rule_b == "rule_c"
+
+
+# ---------------------------------------------------------------------------
+# DedupPair shape
+# ---------------------------------------------------------------------------
+
+
+def test_dedup_pair_is_frozen() -> None:
+    """``DedupPair`` mutation raises — verifies ``frozen=True`` contract."""
+    pair = DedupPair(rule_a="a", rule_b="b", cosine=0.99, activation_a_size=10, activation_b_size=12)
+    with pytest.raises((AttributeError, TypeError)):
+        pair.cosine = 0.0  # type: ignore[misc]  — intentionally illegal

--- a/tests/embeddings/test_store.py
+++ b/tests/embeddings/test_store.py
@@ -1,0 +1,319 @@
+"""Unit 2 tests — card_embeddings blob store round-trip + fallback.
+
+Covers:
+
+* Round-trip: ``write_vectors`` + ``load_card_embeddings`` preserves
+  bitwise-identical ``float32`` arrays.
+* ``read_vector`` returns the exact array for known names, ``None``
+  for missing names.
+* Graceful-fallback reader:
+  - missing table → ``{}`` + warning
+  - empty table → ``{}`` + warning
+  - all-zero row → row skipped, others kept
+  - wrong-length row → row skipped, others kept
+* Transaction atomicity: simulated mid-write exception leaves DB
+  unchanged.
+* Replace-all semantics: re-running with a smaller corpus wipes old
+  rows rather than accumulating.
+* Config KV rows are written alongside vectors; post-write
+  ``verify_current_or_raise`` passes.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from mtg_synergy_graph.embeddings import config as emb_config
+from mtg_synergy_graph.embeddings import store as emb_store
+
+
+def _make_store_db(tmp_path: Path) -> sqlite3.Connection:
+    """Open a connection with only the two embedding tables applied.
+
+    Kept intentionally narrower than ``db.open_db`` so these tests do
+    not couple to the full schema (which includes the FK from
+    ``card_embeddings.card_name`` to ``cards(name)`` — irrelevant to
+    the blob round-trip contract).
+    """
+    db_path = tmp_path / "emb.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE card_embeddings (
+            card_name          TEXT PRIMARY KEY,
+            vector             BLOB NOT NULL,
+            vectorizer_version INTEGER NOT NULL,
+            built_at           TEXT NOT NULL
+        );
+        CREATE TABLE card_embeddings_config (
+            key   TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        """
+    )
+    return conn
+
+
+def _make_inputs() -> emb_config.EmbeddingConfigInputs:
+    return emb_config.EmbeddingConfigInputs(
+        token_format_version="v1",  # noqa: S106 — version tag, not a secret
+        svd_dims=128,
+        min_df=2,
+        vectorizer_version=1,
+        port_signature_version="v1",
+    )
+
+
+def _make_vector(seed: int) -> np.ndarray:
+    """Deterministic 128-dim unit vector with a small offset per ``seed``.
+
+    Not all-zero (so it survives ``load_card_embeddings`` filtering).
+    """
+    rng = np.random.default_rng(seed)
+    vec = rng.standard_normal(128).astype(np.float32)
+    # L2-normalize so it matches the downstream contract from Unit 1's
+    # ``truncated_svd`` — every vector read at inference is unit-norm.
+    vec /= np.linalg.norm(vec)
+    return vec
+
+
+# ---------------------------------------------------------------------------
+# write_vectors + load_card_embeddings round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_preserves_bits(tmp_path: Path) -> None:
+    conn = _make_store_db(tmp_path)
+    try:
+        vectors = {
+            "Lightning Bolt": _make_vector(1),
+            "Counterspell": _make_vector(2),
+            "Sol Ring": _make_vector(3),
+        }
+        emb_store.write_vectors(conn, vectors, _make_inputs())
+
+        loaded = emb_store.load_card_embeddings(conn)
+        assert set(loaded.keys()) == set(vectors.keys())
+        for name, expected in vectors.items():
+            assert np.array_equal(loaded[name], expected)
+            # Dtype preserved.
+            assert loaded[name].dtype == np.float32
+    finally:
+        conn.close()
+
+
+def test_read_vector_returns_exact_float32(tmp_path: Path) -> None:
+    conn = _make_store_db(tmp_path)
+    try:
+        vectors = {"Lightning Bolt": _make_vector(1)}
+        emb_store.write_vectors(conn, vectors, _make_inputs())
+
+        loaded = emb_store.read_vector(conn, "Lightning Bolt")
+        assert loaded is not None
+        assert np.array_equal(loaded, vectors["Lightning Bolt"])
+        assert loaded.dtype == np.float32
+    finally:
+        conn.close()
+
+
+def test_read_vector_returns_none_for_missing_name(tmp_path: Path) -> None:
+    conn = _make_store_db(tmp_path)
+    try:
+        emb_store.write_vectors(conn, {"A": _make_vector(1)}, _make_inputs())
+        assert emb_store.read_vector(conn, "Nonexistent Card") is None
+    finally:
+        conn.close()
+
+
+def test_read_vector_returned_array_is_writable(tmp_path: Path) -> None:
+    """``.copy()`` in read_vector means the caller can mutate in place.
+
+    Without ``.copy()``, ``np.frombuffer`` returns a read-only view
+    over the sqlite3 row buffer and any downstream mutation raises
+    ``ValueError: assignment destination is read-only``.
+    """
+    conn = _make_store_db(tmp_path)
+    try:
+        emb_store.write_vectors(conn, {"A": _make_vector(1)}, _make_inputs())
+        loaded = emb_store.read_vector(conn, "A")
+        assert loaded is not None
+        loaded[0] = 0.0  # must not raise
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Graceful-fallback reader contract
+# ---------------------------------------------------------------------------
+
+
+def test_load_returns_empty_on_missing_tables(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """DB that never had the embedding tables applied."""
+    db_path = tmp_path / "bare.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        with caplog.at_level(logging.WARNING, logger="mtg_synergy_graph.embeddings.store"):
+            result = emb_store.load_card_embeddings(conn)
+        assert result == {}
+        assert any("missing" in rec.message or "missing" in rec.getMessage() for rec in caplog.records)
+    finally:
+        conn.close()
+
+
+def test_load_returns_empty_on_empty_table(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    conn = _make_store_db(tmp_path)
+    try:
+        with caplog.at_level(logging.WARNING, logger="mtg_synergy_graph.embeddings.store"):
+            result = emb_store.load_card_embeddings(conn)
+        assert result == {}
+        assert any("empty" in rec.getMessage() for rec in caplog.records)
+    finally:
+        conn.close()
+
+
+def test_load_skips_all_zero_row_and_keeps_valid_rows(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    conn = _make_store_db(tmp_path)
+    try:
+        zero_blob = np.zeros(128, dtype=np.float32).tobytes()
+        valid_vec = _make_vector(1)
+        conn.executemany(
+            "INSERT INTO card_embeddings(card_name, vector, vectorizer_version, built_at) VALUES (?, ?, ?, ?)",
+            [
+                ("AllZero", zero_blob, 1, "2026-04-23T00:00:00+00:00"),
+                ("Valid", valid_vec.tobytes(), 1, "2026-04-23T00:00:00+00:00"),
+            ],
+        )
+        conn.commit()
+
+        with caplog.at_level(logging.WARNING, logger="mtg_synergy_graph.embeddings.store"):
+            result = emb_store.load_card_embeddings(conn)
+
+        assert "AllZero" not in result
+        assert "Valid" in result
+        assert np.array_equal(result["Valid"], valid_vec)
+        assert any("AllZero" in rec.getMessage() for rec in caplog.records)
+    finally:
+        conn.close()
+
+
+def test_load_skips_wrong_length_row_and_keeps_valid_rows(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    conn = _make_store_db(tmp_path)
+    try:
+        short_blob = np.ones(64, dtype=np.float32).tobytes()
+        valid_vec = _make_vector(2)
+        conn.executemany(
+            "INSERT INTO card_embeddings(card_name, vector, vectorizer_version, built_at) VALUES (?, ?, ?, ?)",
+            [
+                ("TooShort", short_blob, 1, "2026-04-23T00:00:00+00:00"),
+                ("Valid", valid_vec.tobytes(), 1, "2026-04-23T00:00:00+00:00"),
+            ],
+        )
+        conn.commit()
+
+        with caplog.at_level(logging.WARNING, logger="mtg_synergy_graph.embeddings.store"):
+            result = emb_store.load_card_embeddings(conn)
+
+        assert "TooShort" not in result
+        assert "Valid" in result
+        assert any("TooShort" in rec.getMessage() for rec in caplog.records)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Atomicity + replace-all semantics
+# ---------------------------------------------------------------------------
+
+
+def test_write_vectors_is_atomic_on_mid_write_exception(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A crash between the delete and the commit must leave DB unchanged."""
+    conn = _make_store_db(tmp_path)
+    try:
+        # Seed an initial successful write so there is pre-existing state to
+        # preserve across the failing second write.
+        original = {"A": _make_vector(1), "B": _make_vector(2)}
+        emb_store.write_vectors(conn, original, _make_inputs())
+
+        # Monkeypatch ``compute_embedding_hash`` to raise during the second
+        # write. This fires AFTER the DELETE but before the config KV
+        # insert — exactly the mid-transaction failure mode that the
+        # ``with conn:`` block must roll back.
+        def exploding_hash(_inputs: emb_config.EmbeddingConfigInputs) -> str:
+            raise RuntimeError("simulated mid-write failure")
+
+        monkeypatch.setattr(emb_store, "compute_embedding_hash", exploding_hash)
+
+        with pytest.raises(RuntimeError, match="simulated mid-write failure"):
+            emb_store.write_vectors(conn, {"C": _make_vector(3)}, _make_inputs())
+
+        # DB state is the pre-failure state.
+        loaded = emb_store.load_card_embeddings(conn)
+        assert set(loaded.keys()) == {"A", "B"}
+        assert np.array_equal(loaded["A"], original["A"])
+        assert np.array_equal(loaded["B"], original["B"])
+    finally:
+        conn.close()
+
+
+def test_write_vectors_replaces_all_rows_not_incremental(tmp_path: Path) -> None:
+    conn = _make_store_db(tmp_path)
+    try:
+        first = {name: _make_vector(i) for i, name in enumerate(["A", "B", "C", "D", "E"], start=1)}
+        emb_store.write_vectors(conn, first, _make_inputs())
+
+        second = {name: _make_vector(i + 100) for i, name in enumerate(["X", "Y", "Z"], start=1)}
+        emb_store.write_vectors(conn, second, _make_inputs())
+
+        loaded = emb_store.load_card_embeddings(conn)
+        assert set(loaded.keys()) == {"X", "Y", "Z"}
+
+        # KV config table is also wiped + rewritten (not accumulated).
+        config_rows = conn.execute("SELECT key FROM card_embeddings_config").fetchall()
+        keys = [r[0] for r in config_rows]
+        # Each key should appear exactly once; no duplicates from the second
+        # write layering on top of the first.
+        assert len(keys) == len(set(keys))
+    finally:
+        conn.close()
+
+
+def test_write_vectors_populates_config_kv_and_verify_passes(tmp_path: Path) -> None:
+    conn = _make_store_db(tmp_path)
+    try:
+        inputs = _make_inputs()
+        vectors = {"A": _make_vector(1)}
+        emb_store.write_vectors(conn, vectors, inputs)
+
+        stored = dict(conn.execute("SELECT key, value FROM card_embeddings_config").fetchall())
+        # Hash + each diagnostic field.
+        assert "config_hash" in stored
+        assert len(stored["config_hash"]) == 64
+        assert stored["token_format_version"] == "v1"  # noqa: S105 — version tag
+        assert stored["svd_dims"] == "128"
+        assert stored["min_df"] == "2"
+        assert stored["vectorizer_version"] == "1"
+        assert stored["port_signature_version"] == "v1"
+        assert "built_at" in stored
+
+        # Post-write, the strict verifier passes.
+        emb_config.verify_current_or_raise(conn, inputs)
+    finally:
+        conn.close()
+
+
+def test_write_vectors_stamps_vectorizer_version_per_row(tmp_path: Path) -> None:
+    conn = _make_store_db(tmp_path)
+    try:
+        inputs = _make_inputs()._replace(vectorizer_version=7)
+        vectors = {"A": _make_vector(1), "B": _make_vector(2)}
+        emb_store.write_vectors(conn, vectors, inputs)
+
+        versions = [row[0] for row in conn.execute("SELECT vectorizer_version FROM card_embeddings").fetchall()]
+        assert versions == [7, 7]
+    finally:
+        conn.close()

--- a/tests/embeddings/test_svd.py
+++ b/tests/embeddings/test_svd.py
@@ -1,0 +1,239 @@
+"""Unit 1 tests — truncated-SVD + row-wise L2 normalization.
+
+Covers:
+
+* Deterministic output: same input produces bitwise-identical output
+  across two calls (``np.array_equal`` contract).
+* L2-normalized rows: ``||row||_2`` is ``1.0`` within float tolerance
+  for non-zero-norm inputs.
+* Zero-norm rows survive normalization as all-zeros, not NaN.
+* ``k`` is clamped when the input matrix is smaller than ``k`` columns.
+* Integration with the vectorizer: 50 synthetic cards → 50 distinct
+  unit-norm 128-dim vectors.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import numpy as np
+
+from mtg_synergy_graph.embeddings.svd import truncated_svd
+from mtg_synergy_graph.embeddings.vectorizer import (
+    compute_tfidf,
+    extract_card_tokens,
+)
+
+#: Same minimal schema as ``test_vectorizer.py`` — kept local to avoid
+#: coupling to conftest, per Unit 1 scope.
+_SCHEMA = """\
+CREATE TABLE cards (
+    name     TEXT PRIMARY KEY,
+    keywords TEXT
+);
+CREATE TABLE card_ports (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    card_name        TEXT NOT NULL,
+    port_type        TEXT NOT NULL,
+    event_class      TEXT NOT NULL,
+    zone_origin      TEXT,
+    zone_destination TEXT,
+    counter_type     TEXT,
+    branch_kind      TEXT
+);
+CREATE TABLE port_attributes (
+    port_id    INTEGER NOT NULL,
+    attr_kind  TEXT NOT NULL,
+    attr_value TEXT NOT NULL
+);
+"""
+
+
+def _seed_fifty_card_db() -> sqlite3.Connection:
+    """Build a 50-card DB with varied port/keyword shapes.
+
+    Each card has a 3-port fingerprint drawn from a 10-element pool so
+    card vectors differ pair-wise while sharing enough tokens to exceed
+    ``min_df=2``. Also seeds a single keyword per card.
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(_SCHEMA)
+
+    port_pool = [
+        ("trigger", "SpellCast"),
+        ("trigger", "ETB"),
+        ("trigger", "Dies"),
+        ("effect", "Draw"),
+        ("effect", "DealDamage"),
+        ("effect", "Token"),
+        ("static", "Lord"),
+        ("cost", "Sacrifice"),
+        ("replacement", "ChangeZone"),
+        ("keyword", "Flying"),
+    ]
+    keyword_pool = [
+        "Flying",
+        "Haste",
+        "Trample",
+        "Vigilance",
+        "Lifelink",
+        "Deathtouch",
+        "Reach",
+        "Menace",
+        "Ward",
+        "Indestructible",
+    ]
+
+    for i in range(50):
+        card_name = f"Card{i:03d}"
+        # Each card gets a 2-keyword multiset unique to its index so the
+        # combination ``(port_signature, keyword_signature)`` is
+        # guaranteed pairwise-distinct across 50 cards. Keywords appear
+        # on ≥ 2 cards so they survive ``min_df=2``.
+        kw_a = keyword_pool[i % len(keyword_pool)]
+        kw_b = keyword_pool[(i // len(keyword_pool)) % len(keyword_pool)]
+        conn.execute(
+            "INSERT INTO cards (name, keywords) VALUES (?, ?)",
+            (card_name, json.dumps([kw_a, kw_b])),
+        )
+        # 3-port fingerprint drawn from the shared pool — ports repeat
+        # across cards (shared structure is what makes TF-IDF useful).
+        picks = [
+            port_pool[i % len(port_pool)],
+            port_pool[(i * 3 + 1) % len(port_pool)],
+            port_pool[(i * 7 + 2) % len(port_pool)],
+        ]
+        for pt, ev in picks:
+            conn.execute(
+                "INSERT INTO card_ports (card_name, port_type, event_class) VALUES (?, ?, ?)",
+                (card_name, pt, ev),
+            )
+    conn.commit()
+    return conn
+
+
+def test_truncated_svd_is_deterministic() -> None:
+    rng = np.random.default_rng(seed=42)
+    tfidf = rng.standard_normal((30, 20)).astype(np.float64)
+
+    first = truncated_svd(tfidf, k=8)
+    second = truncated_svd(tfidf, k=8)
+
+    assert np.array_equal(first, second)
+
+
+def test_truncated_svd_rows_are_unit_norm() -> None:
+    rng = np.random.default_rng(seed=7)
+    tfidf = np.abs(rng.standard_normal((25, 40))).astype(np.float64)
+
+    embedding = truncated_svd(tfidf, k=16)
+
+    assert embedding.shape == (25, 16)
+    norms = np.linalg.norm(embedding, axis=1)
+    np.testing.assert_allclose(norms, np.ones(25), atol=1e-9)
+
+
+def test_truncated_svd_handles_zero_row_without_nan() -> None:
+    tfidf = np.array(
+        [
+            [1.0, 2.0, 3.0],
+            [0.0, 0.0, 0.0],  # zero row — would NaN under a naive divide
+            [4.0, 5.0, 6.0],
+        ],
+        dtype=np.float64,
+    )
+
+    embedding = truncated_svd(tfidf, k=2)
+
+    assert not np.isnan(embedding).any()
+    # The zero-input row must remain zero after normalization.
+    assert np.all(embedding[1] == 0.0)
+    # Non-zero rows are unit-norm.
+    assert np.isclose(np.linalg.norm(embedding[0]), 1.0)
+    assert np.isclose(np.linalg.norm(embedding[2]), 1.0)
+
+
+def test_truncated_svd_pads_when_k_exceeds_rank() -> None:
+    # 3×2 matrix; rank ≤ 2 but we request k=5 → pad with 3 zero columns.
+    tfidf = np.array(
+        [
+            [1.0, 2.0],
+            [3.0, 4.0],
+            [5.0, 6.0],
+        ],
+        dtype=np.float64,
+    )
+
+    embedding = truncated_svd(tfidf, k=5)
+
+    assert embedding.shape == (3, 5)
+    # Padding columns must be exactly zero.
+    assert np.all(embedding[:, 2:] == 0.0)
+    # Non-zero prefix columns carry the signal → rows still unit-norm.
+    norms = np.linalg.norm(embedding, axis=1)
+    np.testing.assert_allclose(norms, np.ones(3), atol=1e-9)
+
+
+def test_truncated_svd_empty_matrix() -> None:
+    # Empty input — returns (0, k) zero matrix, not a crash.
+    embedding = truncated_svd(np.zeros((0, 5), dtype=np.float64), k=8)
+
+    assert embedding.shape == (0, 8)
+
+
+def test_truncated_svd_zero_column_matrix() -> None:
+    # Zero columns (no vocabulary survived min_df) — same contract.
+    embedding = truncated_svd(np.zeros((4, 0), dtype=np.float64), k=8)
+
+    assert embedding.shape == (4, 8)
+    assert np.all(embedding == 0.0)
+
+
+def test_integration_fifty_cards_distinct_unit_vectors() -> None:
+    conn = _seed_fifty_card_db()
+    try:
+        corpus = extract_card_tokens(conn)
+        tfidf_result = compute_tfidf(corpus, min_df=2)
+        embedding = truncated_svd(tfidf_result.tfidf_matrix, k=128)
+
+        assert embedding.shape == (50, 128)
+
+        # Every row is unit-norm (no card has zero tokens in this
+        # fixture).
+        norms = np.linalg.norm(embedding, axis=1)
+        np.testing.assert_allclose(norms, np.ones(50), atol=1e-9)
+
+        # All 50 rows are pairwise distinct.
+        unique_rows = {tuple(row) for row in embedding.tolist()}
+        assert len(unique_rows) == 50
+    finally:
+        conn.close()
+
+
+def test_integration_zero_token_card_yields_zero_vector() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(_SCHEMA)
+    conn.execute("INSERT INTO cards (name, keywords) VALUES ('Alpha', NULL)")
+    conn.execute(
+        "INSERT INTO cards (name, keywords) VALUES ('Beta', ?)",
+        (json.dumps(["Flying", "Haste"]),),
+    )
+    conn.execute("INSERT INTO card_ports (card_name, port_type, event_class) VALUES ('Beta', 'trigger', 'ETB')")
+    # Only Alpha has zero tokens. Provide at least one token on Beta
+    # that survives min_df=1 so compute_tfidf returns a non-empty matrix.
+    conn.commit()
+    try:
+        corpus = extract_card_tokens(conn)
+        tfidf = compute_tfidf(corpus, min_df=1)
+        embedding = truncated_svd(tfidf.tfidf_matrix, k=4)
+
+        alpha_idx = tfidf.card_names.index("Alpha")
+        # Alpha had zero tokens → its TF-IDF row is all-zero → embedding
+        # row is all-zero after normalization (no NaN).
+        assert np.all(embedding[alpha_idx] == 0.0)
+        assert not np.isnan(embedding).any()
+    finally:
+        conn.close()

--- a/tests/embeddings/test_vectorizer.py
+++ b/tests/embeddings/test_vectorizer.py
@@ -1,0 +1,364 @@
+"""Unit 1 tests — feature-bag extraction + TF-IDF math.
+
+Covers:
+
+* Token-grammar correctness: port-row columns, port_attributes rows,
+  and cards.keywords all emit the documented token shapes.
+* TF-IDF values match a hand-computed reference within 1e-9.
+* ``min_df=2`` prunes tokens that appear on only one card.
+* Duplicate tokens on a single card survive TF (raw-count behavior).
+* Zero-token cards produce zero rows that downstream SVD + L2 handle
+  without NaN.
+* Deterministic ordering: ``card_names`` sorted ascending,
+  ``vocabulary`` sorted ascending.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import sqlite3
+
+import numpy as np
+import pytest
+
+from mtg_synergy_graph.embeddings.vectorizer import (
+    TOKEN_FORMAT_VERSION,
+    compute_tfidf,
+    extract_card_tokens,
+)
+
+#: Minimal in-memory schema containing only the columns the vectorizer
+#: reads. Deliberately narrower than ``tests/conftest.py``'s rules_db
+#: so this unit does not couple to conftest evolution (Unit 3's scope).
+_VECTORIZER_SCHEMA = """\
+CREATE TABLE cards (
+    name     TEXT PRIMARY KEY,
+    keywords TEXT
+);
+CREATE TABLE card_ports (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    card_name        TEXT NOT NULL,
+    port_type        TEXT NOT NULL,
+    event_class      TEXT NOT NULL,
+    zone_origin      TEXT,
+    zone_destination TEXT,
+    counter_type     TEXT,
+    branch_kind      TEXT
+);
+CREATE TABLE port_attributes (
+    port_id    INTEGER NOT NULL,
+    attr_kind  TEXT NOT NULL,
+    attr_value TEXT NOT NULL
+);
+"""
+
+
+def _fresh_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(_VECTORIZER_SCHEMA)
+    return conn
+
+
+def _insert_card(
+    conn: sqlite3.Connection,
+    name: str,
+    keywords: list[str] | None = None,
+) -> None:
+    conn.execute(
+        "INSERT INTO cards (name, keywords) VALUES (?, ?)",
+        (name, json.dumps(keywords) if keywords is not None else None),
+    )
+
+
+def _insert_port(
+    conn: sqlite3.Connection,
+    card_name: str,
+    port_type: str,
+    event_class: str,
+    *,
+    zone_origin: str | None = None,
+    zone_destination: str | None = None,
+    counter_type: str | None = None,
+    branch_kind: str | None = None,
+    attributes: list[tuple[str, str]] | None = None,
+) -> int:
+    cur = conn.execute(
+        "INSERT INTO card_ports (card_name, port_type, event_class, "
+        "zone_origin, zone_destination, counter_type, branch_kind) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            card_name,
+            port_type,
+            event_class,
+            zone_origin,
+            zone_destination,
+            counter_type,
+            branch_kind,
+        ),
+    )
+    port_id = int(cur.lastrowid or 0)
+    if attributes:
+        conn.executemany(
+            "INSERT INTO port_attributes (port_id, attr_kind, attr_value) VALUES (?, ?, ?)",
+            [(port_id, k, v) for (k, v) in attributes],
+        )
+    return port_id
+
+
+def test_token_format_version_is_v1() -> None:
+    assert TOKEN_FORMAT_VERSION == "v1"  # noqa: S105 — version tag, not a secret
+
+
+def test_extract_tokens_port_row_columns() -> None:
+    conn = _fresh_db()
+    _insert_card(conn, "Alpha", keywords=["Flying"])
+    _insert_port(
+        conn,
+        "Alpha",
+        "trigger",
+        "SpellCast",
+        zone_origin="Hand",
+        zone_destination="Battlefield",
+        counter_type="P1P1",
+        branch_kind="root",
+    )
+    conn.commit()
+
+    corpus = extract_card_tokens(conn)
+
+    assert set(corpus["Alpha"]) == {
+        "port_type:trigger",
+        "event_class:SpellCast",
+        "zone_origin:Hand",
+        "zone_destination:Battlefield",
+        "counter_type:P1P1",
+        "branch_kind:root",
+        "keyword:Flying",
+    }
+
+
+def test_extract_tokens_skips_null_optional_columns() -> None:
+    conn = _fresh_db()
+    _insert_card(conn, "Beta")
+    _insert_port(conn, "Beta", "effect", "Draw")
+    conn.commit()
+
+    corpus = extract_card_tokens(conn)
+
+    # Only the two required columns + nothing else (card has no keywords).
+    assert corpus["Beta"] == ("port_type:effect", "event_class:Draw")
+
+
+def test_extract_tokens_emits_attr_rows() -> None:
+    conn = _fresh_db()
+    _insert_card(conn, "Gamma")
+    _insert_port(
+        conn,
+        "Gamma",
+        "trigger",
+        "ETB",
+        attributes=[("type", "Creature"), ("subtype", "Goblin")],
+    )
+    conn.commit()
+
+    corpus = extract_card_tokens(conn)
+
+    assert "attr:type:Creature" in corpus["Gamma"]
+    assert "attr:subtype:Goblin" in corpus["Gamma"]
+
+
+def test_extract_tokens_keywords_json_decoded() -> None:
+    conn = _fresh_db()
+    _insert_card(conn, "Delta", keywords=["Flying", "Haste", "Trample"])
+    _insert_port(conn, "Delta", "keyword", "Flying")
+    conn.commit()
+
+    corpus = extract_card_tokens(conn)
+
+    assert sum(1 for t in corpus["Delta"] if t.startswith("keyword:")) == 3
+    assert "keyword:Flying" in corpus["Delta"]
+    assert "keyword:Haste" in corpus["Delta"]
+    assert "keyword:Trample" in corpus["Delta"]
+
+
+def test_extract_tokens_card_with_no_ports_and_no_keywords() -> None:
+    conn = _fresh_db()
+    _insert_card(conn, "Orphan")
+    conn.commit()
+
+    corpus = extract_card_tokens(conn)
+
+    assert "Orphan" in corpus
+    assert corpus["Orphan"] == ()
+
+
+def test_extract_tokens_tolerates_missing_port_attributes_table() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    # No port_attributes table at all — simulates a very minimal fixture.
+    conn.executescript(
+        """
+        CREATE TABLE cards (name TEXT PRIMARY KEY, keywords TEXT);
+        CREATE TABLE card_ports (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            card_name TEXT NOT NULL,
+            port_type TEXT NOT NULL,
+            event_class TEXT NOT NULL,
+            zone_origin TEXT,
+            zone_destination TEXT,
+            counter_type TEXT,
+            branch_kind TEXT
+        );
+        """
+    )
+    conn.execute("INSERT INTO cards (name, keywords) VALUES ('Solo', NULL)")
+    conn.execute("INSERT INTO card_ports (card_name, port_type, event_class) VALUES ('Solo', 'trigger', 'ETB')")
+    conn.commit()
+
+    corpus = extract_card_tokens(conn)
+
+    assert corpus["Solo"] == ("port_type:trigger", "event_class:ETB")
+
+
+def test_extract_tokens_ignores_malformed_keywords_json() -> None:
+    conn = _fresh_db()
+    conn.execute(
+        "INSERT INTO cards (name, keywords) VALUES (?, ?)",
+        ("Bad", "{this is not json"),
+    )
+    conn.commit()
+
+    corpus = extract_card_tokens(conn)
+
+    # Malformed JSON doesn't raise; the card still appears with an empty tuple.
+    assert corpus["Bad"] == ()
+
+
+def test_compute_tfidf_matches_hand_computed_values() -> None:
+    """5-card synthetic corpus with a known TF-IDF reference."""
+    corpus: dict[str, tuple[str, ...]] = {
+        "A": ("x", "y"),
+        "B": ("x", "z"),
+        "C": ("x", "y", "z"),
+        "D": ("y", "w"),  # 'w' appears only here → pruned by min_df=2
+        "E": ("x", "z"),
+    }
+
+    result = compute_tfidf(corpus, min_df=2)
+
+    # Card names sorted; 'w' pruned because df=1.
+    assert result.card_names == ["A", "B", "C", "D", "E"]
+    assert result.vocabulary == ["x", "y", "z"]
+
+    # IDF = ln((1+N)/(1+df)) + 1, N=5
+    # df(x) = 4 → idf = ln(6/5) + 1
+    # df(y) = 3 → idf = ln(6/4) + 1
+    # df(z) = 3 → idf = ln(6/4) + 1
+    idf_x = math.log(6.0 / 5.0) + 1.0
+    idf_y = math.log(6.0 / 4.0) + 1.0
+    idf_z = math.log(6.0 / 4.0) + 1.0
+
+    expected = np.array(
+        [
+            [idf_x, idf_y, 0.0],  # A: x, y
+            [idf_x, 0.0, idf_z],  # B: x, z
+            [idf_x, idf_y, idf_z],  # C: x, y, z
+            [0.0, idf_y, 0.0],  # D: y (w pruned)
+            [idf_x, 0.0, idf_z],  # E: x, z
+        ],
+        dtype=np.float64,
+    )
+
+    np.testing.assert_allclose(result.tfidf_matrix, expected, atol=1e-9)
+
+
+def test_compute_tfidf_prunes_tokens_below_min_df() -> None:
+    corpus: dict[str, tuple[str, ...]] = {
+        "A": ("shared", "unique_a"),
+        "B": ("shared", "unique_b"),
+    }
+
+    result = compute_tfidf(corpus, min_df=2)
+
+    assert result.vocabulary == ["shared"]
+    assert result.tfidf_matrix.shape == (2, 1)
+
+
+def test_compute_tfidf_min_df_one_retains_everything() -> None:
+    corpus: dict[str, tuple[str, ...]] = {
+        "A": ("singleton",),
+    }
+
+    result = compute_tfidf(corpus, min_df=1)
+
+    assert result.vocabulary == ["singleton"]
+    assert result.tfidf_matrix.shape == (1, 1)
+
+
+def test_compute_tfidf_duplicate_tokens_counted_raw() -> None:
+    corpus: dict[str, tuple[str, ...]] = {
+        "A": ("keyword:Flying", "keyword:Flying", "keyword:Flying"),
+        "B": ("keyword:Flying",),
+    }
+
+    result = compute_tfidf(corpus, min_df=1)
+
+    idf = math.log(3.0 / 3.0) + 1.0  # df=2, N=2 → ln((1+2)/(1+2))+1 = 1.0
+    # Row A has TF=3 → value = 3 * 1.0 = 3.0
+    # Row B has TF=1 → value = 1 * 1.0 = 1.0
+    assert result.vocabulary == ["keyword:Flying"]
+    np.testing.assert_allclose(
+        result.tfidf_matrix,
+        np.array([[3.0 * idf], [1.0 * idf]], dtype=np.float64),
+        atol=1e-9,
+    )
+
+
+def test_compute_tfidf_empty_corpus() -> None:
+    result = compute_tfidf({}, min_df=1)
+
+    assert result.card_names == []
+    assert result.vocabulary == []
+    assert result.tfidf_matrix.shape == (0, 0)
+
+
+def test_compute_tfidf_all_tokens_pruned() -> None:
+    # Every token appears on exactly one card; min_df=2 kills them all.
+    corpus: dict[str, tuple[str, ...]] = {
+        "A": ("unique_a",),
+        "B": ("unique_b",),
+    }
+
+    result = compute_tfidf(corpus, min_df=2)
+
+    assert result.vocabulary == []
+    assert result.tfidf_matrix.shape == (2, 0)
+
+
+def test_compute_tfidf_rejects_min_df_zero() -> None:
+    with pytest.raises(ValueError, match="min_df must be >= 1"):
+        compute_tfidf({"A": ("x",)}, min_df=0)
+
+
+def test_compute_tfidf_deterministic_ordering() -> None:
+    # Same corpus supplied in different insertion orders must produce
+    # identical output (sorted card_names + sorted vocabulary).
+    corpus_1: dict[str, tuple[str, ...]] = {
+        "Z": ("t1", "t2"),
+        "A": ("t1", "t3"),
+        "M": ("t1", "t2", "t3"),
+    }
+    corpus_2: dict[str, tuple[str, ...]] = {
+        "A": ("t3", "t1"),
+        "M": ("t2", "t3", "t1"),
+        "Z": ("t2", "t1"),
+    }
+
+    r1 = compute_tfidf(corpus_1, min_df=1)
+    r2 = compute_tfidf(corpus_2, min_df=1)
+
+    assert r1.card_names == r2.card_names == ["A", "M", "Z"]
+    assert r1.vocabulary == r2.vocabulary == ["t1", "t2", "t3"]
+    np.testing.assert_array_equal(r1.tfidf_matrix, r2.tfidf_matrix)

--- a/tests/fixtures/golden_set_run.json
+++ b/tests/fixtures/golden_set_run.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
-  "config_hash": "f8bd21f86c40494aceeac123c7d2608cbd9ea91c8e464423cb958ca4435f3414",
-  "created_at": "2026-04-23T16:57:16+00:00",
+  "config_hash": "03c355181c2089c5eaa9fd38af2f970e4e5885b754d82e3778870e4317735b92",
+  "created_at": "2026-04-24T02:22:33+00:00",
   "entries": [
     {
       "edhrec_top10": [

--- a/tests/test_explain_embedding_render.py
+++ b/tests/test_explain_embedding_render.py
@@ -1,0 +1,220 @@
+"""Integration tests for the ``--explain`` embedding render lines.
+
+Plan 2026-04-23-003 Unit 7 / FR6 — verify that ``SynergyEngine.page``
+with ``include_explanations=True`` emits an ``embedding_contribution:``
+decomposition line plus a ``nearest covered neighbors:`` line when the
+flag is on AND the candidate has a nonzero embedding contribution.
+With the flag OFF (module default), neither line appears — the render
+path short-circuits at ``universal_score.embedding_contribution == 0``.
+
+These tests wire the whole chain:
+    SynergyEngine.page() → score_all_universal() → embedding_contribution
+    → _render_explanation → _render_embedding_block → nearest_covered_neighbors
+
+No mocking of the embedding functions — the DB is populated with
+deterministic synthetic vectors and the real ``load_card_embeddings_verified``
+round-trip is exercised end-to-end.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from mtg_synergy_graph.db import open_db
+from mtg_synergy_graph.embeddings import commander_target as ct
+from mtg_synergy_graph.embeddings import config as emb_config
+from mtg_synergy_graph.embeddings import contribution as emb_contribution
+from mtg_synergy_graph.embeddings import store as emb_store
+from mtg_synergy_graph.engine import SynergyEngine
+
+
+def _make_unit_vector(seed: int, dim: int = 128) -> np.ndarray:
+    """Deterministic L2-normalized float32 vector."""
+    rng = np.random.default_rng(seed)
+    vec = rng.standard_normal(dim).astype(np.float32)
+    norm = float(np.linalg.norm(vec))
+    assert norm > 0.0
+    return (vec / norm).astype(np.float32)
+
+
+def _seed_engine_db(db_path: Path) -> None:
+    """Populate ``synergy.db`` with a commander + a few candidates + ports.
+
+    The commander has an ETB trigger; Token Maker has a Token effect that
+    matches via ``trigger_effect``; Counter Doubler has a replacement
+    port. A generic creature without meaningful ports is included so the
+    embedding-only contribution path is exercisable on the rule-empty tail.
+    """
+    conn = open_db(db_path)
+    conn.execute(
+        "INSERT INTO cards (name, card_types, subtypes, cmc, color_identity, edhrec_rank, legal_commander) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("Test Commander", "Creature", "", 4, "R", 1000, 1),
+    )
+    conn.execute(
+        "INSERT INTO cards (name, card_types, subtypes, cmc, color_identity, edhrec_rank, legal_commander) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("Token Maker", "Creature", "", 3, "R", 500, 1),
+    )
+    conn.execute(
+        "INSERT INTO cards (name, card_types, subtypes, cmc, color_identity, edhrec_rank, legal_commander) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("Counter Doubler", "Enchantment", "", 3, "R", 300, 1),
+    )
+    conn.execute(
+        "INSERT INTO cards (name, card_types, subtypes, cmc, color_identity, edhrec_rank, legal_commander) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("Generic Creature", "Creature", "Human", 2, "R", 5000, 1),
+    )
+
+    # Commander has an ETB trigger on creatures.
+    conn.execute(
+        "INSERT INTO card_ports (card_name, port_type, event_class, valid_filter, raw_line) VALUES (?, ?, ?, ?, ?)",
+        ("Test Commander", "trigger", "ChangesZone", "Creature.YouCtrl", "{ETB}"),
+    )
+    conn.execute(
+        "INSERT INTO card_ports (card_name, port_type, event_class, valid_filter, raw_line) VALUES (?, ?, ?, ?, ?)",
+        ("Token Maker", "effect", "Token", "Creature.Token", "{make}"),
+    )
+    conn.execute(
+        "INSERT INTO card_ports (card_name, port_type, event_class, valid_filter, raw_line) VALUES (?, ?, ?, ?, ?)",
+        ("Counter Doubler", "replacement", "PutCounter", "Creature.YouCtrl", "{double}"),
+    )
+
+    # Populate deterministic embeddings for every card. Must be done
+    # *before* the engine opens the DB because ``write_vectors`` runs
+    # its own transaction and the engine keeps a cached connection.
+    vectors = {
+        "Test Commander": _make_unit_vector(seed=1),
+        "Token Maker": _make_unit_vector(seed=2),
+        "Counter Doubler": _make_unit_vector(seed=3),
+        "Generic Creature": _make_unit_vector(seed=4),
+    }
+    emb_store.write_vectors(conn, vectors, emb_config.get_embedding_config_inputs())
+
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture()
+def engine_with_embeddings(tmp_path: Path) -> SynergyEngine:
+    """SynergyEngine opened against a DB seeded with ports + vectors."""
+    db_path = tmp_path / "synergy.db"
+    _seed_engine_db(db_path)
+    return SynergyEngine(db_path)
+
+
+# ---------------------------------------------------------------------------
+# Flag ON → embedding lines render
+# ---------------------------------------------------------------------------
+
+
+def test_explain_includes_embedding_lines_when_flag_on(
+    engine_with_embeddings: SynergyEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Flag on + w_emb=0.5 + populated vectors → at least one candidate's
+    explanation contains the ``embedding_contribution:`` line and the
+    ``nearest covered neighbors:`` line.
+    """
+    monkeypatch.setattr(emb_contribution, "_ENABLE_EMBEDDING_CONTRIBUTION", True)
+    monkeypatch.setattr(emb_contribution, "_EMBEDDING_W", 0.5)
+    ct.clear_cache()
+
+    page = engine_with_embeddings.page(
+        "Test Commander",
+        offset=0,
+        limit=10,
+        include_explanations=True,
+    )
+
+    joined: list[str] = []
+    for item in page.items:
+        if item.explanation:
+            joined.extend(item.explanation)
+
+    has_embedding_line = any("embedding_contribution:" in line for line in joined)
+    has_neighbors_line = any("nearest covered neighbors:" in line for line in joined)
+
+    assert has_embedding_line, (
+        "Flag on + nonzero w_emb + populated vectors should produce at least "
+        "one 'embedding_contribution:' line in --explain output. Got:\n" + "\n".join(joined)
+    )
+    # Neighbors line only fires when the candidate has rule-covered
+    # peers; with the current 3-candidate fixture Token Maker + Counter
+    # Doubler both accumulate trigger_effect hits so the rule_covered
+    # set has at least two entries.
+    assert has_neighbors_line, (
+        "With multiple rule-covered candidates there should be a 'nearest "
+        "covered neighbors:' line. Got:\n" + "\n".join(joined)
+    )
+
+
+def test_explain_embedding_line_decomposes_decay_times_cosine(
+    engine_with_embeddings: SynergyEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The embedding line exposes decay × cosine decomposition verbatim."""
+    monkeypatch.setattr(emb_contribution, "_ENABLE_EMBEDDING_CONTRIBUTION", True)
+    monkeypatch.setattr(emb_contribution, "_EMBEDDING_W", 0.5)
+    ct.clear_cache()
+
+    page = engine_with_embeddings.page(
+        "Test Commander",
+        offset=0,
+        limit=10,
+        include_explanations=True,
+    )
+
+    lines: list[str] = []
+    for item in page.items:
+        if item.explanation:
+            lines.extend(item.explanation)
+
+    emb_lines = [line for line in lines if "embedding_contribution:" in line]
+    assert emb_lines, "expected at least one embedding_contribution line"
+    # Format: "  embedding_contribution: +X.XXX (decay × cosine = Y.YY × Z.ZZZ)"
+    for line in emb_lines:
+        assert "(decay" in line and "cosine" in line, (
+            f"embedding line should include decay x cosine decomposition: {line}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Flag OFF → no embedding lines render
+# ---------------------------------------------------------------------------
+
+
+def test_explain_omits_embedding_lines_when_flag_off(
+    engine_with_embeddings: SynergyEngine,
+) -> None:
+    """Module default: flag is False → no embedding lines should appear.
+
+    Exercises the identity-preservation guarantee of Unit 7: even with
+    populated ``card_embeddings`` in the DB, the explain render
+    short-circuits at ``embedding_contribution == 0``.
+    """
+    # No monkeypatch — rely on the module default (False).
+    assert emb_contribution._ENABLE_EMBEDDING_CONTRIBUTION is False
+
+    page = engine_with_embeddings.page(
+        "Test Commander",
+        offset=0,
+        limit=10,
+        include_explanations=True,
+    )
+
+    joined: list[str] = []
+    for item in page.items:
+        if item.explanation:
+            joined.extend(item.explanation)
+
+    assert not any("embedding_contribution:" in line for line in joined), (
+        "Flag off → explain must NOT include 'embedding_contribution:' lines. Got:\n" + "\n".join(joined)
+    )
+    assert not any("nearest covered neighbors:" in line for line in joined), (
+        "Flag off → explain must NOT include 'nearest covered neighbors:' lines. Got:\n" + "\n".join(joined)
+    )

--- a/tests/test_pathway_flag_gate.py
+++ b/tests/test_pathway_flag_gate.py
@@ -143,6 +143,12 @@ def test_scoring_config_inputs_exposes_pathway_flag() -> None:
     flips. The first three fields stay at their legacy positions for
     backward compatibility with any callsite that constructs the
     tuple positionally.
+
+    Plan 2026-04-23-003 Unit 7 appends four additional fields
+    (``enable_embedding_contribution``, ``embedding_w``, ``embedding_k``,
+    ``vectorizer_version``) so the embedding flip + weight knobs also
+    invalidate the pinned tensor. The leading four fields stay at their
+    legacy positions.
     """
     from mtg_synergy_graph.universal_scorer import ScoringConfigInputs
 
@@ -151,6 +157,10 @@ def test_scoring_config_inputs_exposes_pathway_flag() -> None:
         "flat_weight_overrides",
         "synergy_pairs",
         "enable_pathway_rules",
+        "enable_embedding_contribution",
+        "embedding_w",
+        "embedding_k",
+        "vectorizer_version",
     )
 
 


### PR DESCRIPTION
## Summary

Lands plan [`docs/plans/2026-04-23-003-feat-content-embeddings-fallback-plan.md`](docs/plans/2026-04-23-003-feat-content-embeddings-fallback-plan.md) — a deterministic 128-dim TF-IDF + truncated-SVD embedding substrate wired into the scorer behind `_ENABLE_EMBEDDING_CONTRIBUTION = False`.

- 7 implementation units across 4 phases (infra, commander target + reader, diagnostic, scorer flip)
- Zero new runtime deps — hand-rolled TF-IDF + `numpy.linalg.svd` only
- Hybrid hash discipline: `EmbeddingConfigInputs` (on-disk KV table) + `ScoringConfigInputs.vectorizer_version` (pinned tensor) — two independent staleness guards
- Graceful-fallback contract: inference path never raises from embedding code (widened after review, R-001..R-004 fixed)
- `bench.py audit --embedding-dedup` complements `--collinearity` for rule-pair redundancy diagnosis
- Flag stays False; only Unit 7 reshapes `ScoringConfigInputs`, fixture re-pinned (Δ=+0.0000 across 100 commanders)

## Test plan

- [x] 115 new tests across `tests/embeddings/`, `tests/bench/`, and top-level — all pass
- [x] Full suite: **1685 passed**, coverage **87.63%** (gate 80%)
- [x] `uv run pyright src/`: 0 errors
- [x] `uv run ruff check` + `ruff format --check`: clean
- [x] `uv run scripts/bench.py audit --expect-identity` on re-pinned fixture: **PASS**
- [x] Advisory pre-commit bench-audit hook reports TRIVIAL (Δ=+0.0000, 100 cmdrs, histogram no_change=100) at every review fix commit

## Review

[\`/compound-engineering:ce-code-review\`](.context/compound-engineering/ce-code-review/20260423-213012-17f8d1eb/) ran with 13 reviewers (6 always-on + 6 cross-cutting + 1 stack-specific). Outcome:

- **15 fixes landed** in-branch (6 safe_auto in \`ab8b2a3\`, 9 gated_auto in \`c507b29\`)
- **5 pre-flag-flip follow-ups** queued in [\`docs/reviews/2026-04-23-content-embeddings-followups.md\`](docs/reviews/2026-04-23-content-embeddings-followups.md) (\`abd3a13\`)
- **17 P3 advisory** findings bundled in the same doc

Notable fixes applied during review:
- CLAUDE.md updated per plan's Documentation Plan (Common Commands + Scoring Architecture section)
- Graceful-fallback contract widened at 4 sites to meet plan D6 "never raises from inference path"
- Blob endianness canonicalized to `'<f4'` (cross-arch portability)
- \`event_class\` NOT NULL enforcement (verified schema, moved out of optional token set)
- Factually incorrect \`ScoringConfigInputs\` comment corrected
- Private \`_ENABLE_EMBEDDING_CONTRIBUTION\` removed from public \`__all__\`

## Operational next step (post-merge, separate commit)

Audit sweep per plan FR7: iterate \`w_emb ∈ {0.1, 0.3, 0.5, 1.0}\` × \`k ∈ {0.5, 0.8, 1.2}\`, flipping \`_ENABLE_EMBEDDING_CONTRIBUTION = True\` locally; pick the combo that improves aggregate NDCG **and** \`hidden_gem_hit_rate\` without any commander regressing beyond MARGINAL. The 5 deferred follow-ups resolve at flag-flip time — they're tracked in \`docs/reviews/\`.