### PR TITLE
fix(bench): write_proposal_json crashes on production color_buckets type

### DIFF
--- a/src/mtg_synergy_graph/bench/optimize.py
+++ b/src/mtg_synergy_graph/bench/optimize.py
@@ -1297,7 +1297,10 @@ def write_proposal_json(
         "dead_keys": list(result.dead_keys),
         "train_split_size": len(result.train_split),
         "held_split_size": len(result.held_split),
-        "color_buckets": dict(result.color_buckets),
+        # color_buckets has nested MappingProxyType (outer + inner) for
+        # frozen-dataclass immutability. json.dumps doesn't know how to
+        # encode mappingproxy — flatten both layers to plain dicts.
+        "color_buckets": {k: dict(v) for k, v in result.color_buckets.items()},
     }
 
     target_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/bench/test_optimize.py
+++ b/tests/bench/test_optimize.py
@@ -1147,7 +1147,15 @@ def _make_result(
     partial_sweep: bool = False,
     dead_keys: tuple[str, ...] = (),
 ) -> OptimizerResult:
-    """Build a synthetic OptimizerResult for artifact tests."""
+    """Build a synthetic OptimizerResult for artifact tests.
+
+    ``color_buckets`` mirrors the production type from ``random_split``:
+    ``MappingProxyType`` at BOTH layers (outer dict + inner per-bucket dict).
+    Tests that omitted the inner ``MappingProxyType`` masked a real bug —
+    ``json.dumps`` doesn't know how to encode ``mappingproxy``, so
+    ``write_proposal_json`` would crash on production input until the
+    mappingproxy values were flattened to plain dicts.
+    """
     from types import MappingProxyType
 
     return OptimizerResult(
@@ -1161,7 +1169,7 @@ def _make_result(
         dead_keys=dead_keys,
         train_split=("a", "b"),
         held_split=("c",),
-        color_buckets={"mono": {"train": 2, "held": 1}},
+        color_buckets=MappingProxyType({"mono": MappingProxyType({"train": 2, "held": 1})}),
         train_composite_baseline=0.5,
         held_composite_baseline=0.5,
         train_ndcg_baseline=0.4,


### PR DESCRIPTION
## Summary

**P0 production bug** found during benchmarking — `bench.py audit --optimize` crashed with `TypeError: Object of type mappingproxy is not JSON serializable` after a full ~3-minute sweep completed. The optimizer was effectively unusable end-to-end on `main`.

## Root cause

PR #27's finding-#15 fix wrapped both layers of `OptimizerResult.color_buckets` in `MappingProxyType` for frozen-dataclass immutability. `write_proposal_json` did `dict(result.color_buckets)` which converts the OUTER mappingproxy but leaves the INNER values as mappingproxy. `json.dumps` doesn't know how to encode `mappingproxy`.

## Why it didn't trigger in CI

1. `TestWriteProposalJson` used a `_make_result` helper that stashed plain dicts in `color_buckets`, not the production `MappingProxyType`-wrapped shape.
2. The original optimizer session ran via `run_optimizer` directly (probe script `probe_alpha_calibration.py`), which doesn't call `write_proposal_json`. The CLI handler tests in `TestHandleOptimize` only cover rc=2 paths — never the happy path through `write_proposal_json` with a real `OptimizerResult`.

So the test fixture and the CLI integration both had blind spots that lined up to hide a real bug.

## Fix

- `write_proposal_json` flattens both layers explicitly: `{k: dict(v) for k, v in result.color_buckets.items()}`.
- `_make_result` in tests now mirrors the production type with nested `MappingProxyType` so this regression class fails loudly in the existing 7 `TestWriteProposalJson` tests (the new fixture would have caught the original bug).

## Test plan

- [x] `uv run pytest tests/bench/test_optimize.py::TestWriteProposalJson` — 7 passed (each test now exercises the production-typed fixture)
- [x] `uv run pytest tests/ --ignore=tests/test_rules_migration_cascade.py` — 1791 passed, 2 skipped
- [x] `uv run ruff check` — clean
- [x] `uv run pyright` — 0 errors
- [x] Pre-commit hooks all green
- [ ] (manual, post-merge) Re-run `bench.py audit --optimize` end-to-end on the 100-commander fixture to confirm the JSON write completes