### PR TITLE
perf(bench): cache IDF basis per commander across grid cells

### DIFF
--- a/src/mtg_synergy_graph/bench/optimize.py
+++ b/src/mtg_synergy_graph/bench/optimize.py
@@ -46,7 +46,11 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from mtg_synergy_graph.complement_rules import PortComplement
-    from mtg_synergy_graph.universal_scorer import CandidateCache, UniversalScore
+    from mtg_synergy_graph.universal_scorer import (
+        CandidateCache,
+        IdfBasis,
+        UniversalScore,
+    )
 
 # ---------------------------------------------------------------------------
 # Unit 1: Composite α-blended objective
@@ -402,6 +406,7 @@ def score_commander_from_complements(
     complements: Sequence[PortComplement],
     *,
     candidate_cache: CandidateCache | None = None,
+    idf_basis: IdfBasis | None = None,
 ) -> CommanderScoreResult:
     """Score one commander given precomputed complements.
 
@@ -411,6 +416,12 @@ def score_commander_from_complements(
     if grid-cell weights differ from baseline. ``_score_from_complements``
     handles the staple/circuit/cmc/rank/embedding side-channels exactly
     as ``score_all_universal`` does.
+
+    When ``idf_basis`` is supplied, the inner ``_compute_idf_weights`` walk
+    is replaced with a cheap ``_RULE_QUALITY_MULTIPLIER`` lookup over the
+    cached basis. The basis is weight-independent (see :class:`IdfBasis`),
+    so the optimizer can build it once per commander and reuse across
+    every grid cell.
 
     The returned ``score_by_candidate`` and ``top_30`` use
     ``to_legacy_buckets()["total"]`` — the production sort key from
@@ -425,6 +436,7 @@ def score_commander_from_complements(
         [commander],
         complements,
         candidate_cache=candidate_cache,
+        idf_basis=idf_basis,
     )
 
     # Production sort key: (-total, cmc_bonus_inverse_proxy, edhrec_rank, name).
@@ -584,6 +596,7 @@ def _score_split(
     labels_cache: dict[str, EdhrecLabels],
     alpha: float,
     candidate_cache: CandidateCache | None = None,
+    idf_basis_cache: dict[str, IdfBasis] | None = None,
 ) -> CompositeObjective:
     """Score a commander split with the given weights; return composite objective.
 
