### PR TITLE
fix(bench): optimizer follow-up batch D — correctness + edge cases

### DIFF
--- a/src/mtg_synergy_graph/bench/optimize.py
+++ b/src/mtg_synergy_graph/bench/optimize.py
@@ -641,6 +641,97 @@ def _score_split(
     return composite_objective(per_ndcg, per_gem, alpha)
 
 
+def _apply_drift_revert(
+    *,
+    history: list[OptimizerStep],
+    accepted_step_indices: list[int],
+    n_steps_accepted: int,
+    n_steps_rejected: int,
+) -> tuple[int, int]:
+    """Cumulative-drift revert: mark every accepted step as reverted, return updated counters.
+
+    Mutates ``history`` (replaces each accepted ``OptimizerStep`` with a copy
+    flagged ``accepted=False, reject_reason="cumulative_drift_revert"``) and
+    clears ``accepted_step_indices``. Returns the corrected
+    ``(n_steps_accepted, n_steps_rejected)`` so the caller can update its own
+    counters and reset metrics atomically.
+
+    Used at two trip points: mid-sweep (after every accept) and sweep-boundary
+    backstop. Both call sites must reset metrics to baseline values themselves —
+    this helper only owns the history bookkeeping.
+    """
+    for idx in accepted_step_indices:
+        step = history[idx]
+        history[idx] = OptimizerStep(
+            sweep_n=step.sweep_n,
+            rule_id=step.rule_id,
+            old_value=step.old_value,
+            new_value=step.new_value,
+            train_composite=step.train_composite,
+            held_composite=step.held_composite,
+            train_ndcg=step.train_ndcg,
+            held_ndcg=step.held_ndcg,
+            train_gem=step.train_gem,
+            held_gem=step.held_gem,
+            accepted=False,
+            reject_reason="cumulative_drift_revert",
+        )
+        n_steps_accepted -= 1
+        n_steps_rejected += 1
+    accepted_step_indices.clear()
+    return n_steps_accepted, n_steps_rejected
+
+
+def _select_self_test_plant(
+    baseline_weights: Mapping[str, float],
+    *,
+    seed: int,
+    planted_mult: float,
+    clamp_min: float,
+    clamp_max: float,
+) -> tuple[str, float]:
+    """Pick a (rule_id, planted_value) pair that doesn't collapse to baseline under clamp.
+
+    Tries rules in deterministic seed-shuffled order. For each rule, tries the
+    UP direction first (``baseline × planted_mult``); if that clamps back to
+    baseline (rule already at ``clamp_max``), tries the DOWN direction
+    (``baseline / planted_mult``). The 0.5×/2.0× grid recovers either way —
+    a 2× plant lands exactly back on baseline at grid 0.5×, and a 0.5× plant
+    lands exactly on baseline at grid 2.0×.
+
+    Returns the first rule with non-trivial planting room. Raises only if EVERY
+    rule has zero room in both directions (only possible when every rule's
+    baseline is simultaneously pinned at clamp_min == clamp_max, which is
+    structurally unreachable for the default config and would mean the
+    catalogue is unusable anyway).
+
+    Raises:
+        OptimizerSelfTestFailed: no rule has planting room.
+    """
+    rng = random.Random(seed)  # noqa: S311 — determinism, not crypto
+    candidates = list(baseline_weights.keys())
+    rng.shuffle(candidates)
+
+    for rule_id in candidates:
+        baseline_value = baseline_weights[rule_id]
+        # Try UP direction first (the original 2.0× plant).
+        up_value = _clamp(baseline_value * planted_mult, clamp_min, clamp_max)
+        if up_value != baseline_value:
+            return rule_id, up_value
+        # UP collapsed (baseline at clamp_max). Try DOWN: baseline / planted_mult.
+        # The grid recovers symmetrically — 0.5× plant + 2.0× grid step = baseline.
+        down_value = _clamp(baseline_value / planted_mult, clamp_min, clamp_max)
+        if down_value != baseline_value:
+            return rule_id, down_value
+
+    raise OptimizerSelfTestFailed(
+        f"self-test could not find ANY rule with planting room: every rule's "
+        f"baseline collapses under both x{planted_mult} (UP) and /{planted_mult} (DOWN) "
+        f"clamping (clamp_min={clamp_min}, clamp_max={clamp_max}). "
+        "The catalogue may be misconfigured."
+    )
+
+
 def _planted_perturbation_self_test(
     conn: sqlite3.Connection,
     edhrec_conn: sqlite3.Connection,
@@ -652,34 +743,30 @@ def _planted_perturbation_self_test(
     labels_cache: dict[str, EdhrecLabels],
     candidate_cache: CandidateCache | None = None,
 ) -> None:
-    """Plant a 2.0x perturbation on a random rule; assert recovery on the grid.
+    """Plant a 2.0x perturbation on a rule; assert recovery on the grid.
+
+    Picks the rule via :func:`_select_self_test_plant`, which rotates through
+    rules in deterministic shuffled order until one has planting room (handles
+    the case where the seed-picked rule's baseline is already at ``clamp_max``).
 
     Sweeps ``config.grid`` from the planted state and verifies the optimizer's
     chosen multiplier lands within ``self_test_recovery_tolerance`` of the
-    baseline value. The grid step ``0.5x`` against a ``2.0x`` plant lands
-    exactly on baseline; ±5% tolerance accommodates float noise but rejects
-    "couldn't recover at all" failures.
+    baseline value. The grid step ``0.5x`` against a ``2.0x`` plant (or
+    ``2.0x`` against a ``0.5x`` plant) lands exactly on baseline; ±5% tolerance
+    accommodates float noise but rejects "couldn't recover at all" failures.
 
     Raises:
-        OptimizerSelfTestFailed: optimizer could not recover the baseline.
+        OptimizerSelfTestFailed: optimizer could not recover the baseline,
+            or no rule has planting room.
     """
-    rule_id = random.Random(config.self_test_seed).choice(list(baseline_weights.keys()))  # noqa: S311
-    baseline_value = baseline_weights[rule_id]
-    planted_value = _clamp(
-        baseline_value * config.self_test_planted_mult,
-        config.clamp_min,
-        config.clamp_max,
+    rule_id, planted_value = _select_self_test_plant(
+        baseline_weights,
+        seed=config.self_test_seed,
+        planted_mult=config.self_test_planted_mult,
+        clamp_min=config.clamp_min,
+        clamp_max=config.clamp_max,
     )
-
-    if planted_value == baseline_value:
-        # Plant collapsed to baseline due to clamp — pick a different rule.
-        # Practically impossible at default config; bail with a clear message.
-        raise OptimizerSelfTestFailed(
-            f"self-test plant for {rule_id!r} collapsed to baseline under clamp; "
-            f"baseline={baseline_value}, planted_target={baseline_value * config.self_test_planted_mult}, "
-            f"clamp=({config.clamp_min}, {config.clamp_max})"
-        )
-
+    baseline_value = baseline_weights[rule_id]
     planted_weights = {**baseline_weights, rule_id: planted_value}
 
     # Sweep the grid from the planted state; track the best train composite.
@@ -818,6 +905,25 @@ def run_optimizer(
         candidate_cache=candidate_cache,
     )
 
+    # Slug-mismatch / EDHREC-empty warning. After both baseline calls populate
+    # labels_cache for every commander, count those whose top_30_set is None
+    # (no high-synergy data — typically a slug mismatch or a brand-new commander
+    # not yet on EDHREC). If a meaningful fraction of the catalogue lacks data,
+    # the gem axis silently degrades to zero contribution. Warn once with the
+    # aggregate count instead of spamming per-commander.
+    missing_gem = [c for c, lbls in labels_cache.items() if lbls.top_30_set is None]
+    if missing_gem:
+        n_total = len(labels_cache)
+        pct = (len(missing_gem) / n_total) * 100 if n_total else 0.0
+        _logger.warning(
+            "EDHREC labels missing for %d/%d commanders (%.1f%%) — gem axis will "
+            "contribute nothing for these. Sample: %s",
+            len(missing_gem),
+            n_total,
+            pct,
+            ", ".join(sorted(missing_gem)[:5]) + ("..." if len(missing_gem) > 5 else ""),
+        )
+
     # Identify dead keys after baseline scoring populates the complements cache.
     firing_rules: set[str] = set()
     for comps in complements_cache.values():
@@ -937,46 +1043,53 @@ def run_optimizer(
                 n_steps_accepted += 1
                 accepted_step_indices.append(len(history) - 1)
                 sweep_had_accept = True
+
+                # Mid-sweep cumulative-drift check. Trip earlier if accepts have
+                # already drifted held below the cumulative gate. Without this,
+                # a wall-clock-aborted sweep would skip the drift check entirely
+                # (the boundary check at the end of sweep_n only fires when the
+                # sweep completes), and intra-sweep drift escapes detection.
+                if current_held_composite - baseline_held.composite < -config.eps_cumulative:
+                    n_steps_accepted, n_steps_rejected = _apply_drift_revert(
+                        history=history,
+                        accepted_step_indices=accepted_step_indices,
+                        n_steps_accepted=n_steps_accepted,
+                        n_steps_rejected=n_steps_rejected,
+                    )
+                    current_weights = dict(baseline_weights)
+                    current_train_composite = baseline_train.composite
+                    current_held_composite = baseline_held.composite
+                    current_train_ndcg = baseline_train.mean_ndcg
+                    current_held_ndcg = baseline_held.mean_ndcg
+                    current_train_gem = baseline_train.gem_rate
+                    current_held_gem = baseline_held.gem_rate
+                    partial_sweep = True
+                    break
             else:
                 n_steps_rejected += 1
 
-        # End of sweep: cumulative-drift check (only if we didn't already abort).
+        # End of sweep. If wall-clock or mid-sweep drift already aborted, exit.
         if partial_sweep:
             break
 
-        held_drift = current_held_composite - baseline_held.composite
-        if held_drift < -config.eps_cumulative:
-            # Cumulative drift trip: roll back to baseline weights AND mark every
-            # accept across all sweeps as reverted. The metrics-vs-weights
-            # invariant (final_weights describes the state that produced the
-            # final composite values) is preserved by resetting both together.
+        # Sweep-boundary drift check is now a backstop — most drift trips will
+        # fire mid-sweep above. Kept here for defense-in-depth and so the trip
+        # condition is identical at both call sites.
+        if current_held_composite - baseline_held.composite < -config.eps_cumulative:
+            n_steps_accepted, n_steps_rejected = _apply_drift_revert(
+                history=history,
+                accepted_step_indices=accepted_step_indices,
+                n_steps_accepted=n_steps_accepted,
+                n_steps_rejected=n_steps_rejected,
+            )
             current_weights = dict(baseline_weights)
-            for idx in accepted_step_indices:
-                step = history[idx]
-                history[idx] = OptimizerStep(
-                    sweep_n=step.sweep_n,
-                    rule_id=step.rule_id,
-                    old_value=step.old_value,
-                    new_value=step.new_value,
-                    train_composite=step.train_composite,
-                    held_composite=step.held_composite,
-                    train_ndcg=step.train_ndcg,
-                    held_ndcg=step.held_ndcg,
-                    train_gem=step.train_gem,
-                    held_gem=step.held_gem,
-                    accepted=False,
-                    reject_reason="cumulative_drift_revert",
-                )
-                n_steps_accepted -= 1
-                n_steps_rejected += 1
-            accepted_step_indices.clear()
-            partial_sweep = True
             current_train_composite = baseline_train.composite
             current_held_composite = baseline_held.composite
             current_train_ndcg = baseline_train.mean_ndcg
             current_held_ndcg = baseline_held.mean_ndcg
             current_train_gem = baseline_train.gem_rate
             current_held_gem = baseline_held.gem_rate
+            partial_sweep = True
             break
 
         # Convergence: no perturbation accepted this sweep.
@@ -1216,12 +1329,14 @@ def _history_row_for_step(step: OptimizerStep, timestamp: str, run_id: str) -> l
 # ---------------------------------------------------------------------------
 
 
-#: Minimum commander count for a meaningful train/held split. Below this,
-#: ``round(n * 0.8)`` may produce ``held=0``, which makes the held-eps gate
-#: trivially pass and silently nullifies cross-validation. The pinned golden
-#: set has 100 commanders; this floor is a usability guardrail for
-#: CLI invocations against a synthetic or hand-built fixture.
-_MIN_COMMANDERS_FOR_SPLIT = 5
+#: Minimum commander count for a non-degenerate train/held split.
+#: At ``train_ratio=0.8`` (default), ``round(n * 0.8)`` produces ``held=0``
+#: when ``n <= 2`` (round(0.8)=1, round(1.6)=2). At ``n=3`` the split is
+#: 2 train + 1 held — the smallest input that doesn't trivially pass the
+#: held-eps gate. Below this, cross-validation is silently nullified.
+#: The pinned golden set has 100 commanders; this floor is a usability
+#: guardrail for CLI invocations against a synthetic or hand-built fixture.
+_MIN_COMMANDERS_FOR_SPLIT = 3
 
 
 def handle_optimize(args: argparse.Namespace) -> int:

--- a/tests/bench/test_optimize.py
+++ b/tests/bench/test_optimize.py
@@ -974,6 +974,80 @@ class TestPlantedPerturbationSelfTest:
         assert "baseline=" in str(exc.value)
         assert "recovered=" in str(exc.value)
 
+    def test_select_plant_rotates_when_picked_rule_at_clamp_max(self) -> None:
+        """If the seed-picked rule is at clamp_max, _select_self_test_plant rotates to a rule with room.
+
+        Regression test for the false-positive where applying a proposal that
+        pushes any rule to clamp_max=5.0 would cause the next run's self-test
+        to raise OptimizerSelfTestFailed("plant collapsed to baseline").
+        """
+        from mtg_synergy_graph.bench.optimize import _select_self_test_plant
+
+        # alpha_rule pinned at clamp_max → ×2.0 collapses; ÷2.0 should be picked
+        # (or the function should rotate to beta_rule which has full room).
+        baseline = {"alpha_rule": 5.0, "beta_rule": 1.0, "gamma_rule": 1.0}
+        rule_id, planted_value = _select_self_test_plant(
+            baseline, seed=0, planted_mult=2.0, clamp_min=0.01, clamp_max=5.0
+        )
+        # Either rotated to a different rule, or stayed on alpha_rule with the
+        # DOWN direction (5.0 / 2.0 = 2.5).
+        if rule_id == "alpha_rule":
+            assert planted_value == pytest.approx(2.5)
+        else:
+            # Rotated to beta_rule or gamma_rule; both have full room either direction.
+            assert rule_id in {"beta_rule", "gamma_rule"}
+            assert planted_value != baseline[rule_id]
+            # Plant must be at the configured ×2.0 (UP) since these rules have room.
+            assert planted_value == pytest.approx(2.0)
+
+    def test_select_plant_raises_when_every_rule_pinned(self) -> None:
+        """When every rule is structurally pinned (clamp_min == clamp_max == baseline), raise."""
+        from mtg_synergy_graph.bench.optimize import _select_self_test_plant
+
+        baseline = {"alpha_rule": 1.0}
+        # Every rule's baseline is pinned at the only allowed value.
+        with pytest.raises(OptimizerSelfTestFailed, match="planting room"):
+            _select_self_test_plant(baseline, seed=0, planted_mult=2.0, clamp_min=1.0, clamp_max=1.0)
+
+    def test_self_test_passes_with_rule_at_clamp_max(
+        self,
+        fake_conns: tuple[object, object],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """End-to-end: a baseline at clamp_max no longer trips the self-test.
+
+        Pre-fix: this scenario raised ``OptimizerSelfTestFailed("collapsed to
+        baseline")`` immediately and the whole run aborted with rc=3.
+        Post-fix: the self-test rotates direction (or rule) and passes.
+        """
+        from mtg_synergy_graph import universal_scorer
+        from mtg_synergy_graph.bench import optimize as opt_mod
+
+        # Set alpha_rule to clamp_max so its UP-direction plant collapses.
+        # beta_rule and gamma_rule are at the default 1.0 (full room).
+        saved = dict(universal_scorer._RULE_QUALITY_MULTIPLIER)
+        universal_scorer._RULE_QUALITY_MULTIPLIER.clear()
+        universal_scorer._RULE_QUALITY_MULTIPLIER.update({"alpha_rule": 5.0, "beta_rule": 1.0, "gamma_rule": 1.0})
+        try:
+            baseline = dict(universal_scorer._RULE_QUALITY_MULTIPLIER)
+
+            def _composite_all_rules(weights: Mapping[str, float]) -> float:
+                total_delta = sum(abs(weights[k] - baseline[k]) for k in baseline)
+                return 1.0 - total_delta
+
+            monkeypatch.setattr(
+                opt_mod,
+                "_score_split",
+                _scripted_score_split(composite_for_weights=_composite_all_rules),
+            )
+
+            config = OptimizerConfig(run_self_test=True, max_sweeps=0, self_test_seed=0)
+            # Should NOT raise.
+            run_optimizer(*fake_conns, ["a", "b", "c", "d", "e"], config=config)
+        finally:
+            universal_scorer._RULE_QUALITY_MULTIPLIER.clear()
+            universal_scorer._RULE_QUALITY_MULTIPLIER.update(saved)
+
 
 class TestRunOptimizerSmoke:
     """End-to-end smoke run against the real-DB scoring fixture."""
@@ -1326,18 +1400,24 @@ class TestHandleOptimize:
         assert "empty" in captured.err
 
     def test_returns_2_on_too_few_commanders(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-        """Fixture below ``_MIN_COMMANDERS_FOR_SPLIT`` is rejected to avoid degenerate held=0 split."""
+        """Fixture below ``_MIN_COMMANDERS_FOR_SPLIT`` (3) is rejected to avoid degenerate held=0 split.
+
+        The threshold is 3: at ``train_ratio=0.8``, ``round(n * 0.8)``
+        produces ``held=0`` only when ``n <= 2``. At ``n=3`` the split is
+        2 train + 1 held — minimal but non-degenerate.
+        """
         import argparse
 
         from mtg_synergy_graph.bench.fixture import FixtureEntry, PinnedFixture
         from mtg_synergy_graph.bench.optimize import handle_optimize
 
-        # 3 commanders < 5 minimum. Use a fake config_hash so we'd hit the
-        # stale-tensor check next; but the size check must fire FIRST.
+        # 2 commanders < 3 minimum (round(2 * 0.8) = 2 → held=0). Use a fake
+        # config_hash so we'd hit the stale-tensor check next; the size check
+        # must fire FIRST.
         fixture = PinnedFixture(
             config_hash="0" * 64,
             created_at="2026-01-01T00:00:00+00:00",
-            entries=[FixtureEntry(commander=f"Cmdr {i}", scores={"a": 1.0}) for i in range(3)],
+            entries=[FixtureEntry(commander=f"Cmdr {i}", scores={"a": 1.0}) for i in range(2)],
         )
         fixture_path = tmp_path / "fixture.json"
         fixture.write(fixture_path)
@@ -1355,8 +1435,8 @@ class TestHandleOptimize:
         rc = handle_optimize(args)
         assert rc == 2
         captured = capsys.readouterr()
-        assert "3 commanders" in captured.err
-        assert "at least 5" in captured.err
+        assert "2 commanders" in captured.err
+        assert "at least 3" in captured.err
 
     def test_returns_2_on_stale_tensor(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         import argparse
@@ -1365,12 +1445,12 @@ class TestHandleOptimize:
         from mtg_synergy_graph.bench.optimize import handle_optimize
 
         # Fixture with a fake config_hash that won't match the live one. Must
-        # have at least _MIN_COMMANDERS_FOR_SPLIT entries so the stale-tensor
+        # have at least _MIN_COMMANDERS_FOR_SPLIT (3) entries so the stale-tensor
         # check fires before the size check.
         fixture = PinnedFixture(
             config_hash="0" * 64,
             created_at="2026-01-01T00:00:00+00:00",
-            entries=[FixtureEntry(commander=f"Cmdr {i}", scores={"a": 1.0}) for i in range(5)],
+            entries=[FixtureEntry(commander=f"Cmdr {i}", scores={"a": 1.0}) for i in range(3)],
         )
         fixture_path = tmp_path / "fixture.json"
         fixture.write(fixture_path)


### PR DESCRIPTION
## Summary

Batch D of the post-merge code-review residual work for the tensor-weight optimizer. 4 correctness fixes (#20 deferred — see below).

## Findings applied

### #12 — Self-test rule rotation when plant collapses at clamp

**Pre-fix:** If a baseline weight is at `clamp_max=5.0` (e.g., after a proposal pushes any rule to ceiling), the next run computed `clamp(5.0 × 2.0) = 5.0 = baseline` and raised `OptimizerSelfTestFailed("plant collapsed to baseline")` — surfacing as rc=3 "calibration broken" when the actual issue was a structural ceiling. **This was a latent bomb** that would fire after the first cycle of "apply proposal → re-pin → run optimizer again."

**Post-fix:** Extracted `_select_self_test_plant` helper that tries rules in deterministic shuffled order. For each rule, tries UP direction (`× planted_mult`) first; if clamped, falls back to DOWN (`/ planted_mult`). Only raises if every rule has zero room in both directions (structurally unreachable for the default config). Three new tests cover the rotation path, the all-pinned edge case, and end-to-end behavior with a baseline pinned at clamp_max.

### #10 — Mid-sweep cumulative-drift check

**Pre-fix:** Drift check fired only at sweep boundary; a wall-clock-aborted sweep skipped it entirely, so intra-sweep drift could escape detection.

**Post-fix:** Extracted `_apply_drift_revert` helper called at two trip points — after each accept (mid-sweep) and at the sweep boundary as a backstop. Same revert semantics either way: restore baseline weights, mark every accepted step as `cumulative_drift_revert`, reset metrics. The existing `test_cumulative_drift_revert_restores_baseline_and_marks_all_accepts` covers both paths since the trip now fires after the first accept that crosses the cumulative threshold.

### #14 — EDHREC slug-mismatch warning at `run_optimizer` entry

**Pre-fix:** `load_edhrec_labels` returned empty labels on slug mismatch silently. Composite degraded to α·ndcg with no diagnostic. If most commanders misslug, the entire run silently dropped the gem axis.

**Post-fix:** After both baseline scoring calls populate `labels_cache`, count commanders whose `top_30_set is None` (typically slug mismatch or brand-new commander not on EDHREC) and emit a single `_logger.warning` with aggregate count + sample list. One-shot per run, not per sweep.

### #30 — Lower `_MIN_COMMANDERS_FOR_SPLIT` from 5 to 3

**Pre-fix:** Stated rationale was "round(n × 0.8) may produce held=0" — but held=0 only at n ≤ 2. The 5 threshold rejected valid 3- and 4-commander inputs.

**Post-fix:** 3 is the smallest non-degenerate split (2 train + 1 held). Updated `test_returns_2_on_too_few_commanders` to use n=2 (the actual degenerate case) and the stale-tensor test to use n=3.

## Deferred from Batch D

- **#20** (atomic dict swap): the concurrent-reader concern flagged by the adversarial reviewer (pytest-xdist seeing empty dict between `clear()` and `update()`) is theoretical for single-process sequential use. The proper fix — threading weights through `_score_from_complements` instead of reading from a module global — is an architectural refactor that should land independently if/when the optimizer becomes multi-process.

## Test plan

- [x] `uv run pytest tests/` — 1794 passed, 1 skipped, 21 deselected (was 1791; +3 new tests for self-test rotation)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pyright src/mtg_synergy_graph/bench/optimize.py tests/bench/test_optimize.py` — 0 errors
- [x] `uv run scripts/bench.py audit --expect-identity` — PASS
- [x] Pre-commit hooks (ruff/format/pyright/pytest/bench-audit) — all PASS

## Residual work after this PR

19 of 24 original residual findings remain — see `.context/compound-engineering/ce-code-review/20260430-114255-57721f90/residual-work.md` (Batch A handled #6, #27, #32, #33, #35; Batch D handles #10, #12, #14, #30 here). Notable still-pending:

- **Batch B (perf)**: #7 IDF basis cache + #9 contributions skip (~30-50% additional sweep speedup; #9 has gem-rate selection-bias risk)
- **#4** (CLI): route success message to stdout via `--format json` flag
- **#39** (agent-native): expose `--alpha`, `--grid`, `--eps-step`, etc.
- **Batch C** test gaps: #23-26, #31
- **#20** atomic dict swap (architectural)