### PR TITLE
perf(scoring): cache _compute_pair_bonus + document optimizer perf profile

### DIFF
--- a/docs/solutions/best-practices/optimizer-perf-profile-2026-04-30.md
+++ b/docs/solutions/best-practices/optimizer-perf-profile-2026-04-30.md
@@ -1,0 +1,100 @@
+---
+last_updated: 2026-04-30
+module: bench/optimize
+title: Profile-driven optimizer perf — measure before chasing reviewer estimates
+tags: [perf, profiling, cprofile, lru-cache, optimizer, benchmarking]
+problem_type: best_practice
+symptoms:
+  - perf-review estimate "20-35% speedup" turned out to be 1.4% for one finding and 7% for another
+  - architectural splits ("hoist this loop") looked correct but didn't move the needle
+  - intuition about which functions are hot turned out to be wrong by an order of magnitude
+resolution_type: pattern
+applies_when:
+  - A perf reviewer flagged multiple optimizations with stacked estimated gains.
+  - The hot path runs millions of iterations across O(thousands) of grid cells.
+  - Wall-clock per run is long enough (minutes) that benchmarking is feasible.
+created: 2026-04-30
+---
+
+# Profile-driven optimizer perf
+
+When a code reviewer estimates speedups, those estimates are educated guesses. Multi-million-call hot paths violate the reviewer's mental model regularly, because the dominant cost is rarely where the reviewer expects. Run cProfile FIRST, then target the actual hot lines.
+
+## Methodology
+
+Two benchmarks against the pinned 100-commander golden set, each running one full sweep (53 rules × 5 grid cells × 100 commanders ≈ 26,500 grid evaluations × ~4,000 candidates each ≈ 43.85M scoring calls):
+
+```bash
+{ time uv run scripts/bench.py audit --optimize \
+    --no-self-test --max-sweeps 1 \
+    --proposal-path /tmp/proposal.json \
+    --optimize-history /tmp/history.csv ; } 2>&1 | tee /tmp/run.log
+```
+
+For profiling:
+
+```bash
+uv run python -m cProfile -o /tmp/profile.prof \
+    scripts/bench.py audit --optimize --no-self-test --max-sweeps 1 ...
+
+uv run python -c "
+import pstats
+pstats.Stats('/tmp/profile.prof').sort_stats('tottime').print_stats(30)
+"
+```
+
+cProfile adds ~55% overhead (190s unprofiled → 298s profiled), but relative ordering of hot functions is preserved.
+
+## Findings
+
+### Reviewer estimate vs measured (per the post-#27 ce-code-review)
+
+| Finding | Reviewer estimate | Measured | Verdict |
+|---|---:|---:|---|
+| #7 IDF basis cache | 20-35% | **1.4%** | Reviewer overestimated by 14-25× |
+| #PERF-01 `_compute_pair_bonus` lru_cache | 7% | **6.6-7.9%** | Reviewer was right |
+| #9 contributions skip in inner grid | (deferred — bias risk) | — | — |
+
+### Top 30 hot functions by `tottime` (post-#7, before pair-bonus cache)
+
+```
+   ncalls  tottime  percall  cumtime  filename:lineno(function)
+    10800   73.023    0.007   96.613  universal_scorer.py:732(_score_from_complements)
+ 43849786   35.258    0.000   70.656  bench/optimize.py:327(_fast_total)
+    10800   32.155    0.003  273.303  bench/optimize.py:403(score_commander_from_complements)
+    10800   29.544    0.003   43.748  bench/optimize.py:368(_build_contributions)
+343522971   27.139    0.000   27.139  {method 'get' of 'dict' objects}
+ 43849786   21.680    0.000   23.829  universal_scorer.py:212(_compute_pair_bonus)  <-- cached
+ 43849786   11.145    0.000   18.372  bench/optimize.py:472(<lambda>)              <-- sort key
+    10812    9.087    0.001   27.459  {method 'sort' of 'list' objects}
+148420183    8.705    0.000    8.705  {method 'add' of 'set' objects}
+143348879    7.458    0.000    7.458  {method 'append' of 'list' objects}
+```
+
+Total run: 297.9 seconds (1.1B function calls).
+
+The architectural picture: 43.85M = once per (commander, grid cell, candidate). 343M = ~3-4 dict.get calls per scoring call, mostly in `_fast_total`'s idf-weight lookup. The reviewer's mental model that frequency-counting was a major cost was wrong — the dominant work is the `_fast_total` inner loop and `_score_from_complements` body, not `_compute_idf_weights`.
+
+## Outcomes
+
+| Run | Wall-clock | User CPU | Speedup vs prior |
+|---|---:|---:|---:|
+| Pre-#7 (`20cd129` + JSON-fix patch) | 3:12.93 | 189.03s | baseline |
+| Post-#7 IDF basis cache | 3:10.21 | 186.43s | 1.4% |
+| Post pair-bonus cache | **2:57.66** | **174.96s** | 6.6% |
+| (cumulative since pre-#7) | | | **7.9%** |
+
+All three runs produced identical proposals (16 steps accepted, train Δ=+0.0083, held Δ=+0.0047) — determinism confirmed.
+
+## Pattern
+
+For multi-million-call hot paths, **profile then optimize, never the reverse**. The cost of one cProfile run (~5 minutes on this codebase) is far less than the cost of refactoring for an architectural fix that turns out to deliver 1% instead of 30%. Save the architectural-fix energy for cases where the profile actually points there.
+
+The IDF-basis-cache split is still a sound architectural change (it sets up future flat-override sweeps cleanly and reduces re-walks). It just isn't the perf win it was sold as. Both can be true.
+
+## Related
+
+- `_compute_pair_bonus` cache: `src/mtg_synergy_graph/universal_scorer.py` (with `cache_clear()` contract documented in the docstring)
+- IDF basis split: `src/mtg_synergy_graph/universal_scorer.py` (`IdfBasis`, `_compute_idf_basis`, `_idf_weights_from_basis`)
+- JSON-serialization fix that unblocked end-to-end benchmarking: PR #31, commit `ac6fa70`
+- Bench harness: `bench.py audit --optimize` (see `CLAUDE.md` Common Commands)

--- a/src/mtg_synergy_graph/universal_scorer.py
+++ b/src/mtg_synergy_graph/universal_scorer.py
@@ -15,7 +15,7 @@ import sqlite3
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from functools import cached_property
+from functools import cached_property, lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple, Protocol
 
@@ -209,8 +209,21 @@ _SYNERGY_PAIRS: dict[frozenset[str], float] = {
 }
 
 
+@lru_cache(maxsize=4096)
 def _compute_pair_bonus(rules: frozenset[str]) -> float:
-    """Sum bonuses for all synergy pairs present in a card's rule set."""
+    """Sum bonuses for all synergy pairs present in a card's rule set.
+
+    Cached because the bench optimizer calls this 43.85M+ times per sweep
+    (once per candidate per grid cell) — see the 2026-04-30 cProfile run
+    in ``docs/solutions/best-practices/optimizer-perf-profile-2026-04-30.md``.
+    The function is pure and the input is hashable, so caching is safe.
+
+    Cache invalidation contract: if a test or migration mutates
+    ``_SYNERGY_PAIRS`` at runtime, call ``_compute_pair_bonus.cache_clear()``
+    in test setup/teardown. The module-level dict is not currently mutated
+    by any non-test code path; callers that monkeypatch ``_SYNERGY_PAIRS``
+    must clear the cache explicitly.
+    """
     bonus = 0.0
     for pair, value in _SYNERGY_PAIRS.items():
         if pair <= rules:

--- a/tests/test_universal_scorer_coverage.py
+++ b/tests/test_universal_scorer_coverage.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+import pytest
+
 from mtg_synergy_graph.complement_rules.core import PortComplement, _extract_filter_group
-from mtg_synergy_graph.universal_scorer import UniversalScore, _compute_idf_weights
+from mtg_synergy_graph.universal_scorer import (
+    UniversalScore,
+    _compute_idf_weights,
+    _compute_pair_bonus,
+)
 
 
 def _comp(
@@ -378,3 +384,51 @@ def test_score_uses_filter_group_for_idf_lookup():
     idf = {("trigger_effect", "ChangesZone", "Token", "Artifact"): 0.42}
     us = UniversalScore(complements=[c], staple_bonus=0.0, idf_weights=idf)
     assert abs(us.score - 0.42) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# _compute_pair_bonus — lru_cache behavior
+# ---------------------------------------------------------------------------
+
+
+def test_compute_pair_bonus_cache_returns_consistent_values():
+    """Repeated calls with the same input return the same value (cache hit
+    path agrees with cache miss path).
+
+    The bench optimizer calls this 43.85M+ times per sweep with frequent
+    repeats; the cache must not return stale or modified results.
+    """
+    rules = frozenset({"trigger_effect", "cost_feeds_trigger"})
+    a = _compute_pair_bonus(rules)
+    b = _compute_pair_bonus(rules)
+    c = _compute_pair_bonus(frozenset(rules))  # fresh frozenset, same elements
+    assert a == b == c
+
+
+def test_compute_pair_bonus_cache_clear_picks_up_pairs_table_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tests that monkeypatch ``_SYNERGY_PAIRS`` MUST call cache_clear afterwards
+    or risk seeing stale cached results.
+
+    This test documents the cache invariant: the cache key is the input
+    frozenset only, NOT the underlying ``_SYNERGY_PAIRS`` dict. If a test
+    forgets to clear, subsequent assertions inside the same test could see
+    pre-monkeypatch values.
+    """
+    from mtg_synergy_graph import universal_scorer
+
+    rules = frozenset({"trigger_effect", "cost_feeds_trigger"})
+    # Prime the cache with the real-table value.
+    pre = _compute_pair_bonus(rules)
+
+    # Monkeypatch _SYNERGY_PAIRS to give this pair a NEW value not in the table.
+    monkeypatch.setitem(universal_scorer._SYNERGY_PAIRS, rules, 999.0)
+    # Without cache_clear, we'd get the stale cached pre-monkeypatch value.
+    assert _compute_pair_bonus(rules) == pre, "cache should still return pre-patch value"
+    # After cache_clear, the new value is observable.
+    _compute_pair_bonus.cache_clear()
+    assert _compute_pair_bonus(rules) == pre + 999.0
+    # Restore: monkeypatch teardown removes the entry, but cache may now hold
+    # the patched value. Clear so the next test sees the real table.
+    _compute_pair_bonus.cache_clear()


### PR DESCRIPTION
## Summary

Profile-driven perf optimization. cProfile on a single optimizer sweep identified `_compute_pair_bonus` as called **43.85M times per sweep** with a hashable input — a textbook `@lru_cache` candidate. Adding the cache delivered the predicted ~7% speedup; verified by re-running the same benchmark.

Also lands a permanent benchmark/profile methodology doc at `docs/solutions/best-practices/optimizer-perf-profile-2026-04-30.md` so future perf work starts from data, not estimates.

## Benchmark results

| State | Wall-clock | User CPU | Speedup |
|---|---:|---:|---:|
| Pre-#7 (`20cd129` + JSON-fix patch) | 3:12.93 | 189.03s | baseline |
| Post-#7 IDF basis cache | 3:10.21 | 186.43s | 1.4% |
| **Post pair-bonus cache (this PR)** | **2:57.66** | **174.96s** | **6.6%** (cumulative since pre-#7: 7.9%) |

All three runs produced **identical proposals** (16 steps accepted, train Δ=+0.0083, held Δ=+0.0047). Determinism preserved.

## Why the reviewer's #7 estimate was off

The post-#27 ce-code-review estimated **20-35% speedup** for #7 (IDF basis caching). Measured: **1.4%**. The reviewer's mental model assumed `_compute_idf_weights` was a major bottleneck; cProfile shows it's not — it's overshadowed by `_fast_total` + `_score_from_complements` + `_compute_pair_bonus`.

PERF-01's estimate (7% for `_compute_pair_bonus` cache) was on target.

**Lesson** (now durable in `docs/solutions/best-practices/optimizer-perf-profile-2026-04-30.md`): profile before chasing reviewer estimates on multi-million-call hot paths. The reviewer's intuition about which functions dominate is wrong by an order of magnitude often enough that one cProfile run is cheaper than one wrong refactor.

## What changed

- **`_compute_pair_bonus`**: `@lru_cache(maxsize=4096)`. Pure function with hashable frozenset argument, called 43.85M+ times per sweep. Cache-clear contract documented on the function: tests that monkeypatch `_SYNERGY_PAIRS` MUST call `_compute_pair_bonus.cache_clear()` afterwards.
- **`tests/test_universal_scorer_coverage.py`**: 2 new tests. One verifies cache consistency; one explicitly documents the cache-clear-after-monkeypatch contract.
- **`docs/solutions/best-practices/optimizer-perf-profile-2026-04-30.md`**: methodology + measured numbers + the top-30 cProfile output + the lesson about reviewer estimates.

## Test plan

- [x] `uv run pytest tests/` — 1793 passed (+2 new), 2 skipped, 21 deselected
- [x] `uv run ruff check src/ tests/ docs/` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run scripts/bench.py audit --expect-identity` — PASS
- [x] Pre-commit `bench-audit` hook — PASS (Δ=+0.0000, 100 cmdrs, histogram no_change=100)
- [x] End-to-end benchmark on 100-commander fixture: 2:57.66 wall-clock, identical proposal to baseline

## Residual after this PR

Of the original 24 residual findings, 13 still pending:
- **#9** (perf, fused-walk variant): the profile shows `_build_contributions` is 9.9% (29.5s) — fusing it into `_fast_total` would save ~half. Worth pursuing if 5% more is wanted; otherwise current perf is fine.
- **#4** (CLI): `--format json` for stdout
- **#39** (agent-native): expose `--alpha`, `--grid`, `--eps-step`, etc.
- **Batch C** test gaps: #23-26, #31
- **Architectural**: #17 split `run_optimizer`, #18 `_fast_total` cached property, #19 public `_score_from_complements`, #20 atomic dict swap, #34 hoist imports, #38 context manager