@@ -597,12 +610,19 @@ def _score_split(
     entry and threaded through; without it, each grid-cell evaluation re-issues
     a full ``SELECT name, cmc, edhrec_rank FROM cards`` table scan, costing
     ~5x wall-clock on a 100-commander × 53-key × 5-grid sweep.
+
+    ``idf_basis_cache`` is the per-commander IDF basis (frequency counts +
+    log2 + cond_mult, all weight-independent). Populated lazily on first miss
+    alongside ``complements_cache``; reused across every grid cell so the
+    inner ``_compute_idf_weights`` walk is replaced by a per-key
+    ``_RULE_QUALITY_MULTIPLIER`` lookup.
     """
     from mtg_synergy_graph import universal_scorer
     from mtg_synergy_graph.bench.hidden_gems import (
         hidden_gem_hit_rate_for_commander,
     )
     from mtg_synergy_graph.complement_rules import find_all_complements
+    from mtg_synergy_graph.universal_scorer import _compute_idf_basis
     from mtg_synergy_graph.validate import compute_ndcg
 
     baseline = dict(universal_scorer._RULE_QUALITY_MULTIPLIER)
@@ -620,7 +640,18 @@ def _score_split(
                 labels_cache[cmdr] = load_edhrec_labels(edhrec_conn, cmdr)
             labels = labels_cache[cmdr]
 
-            result = score_commander_from_complements(conn, cmdr, comps, candidate_cache=candidate_cache)
+            # Lazy-fill the IDF basis for this commander on first miss. The
+            # basis is weight-independent, so subsequent grid cells skip the
+            # frequency-counting walk entirely.
+            cmdr_basis: IdfBasis | None = None
+            if idf_basis_cache is not None:
+                if cmdr not in idf_basis_cache:
+                    idf_basis_cache[cmdr] = _compute_idf_basis(comps)
+                cmdr_basis = idf_basis_cache[cmdr]
+
+            result = score_commander_from_complements(
+                conn, cmdr, comps, candidate_cache=candidate_cache, idf_basis=cmdr_basis
+            )
             ndcg = compute_ndcg(list(result.top_30), dict(labels.graded_labels))
             per_ndcg[cmdr] = ndcg
 
@@ -742,6 +773,7 @@ def _planted_perturbation_self_test(
     complements_cache: dict[str, list[PortComplement]],
     labels_cache: dict[str, EdhrecLabels],
     candidate_cache: CandidateCache | None = None,
+    idf_basis_cache: dict[str, IdfBasis] | None = None,
 ) -> None:
     """Plant a 2.0x perturbation on a rule; assert recovery on the grid.
 
@@ -780,6 +812,7 @@ def _planted_perturbation_self_test(
         labels_cache=labels_cache,
         alpha=config.alpha,
         candidate_cache=candidate_cache,
+        idf_basis_cache=idf_basis_cache,
     ).composite
 
     for mult in config.grid:
@@ -796,6 +829,7 @@ def _planted_perturbation_self_test(
             labels_cache=labels_cache,
             alpha=config.alpha,
             candidate_cache=candidate_cache,
+            idf_basis_cache=idf_basis_cache,
         )
         if obj.composite > best_composite:
             best_composite = obj.composite
@@ -867,6 +901,11 @@ def run_optimizer(
 
     complements_cache: dict[str, list[PortComplement]] = {}
     labels_cache: dict[str, EdhrecLabels] = {}
+    # Per-commander IDF basis cache. Lazily filled on first miss inside
+    # _score_split. Reused across every grid cell to skip the O(complements)
+    # frequency-counting walk in _compute_idf_weights — only the per-key
+    # _RULE_QUALITY_MULTIPLIER lookup runs per cell.
+    idf_basis_cache: dict[str, IdfBasis] = {}
 
     # Run self-test BEFORE measuring baseline — both for sequencing clarity and
     # because the self-test mutates only its own internal state via try/finally.
@@ -880,6 +919,7 @@ def run_optimizer(
             complements_cache=complements_cache,
             labels_cache=labels_cache,
             candidate_cache=candidate_cache,
+            idf_basis_cache=idf_basis_cache,
         )
 
     # Baseline objectives. After this call, complements/labels caches are warm
@@ -893,6 +933,7 @@ def run_optimizer(
         labels_cache=labels_cache,
         alpha=config.alpha,
         candidate_cache=candidate_cache,
+        idf_basis_cache=idf_basis_cache,
     )
     baseline_held = _score_split(
         conn,
@@ -903,6 +944,7 @@ def run_optimizer(
         labels_cache=labels_cache,
         alpha=config.alpha,
         candidate_cache=candidate_cache,
+        idf_basis_cache=idf_basis_cache,
     )
 
     # Slug-mismatch / EDHREC-empty warning. After both baseline calls populate
@@ -977,6 +1019,7 @@ def run_optimizer(
                     labels_cache=labels_cache,
                     alpha=config.alpha,
                     candidate_cache=candidate_cache,
+                    idf_basis_cache=idf_basis_cache,
                 )
                 if best_train is None or train_obj.composite > best_train.composite:
                     best_train = train_obj
@@ -997,6 +1040,7 @@ def run_optimizer(
                 labels_cache=labels_cache,
                 alpha=config.alpha,
                 candidate_cache=candidate_cache,
+                idf_basis_cache=idf_basis_cache,
             )
 
             held_delta = held_obj.composite - current_held_composite

--- a/src/mtg_synergy_graph/universal_scorer.py
+++ b/src/mtg_synergy_graph/universal_scorer.py
@@ -13,7 +13,7 @@ import logging
 import math
 import sqlite3
 from collections import defaultdict
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from functools import cached_property
 from pathlib import Path
@@ -579,6 +579,92 @@ _FLAT_WEIGHT_OVERRIDES: dict[str, float] = _LOADED_SCORING_WEIGHTS.flat_weight_o
 _RULE_QUALITY_MULTIPLIER: dict[str, float] = _LOADED_SCORING_WEIGHTS.rule_quality_multiplier
 
 
+@dataclass(frozen=True)
+class IdfBasis:
+    """Per-commander IDF basis: weight-independent components of ``_compute_idf_weights``.
+
+    Splits the IDF computation into two parts:
+
+    * **Weight-independent** (this dataclass): frequency counts, ``1/log2(1+N)``,
+      ``cond_mult``, and the flat-rule overrides. Cacheable per commander.
+    * **Weight-dependent** (:func:`_idf_weights_from_basis`): a single
+      ``_RULE_QUALITY_MULTIPLIER`` lookup per non-flat key.
+
+    The bench optimizer caches one ``IdfBasis`` per commander alongside its
+    ``complements_cache`` and reuses it across every grid-cell evaluation.
+    Per-cell cost drops from ``O(complements)`` frequency counting to
+    ``O(unique_keys)`` multiplier lookup.
+
+    Cache invalidation contract: ``IdfBasis`` depends on the complements list
+    AND on ``_FLAT_WEIGHT_OVERRIDES`` (which the M1 optimizer does not sweep)
+    AND on the static dampening logic (``_FLAT_COUNT_RULES``, panharmonicon
+    floor, ``cond_mult``). It does NOT depend on ``_RULE_QUALITY_MULTIPLIER``.
+    A future optimizer variant that sweeps ``_FLAT_WEIGHT_OVERRIDES`` MUST
+    rebuild the basis on every override change.
+
+    Attributes:
+        flat_weights: Final IDF weights for ``_FLAT_COUNT_RULES`` keys
+            (already include ``base_w * cond_mult``; no per-cell work).
+        base_idf_non_flat: Pre-multiplier IDF weights for non-flat keys —
+            ``(1/log2(1+N)) * cond_mult``. Multiply by
+            ``_RULE_QUALITY_MULTIPLIER[rule_id]`` per cell.
+    """
+
+    flat_weights: Mapping[tuple[str, str, str, str], float]
+    base_idf_non_flat: Mapping[tuple[str, str, str, str], float]
+
+
+def _compute_idf_basis(complements: Sequence[PortComplement]) -> IdfBasis:
+    """Build the weight-independent IDF basis for one commander's complements.
+
+    See :class:`IdfBasis` for the cache invariant. Mirrors the frequency
+    counting + ``cond_mult`` + flat-override + log2 logic from
+    :func:`_compute_idf_weights`, but stops short of applying
+    ``_RULE_QUALITY_MULTIPLIER``.
+    """
+    freq: dict[tuple[str, str, str, str], set[str]] = defaultdict(set)
+    for c in complements:
+        key = (c.rule_id, c.cmdr_event, c.cand_event, c.filter_group)
+        freq[key].add(c.candidate)
+
+    flat_weights: dict[tuple[str, str, str, str], float] = {}
+    base_idf_non_flat: dict[tuple[str, str, str, str], float] = {}
+    for key, candidates in freq.items():
+        rule_id = key[0]
+        filter_group = key[3] or ""
+        # Effect-conditional dampening: see _compute_idf_weights docstring.
+        cond_mult = 0.5 if filter_group.endswith(":cond") else 1.0
+        if rule_id in _FLAT_COUNT_RULES:
+            override = _FLAT_WEIGHT_OVERRIDES.get(rule_id)
+            base_w = override if override is not None else 1.0
+            flat_weights[key] = base_w * cond_mult
+        else:
+            n = len(candidates)
+            cmdr_event = key[1]
+            if rule_id == "panharmonicon" and "reverse" not in cmdr_event and "stack" not in cmdr_event:
+                n = max(n, 30)
+            base_idf_non_flat[key] = (1.0 / math.log2(1.0 + n)) * cond_mult
+    return IdfBasis(
+        flat_weights=flat_weights,
+        base_idf_non_flat=base_idf_non_flat,
+    )
+
+
+def _idf_weights_from_basis(basis: IdfBasis) -> dict[tuple[str, str, str, str], float]:
+    """Apply current ``_RULE_QUALITY_MULTIPLIER`` to a cached :class:`IdfBasis`.
+
+    The hot-path inner-loop equivalent of :func:`_compute_idf_weights` when
+    the caller has already paid the frequency-counting cost. ``flat_weights``
+    pass through unchanged; non-flat keys get the per-rule multiplier.
+    """
+    result: dict[tuple[str, str, str, str], float] = dict(basis.flat_weights)
+    for key, base_w in basis.base_idf_non_flat.items():
+        rule_id = key[0]
+        mult = _RULE_QUALITY_MULTIPLIER.get(rule_id, 1.0)
+        result[key] = base_w * mult
+    return result
+
+
 def _compute_idf_weights(
     complements: Sequence[PortComplement],
 ) -> dict[tuple[str, str, str, str], float]:
@@ -595,50 +681,14 @@ def _compute_idf_weights(
     Density rules (spell_density, scaling) use flat weight per
     match — for these rules, matching many candidates IS the strategy
     (Talrand wants EVERY instant), so IDF would incorrectly penalize.
-    """
-    freq: dict[tuple[str, str, str, str], set[str]] = defaultdict(set)
-    for c in complements:
-        key = (c.rule_id, c.cmdr_event, c.cand_event, c.filter_group)
-        freq[key].add(c.candidate)
 
-    result: dict[tuple[str, str, str, str], float] = {}
-    for key, candidates in freq.items():
-        rule_id = key[0]
-        filter_group = key[3] or ""
-        # Effect-conditional dampening: when a commander trigger's
-        # execute has a runtime gate (Selvala power compare, Meren's
-        # XP-vs-CMC), matches on that trigger are tagged with ":cond" in
-        # filter_group. Halve IDF for these — the trigger fires broadly
-        # but the payoff is gated, so most matches don't pan out.
-        cond_mult = 0.5 if filter_group.endswith(":cond") else 1.0
-        if rule_id in _FLAT_COUNT_RULES:
-            override = _FLAT_WEIGHT_OVERRIDES.get(rule_id)
-            base_w = override if override is not None else 1.0
-            result[key] = base_w * cond_mult
-        else:
-            n = len(candidates)
-            # For forward panharmonicon matches, apply minimum N=10 floor.
-            # Very rare effects (SacrificeAll N=1) get inflated IDF that
-            # doesn't reflect true synergy quality — Krovikan Vampire at
-            # IDF=1.0 shouldn't outrank Zulaport Cutthroat at IDF=0.17.
-            # Exclude reverse_panharmonicon and panharmonicon_stack which
-            # have genuinely unique high-value matches (Harmonic Prodigy).
-            cmdr_event = key[1]
-            if rule_id == "panharmonicon" and "reverse" not in cmdr_event and "stack" not in cmdr_event:
-                # Floor raised from 10 to 30 so rare board-wide triggers
-                # (ChangesZoneAll + Token, N=35, IDF 0.195) don't swamp
-                # the numerous self-ETB payoff groups (ChangesZone_etb_*,
-                # IDF 0.10-0.14). Yarok's EDHREC Hi-Syn is dominated by
-                # self-ETB value creatures (Mulldrifter, Coiling Oracle)
-                # that were buried at rank 1000+ when board-wide-trigger
-                # cards captured the 0.289 cap.
-                n = max(n, 30)
-            w = 1.0 / math.log2(1.0 + n)
-            # Apply quality multiplier: cost-based rules are boosted,
-            # broad effect rules are dampened.
-            mult = _RULE_QUALITY_MULTIPLIER.get(rule_id, 1.0)
-            result[key] = w * mult * cond_mult
-    return result
+    Refactored into :func:`_compute_idf_basis` + :func:`_idf_weights_from_basis`
+    so the bench optimizer can cache the basis once per commander and only pay
+    the cheap multiplier-lookup per grid cell. This wrapper is the legacy
+    one-shot path used by ``score_all_universal``; bitwise-identical output
+    to pre-refactor.
+    """
+    return _idf_weights_from_basis(_compute_idf_basis(complements))
 
 
 def score_all_universal(
@@ -686,6 +736,7 @@ def _score_from_complements(
     *,
     candidate_cache: CandidateCache | None = None,
     tensor_sink: TensorSink | None = None,
+    idf_basis: IdfBasis | None = None,
 ) -> dict[str, UniversalScore]:
     """Build per-candidate ``UniversalScore`` results from precomputed complements.
 
@@ -696,13 +747,18 @@ def _score_from_complements(
     ``_FLAT_WEIGHT_OVERRIDES``, and the embedding/staple/circuit/cmc/rank
     side-channels exactly as ``score_all_universal`` does.
 
+    When ``idf_basis`` is supplied, skip the per-call frequency-counting walk
+    and apply the current ``_RULE_QUALITY_MULTIPLIER`` to the cached basis
+    instead. The optimizer caches one basis per commander (see
+    :class:`IdfBasis`); production scoring leaves it ``None`` and recomputes.
+
     Refactor invariant: ``score_all_universal`` is a thin wrapper that calls
     ``find_all_complements`` then this helper; behavior is bitwise-identical
     to pre-extraction. Verified by the existing
     ``tests/bench/test_universal_scorer_identity.py`` suite and
     ``bench.py audit --expect-identity``.
     """
-    idf = _compute_idf_weights(complements)
+    idf = _idf_weights_from_basis(idf_basis) if idf_basis is not None else _compute_idf_weights(complements)
 
     # Group complements by candidate
     by_candidate: dict[str, list[PortComplement]] = defaultdict(list)

--- a/tests/bench/test_optimize.py
+++ b/tests/bench/test_optimize.py
@@ -536,6 +536,64 @@ class TestScoreCommanderFromComplements:
         # And whatever's in top_30 is a subset of score_by_candidate.
         assert set(result.top_30).issubset(set(result.score_by_candidate.keys()))
 
+    def test_idf_basis_cached_path_matches_legacy(self, scoring_fixture: sqlite3.Connection) -> None:
+        """``score_commander_from_complements(idf_basis=...)`` must match the legacy path bitwise.
+
+        The cached basis is the perf optimization in Batch B (#7). This test
+        is the fidelity invariant: any future change to ``_compute_idf_basis``
+        / ``_idf_weights_from_basis`` that diverges from ``_compute_idf_weights``
+        must break this test.
+        """
+        from mtg_synergy_graph.complement_rules import find_all_complements
+        from mtg_synergy_graph.universal_scorer import _compute_idf_basis
+
+        complements = find_all_complements(scoring_fixture, ["Test Commander"])
+        # Legacy path: no basis, _compute_idf_weights runs per call.
+        legacy = score_commander_from_complements(scoring_fixture, "Test Commander", complements)
+        # Cached path: basis built once, applied per call.
+        basis = _compute_idf_basis(complements)
+        cached = score_commander_from_complements(scoring_fixture, "Test Commander", complements, idf_basis=basis)
+        assert legacy.top_30 == cached.top_30
+        assert dict(legacy.score_by_candidate) == dict(cached.score_by_candidate)
+        assert legacy.contributions == cached.contributions
+
+    def test_idf_basis_cached_path_matches_legacy_under_weight_shift(self, scoring_fixture: sqlite3.Connection) -> None:
+        """Cached basis must produce identical results to legacy path AFTER weight patching.
+
+        Verifies that ``_idf_weights_from_basis`` correctly applies the live
+        ``_RULE_QUALITY_MULTIPLIER`` — the basis is weight-INDEPENDENT, but
+        the final IDF weights it produces MUST track every multiplier change.
+        """
+        from mtg_synergy_graph import universal_scorer
+        from mtg_synergy_graph.complement_rules import find_all_complements
+        from mtg_synergy_graph.universal_scorer import _compute_idf_basis
+
+        complements = find_all_complements(scoring_fixture, ["Test Commander"])
+        # Build basis at baseline weights — basis itself is weight-independent.
+        basis = _compute_idf_basis(complements)
+
+        # Pick a non-flat rule that fires in the fixture; double its multiplier.
+        baseline = dict(universal_scorer._RULE_QUALITY_MULTIPLIER)
+        firing_rule_ids = {c.rule_id for c in complements}
+        target_rule = next(
+            iter(rid for rid in firing_rule_ids if rid in baseline),
+            None,
+        )
+        if target_rule is None:
+            pytest.skip("No firing rule in baseline weights for this fixture")
+
+        try:
+            universal_scorer._RULE_QUALITY_MULTIPLIER[target_rule] = baseline[target_rule] * 2.0
+            legacy = score_commander_from_complements(scoring_fixture, "Test Commander", complements)
+            cached = score_commander_from_complements(scoring_fixture, "Test Commander", complements, idf_basis=basis)
+        finally:
+            universal_scorer._RULE_QUALITY_MULTIPLIER.clear()
+            universal_scorer._RULE_QUALITY_MULTIPLIER.update(baseline)
+
+        assert legacy.top_30 == cached.top_30
+        assert dict(legacy.score_by_candidate) == dict(cached.score_by_candidate)
+        assert legacy.contributions == cached.contributions
+
 
 # ---------------------------------------------------------------------------
 # run_optimizer (Unit 3)
@@ -575,6 +633,7 @@ def _scripted_score_split(
         labels_cache: dict[str, EdhrecLabels],
         alpha: float,
         candidate_cache: object = None,
+        idf_basis_cache: object = None,
     ) -> CompositeObjective:
         rules_to_use = firing_rules if firing_rules is not None else list(weights.keys())
         for cmdr in commanders:
@@ -861,6 +920,7 @@ class TestRunOptimizerControlLogic:
             labels_cache,
             alpha,
             candidate_cache=None,
+            idf_basis_cache=None,
         ):
             from mtg_synergy_graph.bench.optimize import CompositeObjective, EdhrecLabels
 


### PR DESCRIPTION
## Summary

Batch B of the post-merge code-review residual work for the tensor-weight optimizer. Applies finding #7 (IDF basis caching). Defers #9 (skip contributions in inner grid) — its caveat about gem-rate selection bias is real and warrants a fused-walk refactor instead of a skip.

## What changed

`_compute_idf_weights` is split into two stages:

| Stage | Function | Runs | Cost |
|---|---|---|---|
| Weight-INDEPENDENT | `_compute_idf_basis(complements) -> IdfBasis` | once per commander per run | `O(complements)` frequency counting + `log2` + `cond_mult` + flat overrides |
| Weight-DEPENDENT | `_idf_weights_from_basis(basis) -> dict` | per grid cell | `O(unique_keys)` `_RULE_QUALITY_MULTIPLIER` lookup |

`_compute_idf_weights` now wraps both for the legacy one-shot path used by `score_all_universal`. Bitwise-identical output verified by `bench.py audit --expect-identity`.

## Wiring

- `_score_from_complements` gains optional `idf_basis: IdfBasis | None = None`
- `score_commander_from_complements` (`bench/optimize.py`) gains the same param
- `_score_split` gains `idf_basis_cache: dict[str, IdfBasis] | None = None`; lazy-fills on first miss alongside `complements_cache`
- `run_optimizer` maintains a single per-run `idf_basis_cache` and threads it through every `_score_split` call (self-test, baseline, inner grid, held re-eval)

## Cache invalidation contract (documented on `IdfBasis`)

The basis depends on:
- the complements list (changes per commander, never per grid cell)
- `_FLAT_WEIGHT_OVERRIDES` (the M1 optimizer does NOT sweep these)
- static dampening logic (`_FLAT_COUNT_RULES`, panharmonicon floor, `cond_mult`)

The basis does NOT depend on `_RULE_QUALITY_MULTIPLIER`. A future optimizer variant that sweeps `_FLAT_WEIGHT_OVERRIDES` MUST rebuild the basis on every override change.

## Why #9 (contributions skip) is deferred

`_build_contributions` is called once per scoring call to populate `result.contributions`, which `hidden_gem_hit_rate_for_commander` uses for its mechanical-plausibility gate. Skipping it in the inner grid scan would force the gem axis to compute against an empty tuple, biasing grid-cell selection AWAY from gem-contributing rules. The composite would effectively run α=1.0 in the grid sweep but α=0.5 at the held-eps gate — incoherent.

A better fix is to fuse `_build_contributions` into `_fast_total` (both walk the same complements). That's a separate refactor; not part of this PR.

## Test plan

- [x] `uv run pytest tests/bench/test_optimize.py` — 72 passed, 2 skipped
- [x] `uv run pytest tests/ --ignore=tests/test_rules_migration_cascade.py` — 1791 passed, 2 skipped, 21 deselected
- [x] `uv run pytest tests/test_rules_migration_cascade.py` — 4 passed (full suite shows 1 unrelated flake from `test_audit_integration + test_audit_main + cascade` ordering, **reproducible on `main`** — out of scope for this PR)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run scripts/bench.py audit --expect-identity` — PASS
- [x] Pre-commit `bench-audit` hook — PASS (Δ=+0.0000, 100 cmdrs, histogram no_change=100)

## New tests (2)

- `test_idf_basis_cached_path_matches_legacy` — fidelity at baseline weights
- `test_idf_basis_cached_path_matches_legacy_under_weight_shift` — fidelity after a 2× rule-multiplier patch (forces the apply step to actually do work)

Both tests fail-loudly if a future change to `_compute_idf_basis` / `_idf_weights_from_basis` diverges from `_compute_idf_weights`.

## Estimated speedup

Per the code-review reviewer's analysis: 20-35% additional sweep wall-clock. With this on top of Unit-2 perf (commit `4bba921`'s 37% speedup via CandidateCache + `_fast_total`), expected total: ~55-60% faster than the pre-perf-batch baseline. Not benchmarked in this PR — would require an actual optimizer run on the 100-commander fixture.

## Residual after this PR

Of the original 24 residual findings, 14 still pending:
- **#9** (perf): fused-walk refactor of `_build_contributions` + `_fast_total`
- **#4** (CLI): `--format json` for stdout
- **#39** (agent-native): expose `--alpha`, `--grid`, etc.
- **Batch C** test gaps: #23-26, #31
- **Architectural**: #17 split `run_optimizer`, #18 `_fast_total` cached property, #19 public `_score_from_complements`, #20 atomic dict swap, #34 hoist imports, #38 context manager