### PR TITLE
feat(bench): batch E — agent-native CLI surface for --optimize

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,10 @@ uv run scripts/sweep_embedding_weights.py                                # Grid-
 uv run scripts/bench.py audit --optimize                                 # Run full sweep on the pinned 100-commander fixture
 uv run scripts/bench.py audit --optimize --no-self-test --max-sweeps 1   # Quick exploratory pass (skip planted-perturbation check)
 uv run scripts/bench.py audit --optimize --seed 17                       # Different train/held split for cross-validation
+uv run scripts/bench.py audit --optimize --format json                   # Machine-readable run-summary on stdout (for agent pipelines)
+uv run scripts/bench.py audit --optimize --alpha 0.3                     # Tune nDCG-vs-gem blend (alpha=0 → gem-only, alpha=1 → nDCG-only)
+uv run scripts/bench.py audit --optimize --grid 0.8 0.9 1.1 1.25         # Custom multiplicative grid (default 0.5 0.75 1.25 1.5 2.0)
+# Other knobs: --eps-step --eps-cumulative --clamp-min --clamp-max --train-ratio --wall-clock-seconds --self-test-seed
 ```
 
 The bench.py hook also runs advisorily on pre-commit when edits touch

--- a/src/mtg_synergy_graph/bench/cli.py
+++ b/src/mtg_synergy_graph/bench/cli.py
@@ -47,6 +47,50 @@ def _nonneg_int(s: str) -> int:
     return value
 
 
+def _alpha(s: str) -> float:
+    """argparse type callable: parse a [0, 1] alpha-blend weight."""
+    try:
+        value = float(s)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected a float, got {s!r}") from exc
+    if not 0.0 <= value <= 1.0:
+        raise argparse.ArgumentTypeError(f"alpha must be in [0, 1], got {value}")
+    return value
+
+
+def _ratio(s: str) -> float:
+    """argparse type callable: parse a (0, 1) train/held ratio (open interval)."""
+    try:
+        value = float(s)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected a float, got {s!r}") from exc
+    if not 0.0 < value < 1.0:
+        raise argparse.ArgumentTypeError(f"ratio must be in (0, 1), got {value}")
+    return value
+
+
+def _positive_float(s: str) -> float:
+    """argparse type callable: parse a strictly-positive float (excludes zero and negatives)."""
+    try:
+        value = float(s)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected a float, got {s!r}") from exc
+    if value <= 0.0:
+        raise argparse.ArgumentTypeError(f"must be > 0, got {value}")
+    return value
+
+
+def _nonneg_float(s: str) -> float:
+    """argparse type callable: parse a non-negative float (zero accepted)."""
+    try:
+        value = float(s)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected a float, got {s!r}") from exc
+    if value < 0.0:
+        raise argparse.ArgumentTypeError(f"must be >= 0, got {value}")
+    return value
+
+
 #: Handler table. Unit 2+ reassign these to real implementations.
 _HANDLERS: dict[str, Callable[[Namespace], int]] = {
     "audit": _stubs.audit_stub,
@@ -350,6 +394,87 @@ def _build_parser() -> argparse.ArgumentParser:
         default=".audit/optimize_history.csv",
         help="Used by --optimize only. Append-only convergence log path. Default: .audit/optimize_history.csv.",
     )
+    # OptimizerConfig knobs exposed for agent-driven sweep pipelines.
+    # Defaults mirror OptimizerConfig in src/mtg_synergy_graph/bench/optimize.py;
+    # change defaults THERE not here, otherwise the two drift.
+    audit.add_argument(
+        "--alpha",
+        dest="alpha",
+        type=_alpha,
+        default=0.5,
+        help="Used by --optimize only. Composite-objective blend: "
+        "alpha*mean_ndcg + (1-alpha)*hidden_gem_hit_rate. "
+        "alpha=0 → gem-only; alpha=1 → nDCG-only. Default: 0.5.",
+    )
+    audit.add_argument(
+        "--grid",
+        dest="grid",
+        type=_positive_float,
+        nargs="+",
+        default=[0.5, 0.75, 1.25, 1.5, 2.0],
+        metavar="MULT",
+        help="Used by --optimize only. Multiplicative perturbation grid. "
+        "Each rule is evaluated at current_value*mult for each mult. "
+        "Default: 0.5 0.75 1.25 1.5 2.0.",
+    )
+    audit.add_argument(
+        "--eps-step",
+        dest="eps_step",
+        type=_nonneg_float,
+        default=0.005,
+        help="Used by --optimize only. Held-out drop tolerance per accepted "
+        "step. Steps with held composite worse than current by more than "
+        "this are rejected. Default: 0.005.",
+    )
+    audit.add_argument(
+        "--eps-cumulative",
+        dest="eps_cumulative",
+        type=_nonneg_float,
+        default=0.005,
+        help="Used by --optimize only. Held-out drop tolerance accumulated "
+        "across all accepts in a sweep. Trips the drift-revert when "
+        "cumulative held drop exceeds this. Default: 0.005.",
+    )
+    audit.add_argument(
+        "--clamp-min",
+        dest="clamp_min",
+        type=_positive_float,
+        default=0.01,
+        help="Used by --optimize only. Lower bound on rule multipliers. "
+        "Grid cells clamped at this floor. Default: 0.01.",
+    )
+    audit.add_argument(
+        "--clamp-max",
+        dest="clamp_max",
+        type=_positive_float,
+        default=5.0,
+        help="Used by --optimize only. Upper bound on rule multipliers. "
+        "Grid cells clamped at this ceiling. Default: 5.0.",
+    )
+    audit.add_argument(
+        "--train-ratio",
+        dest="train_ratio",
+        type=_ratio,
+        default=0.8,
+        help="Used by --optimize only. Train fraction in the train/held split. Held = 1 - train_ratio. Default: 0.8.",
+    )
+    audit.add_argument(
+        "--wall-clock-seconds",
+        dest="wall_clock_seconds",
+        type=_positive_float,
+        default=300.0,
+        help="Used by --optimize only. Wall-clock budget. Sweep aborts mid-loop "
+        "when exceeded; partial_sweep=True in the proposal. Default: 300.0.",
+    )
+    audit.add_argument(
+        "--self-test-seed",
+        dest="self_test_seed",
+        type=int,
+        default=7,
+        help="Used by --optimize only. Random seed for the planted-perturbation "
+        "self-test (rule selection). Useful for reproducing flaky self-test "
+        "failures. Default: 7.",
+    )
 
     return parser
 
@@ -437,22 +562,30 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
 
-    # ``--max-sweeps`` / ``--seed`` / ``--no-self-test`` / ``--proposal-path`` /
-    # ``--optimize-history`` are companions to ``--optimize``. Warn on stderr
-    # rather than erroring so the user sees the flag had no effect — same
-    # pattern as ``--trend-n`` and ``--threshold`` above.
+    # All --optimize companion flags warn (rather than error) when used
+    # without --optimize — same pattern as ``--trend-n`` and ``--threshold``.
+    # Each tuple is (attr_name, default_value, flag_name); compare attr
+    # against default via != to detect "user supplied a non-default value".
     if mode != "optimize":
-        ignored = []
-        if getattr(args, "max_sweeps", 5) != 5:
-            ignored.append("--max-sweeps")
-        if getattr(args, "seed", 42) != 42:
-            ignored.append("--seed")
-        if getattr(args, "no_self_test", False):
-            ignored.append("--no-self-test")
-        if getattr(args, "proposal_path", ".audit/optimize_proposal.json") != ".audit/optimize_proposal.json":
-            ignored.append("--proposal-path")
-        if getattr(args, "optimize_history", ".audit/optimize_history.csv") != ".audit/optimize_history.csv":
-            ignored.append("--optimize-history")
+        _OPTIMIZE_COMPANION_FLAGS = (
+            ("max_sweeps", 5, "--max-sweeps"),
+            ("seed", 42, "--seed"),
+            ("no_self_test", False, "--no-self-test"),
+            ("proposal_path", ".audit/optimize_proposal.json", "--proposal-path"),
+            ("optimize_history", ".audit/optimize_history.csv", "--optimize-history"),
+            ("alpha", 0.5, "--alpha"),
+            ("eps_step", 0.005, "--eps-step"),
+            ("eps_cumulative", 0.005, "--eps-cumulative"),
+            ("clamp_min", 0.01, "--clamp-min"),
+            ("clamp_max", 5.0, "--clamp-max"),
+            ("train_ratio", 0.8, "--train-ratio"),
+            ("wall_clock_seconds", 300.0, "--wall-clock-seconds"),
+            ("self_test_seed", 7, "--self-test-seed"),
+        )
+        ignored = [flag for attr, default, flag in _OPTIMIZE_COMPANION_FLAGS if getattr(args, attr, default) != default]
+        # --grid is a list, can't use the simple-equality comparison.
+        if getattr(args, "grid", None) is not None and list(args.grid) != [0.5, 0.75, 1.25, 1.5, 2.0]:
+            ignored.append("--grid")
         if ignored:
             print(
                 f"bench.py audit: warning: {', '.join(ignored)} "

--- a/src/mtg_synergy_graph/bench/optimize.py
+++ b/src/mtg_synergy_graph/bench/optimize.py
@@ -1181,6 +1181,13 @@ _HISTORY_DEFAULT_PATH = ".audit/optimize_history.csv"
 #: so agents diffing proposals across code versions can detect drift.
 PROPOSAL_SCHEMA_VERSION = 1
 
+#: Schema version for the ``--format json`` run-summary printed to stdout
+#: by ``handle_optimize``. Independent from PROPOSAL_SCHEMA_VERSION because
+#: the summary covers run-level metadata (rc context, paths, deltas) while
+#: the proposal covers the candidate-diff payload. Bump on any breaking
+#: change to the summary shape.
+OPTIMIZE_SUMMARY_SCHEMA_VERSION = 1
+
 #: CSV column order for ``optimize_history.csv``. Bumping or reordering
 #: requires updating the reader symmetrically.
 OPTIMIZE_HISTORY_FIELDS: tuple[str, ...] = (
@@ -1443,9 +1450,21 @@ def handle_optimize(args: argparse.Namespace) -> int:
         )
         return 2
 
+    # All OptimizerConfig fields exposed as CLI flags. Defaults come from
+    # OptimizerConfig itself (this is just a forwarding constructor); change
+    # defaults THERE not in cli.py, otherwise the two drift.
     config = OptimizerConfig(
+        alpha=args.alpha,
+        grid=tuple(args.grid),
+        clamp_min=args.clamp_min,
+        clamp_max=args.clamp_max,
         max_sweeps=args.max_sweeps,
+        wall_clock_seconds=args.wall_clock_seconds,
+        eps_step=args.eps_step,
+        eps_cumulative=args.eps_cumulative,
+        train_ratio=args.train_ratio,
         split_seed=args.seed,
+        self_test_seed=args.self_test_seed,
         run_self_test=not args.no_self_test,
     )
     commanders = [entry.commander for entry in fixture.entries]
@@ -1482,22 +1501,50 @@ def handle_optimize(args: argparse.Namespace) -> int:
         )
         return 1
 
-    if result.n_steps_accepted == 0:
-        print(
-            f"no improvement found (n_iterations={result.n_iterations}, "
-            f"partial_sweep={result.partial_sweep}). Proposal written to "
-            f"{args.proposal_path} for inspection.",
-            file=_sys.stderr,
-        )
+    train_delta = result.train_composite_final - result.train_composite_baseline
+    held_delta = result.held_composite_final - result.held_composite_baseline
+
+    if getattr(args, "format", "md") == "json":
+        # Machine-readable summary on stdout for agent-driven sweep pipelines.
+        # The proposal JSON itself is at args.proposal_path; this is the
+        # run-summary so an agent can branch on rc + summary without re-reading
+        # the proposal file just to know "did anything change."
+        import json as _json
+
+        summary = {
+            "schema_version": OPTIMIZE_SUMMARY_SCHEMA_VERSION,
+            "run_id": run_id,
+            "n_iterations": result.n_iterations,
+            "n_steps_accepted": result.n_steps_accepted,
+            "n_steps_rejected": result.n_steps_rejected,
+            "partial_sweep": result.partial_sweep,
+            "train_composite_baseline": result.train_composite_baseline,
+            "train_composite_final": result.train_composite_final,
+            "train_composite_delta": train_delta,
+            "held_composite_baseline": result.held_composite_baseline,
+            "held_composite_final": result.held_composite_final,
+            "held_composite_delta": held_delta,
+            "proposal_path": str(args.proposal_path),
+            "history_path": str(args.optimize_history),
+            "dead_keys_count": len(result.dead_keys),
+        }
+        print(_json.dumps(summary))
     else:
-        train_delta = result.train_composite_final - result.train_composite_baseline
-        held_delta = result.held_composite_final - result.held_composite_baseline
-        print(
-            f"optimizer accepted {result.n_steps_accepted} step(s) over "
-            f"{result.n_iterations} sweep(s). "
-            f"train composite Δ={train_delta:+.4f}, held Δ={held_delta:+.4f}. "
-            f"Proposal written to {args.proposal_path}.",
-            file=_sys.stderr,
-        )
+        # Default human-readable summary on stderr, unchanged from prior behavior.
+        if result.n_steps_accepted == 0:
+            print(
+                f"no improvement found (n_iterations={result.n_iterations}, "
+                f"partial_sweep={result.partial_sweep}). Proposal written to "
+                f"{args.proposal_path} for inspection.",
+                file=_sys.stderr,
+            )
+        else:
+            print(
+                f"optimizer accepted {result.n_steps_accepted} step(s) over "
+                f"{result.n_iterations} sweep(s). "
+                f"train composite Δ={train_delta:+.4f}, held Δ={held_delta:+.4f}. "
+                f"Proposal written to {args.proposal_path}.",
+                file=_sys.stderr,
+            )
 
     return 0

--- a/tests/bench/test_optimize.py
+++ b/tests/bench/test_optimize.py
@@ -1572,3 +1572,135 @@ class TestHandleOptimize:
         parser = _build_parser()
         with pytest.raises(SystemExit):
             parser.parse_args(["audit", "--optimize", "--repin"])
+
+    def test_argparse_validates_alpha_range(self) -> None:
+        """--alpha must be in [0, 1]; out-of-range raises SystemExit."""
+        from mtg_synergy_graph.bench.cli import _build_parser
+
+        parser = _build_parser()
+        # Valid endpoints accepted.
+        parser.parse_args(["audit", "--optimize", "--alpha", "0.0"])
+        parser.parse_args(["audit", "--optimize", "--alpha", "1.0"])
+        # Out of range rejected.
+        with pytest.raises(SystemExit):
+            parser.parse_args(["audit", "--optimize", "--alpha", "1.5"])
+        with pytest.raises(SystemExit):
+            parser.parse_args(["audit", "--optimize", "--alpha", "-0.1"])
+
+    def test_argparse_validates_train_ratio_open_interval(self) -> None:
+        """--train-ratio must be in (0, 1) — both endpoints rejected."""
+        from mtg_synergy_graph.bench.cli import _build_parser
+
+        parser = _build_parser()
+        parser.parse_args(["audit", "--optimize", "--train-ratio", "0.5"])
+        with pytest.raises(SystemExit):
+            parser.parse_args(["audit", "--optimize", "--train-ratio", "0.0"])
+        with pytest.raises(SystemExit):
+            parser.parse_args(["audit", "--optimize", "--train-ratio", "1.0"])
+
+    def test_argparse_grid_accepts_multiple_values(self) -> None:
+        """--grid accepts a space-separated list of positive floats."""
+        from mtg_synergy_graph.bench.cli import _build_parser
+
+        parser = _build_parser()
+        ns = parser.parse_args(["audit", "--optimize", "--grid", "0.5", "0.75", "1.5", "2.0"])
+        assert ns.grid == [0.5, 0.75, 1.5, 2.0]
+        # Non-positive grid value rejected.
+        with pytest.raises(SystemExit):
+            parser.parse_args(["audit", "--optimize", "--grid", "0.5", "0.0"])
+        with pytest.raises(SystemExit):
+            parser.parse_args(["audit", "--optimize", "--grid", "0.5", "-1.0"])
+
+    def test_companion_flag_warning_includes_new_flags(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Passing --alpha/--grid/etc. without --optimize warns on stderr."""
+        import contextlib
+
+        from mtg_synergy_graph.bench.cli import main
+
+        # Use --expect-identity (the cheapest mode that doesn't need a fixture
+        # rebuild) and pass --alpha. Should error somewhere because no DB
+        # exists, but the warning fires before that.
+        with contextlib.suppress(SystemExit):
+            main(["audit", "--expect-identity", "--alpha", "0.7"])
+        captured = capsys.readouterr()
+        assert "--alpha" in captured.err
+        assert "no effect without --optimize" in captured.err
+
+    def test_format_json_emits_summary_to_stdout(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--optimize --format json`` writes a single JSON object to stdout.
+
+        Mocks `run_optimizer` to return a synthetic OptimizerResult so the test
+        is fast and deterministic; the goal is to verify the SUMMARY shape, not
+        the optimizer logic.
+        """
+        import argparse
+        import json
+
+        from mtg_synergy_graph.bench import optimize as opt_mod
+        from mtg_synergy_graph.bench.fixture import FixtureEntry, PinnedFixture
+        from mtg_synergy_graph.bench.optimize import OPTIMIZE_SUMMARY_SCHEMA_VERSION
+
+        # Build a fixture with 5 commanders + the live config_hash so the
+        # stale-tensor check passes.
+        from mtg_synergy_graph.bench.tensor import compute_config_hash
+
+        live_hash = compute_config_hash()
+        fixture = PinnedFixture(
+            config_hash=live_hash,
+            created_at="2026-01-01T00:00:00+00:00",
+            entries=[FixtureEntry(commander=f"Cmdr {i}", scores={"a": 1.0}) for i in range(5)],
+        )
+        fixture_path = tmp_path / "fixture.json"
+        fixture.write(fixture_path)
+
+        # Mock run_optimizer to return a minimal valid OptimizerResult.
+        def _fake_run(conn, edhrec_conn, commanders, *, config=None, time_now=None):
+            return _make_result(
+                baseline_weights={"alpha_rule": 1.0},
+                final_weights={"alpha_rule": 1.5},
+                n_steps_accepted=1,
+            )
+
+        monkeypatch.setattr(opt_mod, "run_optimizer", _fake_run)
+        # Skip the actual write_proposal_json (it tries to compute_config_hash
+        # against patched globals). We just want the JSON summary on stdout.
+        monkeypatch.setattr(opt_mod, "write_proposal_json", lambda r, path=None: {})
+        monkeypatch.setattr(opt_mod, "append_optimize_history_rows", lambda r, run_id, path=None: None)
+
+        args = argparse.Namespace(
+            fixture=str(fixture_path),
+            db="data/synergy.db",
+            edhrec_db="data/tags.db",
+            max_sweeps=1,
+            seed=42,
+            no_self_test=True,
+            proposal_path=str(tmp_path / "p.json"),
+            optimize_history=str(tmp_path / "h.csv"),
+            alpha=0.5,
+            grid=[0.5, 0.75, 1.25, 1.5, 2.0],
+            eps_step=0.005,
+            eps_cumulative=0.005,
+            clamp_min=0.01,
+            clamp_max=5.0,
+            train_ratio=0.8,
+            wall_clock_seconds=300.0,
+            self_test_seed=7,
+            format="json",
+        )
+        rc = opt_mod.handle_optimize(args)
+        assert rc == 0
+        captured = capsys.readouterr()
+        # Stdout has exactly one JSON line; stderr has no human prose.
+        summary = json.loads(captured.out.strip())
+        assert summary["schema_version"] == OPTIMIZE_SUMMARY_SCHEMA_VERSION
+        assert summary["n_steps_accepted"] == 1
+        assert summary["n_iterations"] == 1
+        assert summary["partial_sweep"] is False
+        assert summary["proposal_path"] == str(tmp_path / "p.json")
+        assert summary["history_path"] == str(tmp_path / "h.csv")
+        assert "run_id" in summary
+        # No human-readable summary on stderr in JSON mode.
+        assert "optimizer accepted" not in captured.err
+        assert "no improvement found" not in captured.err


### PR DESCRIPTION
## Summary

Batch E of the post-merge code-review residual work for the tensor-weight optimizer. Applies findings #4 + #39 — the optimizer is now fully agent-tunable and emits a machine-readable summary on stdout when invoked with `--format json`.

## #4 — Machine-readable run summary on stdout

```bash
$ bench.py audit --optimize --format json
{"schema_version": 1, "run_id": "9d97971807fa", "n_iterations": 1,
 "n_steps_accepted": 16, "n_steps_rejected": 0, "partial_sweep": false,
 "train_composite_baseline": 0.4890..., "train_composite_final": 0.4972...,
 "train_composite_delta": 0.0083..., "held_composite_baseline": 0.4640...,
 "held_composite_final": 0.4687..., "held_composite_delta": 0.0047...,
 "proposal_path": "...", "history_path": "...", "dead_keys_count": 25}
```

Default `--format md` keeps the existing stderr human message — no behavior change for human callers. Agents pass `--format json` to get a single JSON line on stdout, suitable for piping to `jq` or parsing in Python without touching the proposal file.

The summary is independently versioned (`OPTIMIZE_SUMMARY_SCHEMA_VERSION = 1`) from the proposal JSON (`PROPOSAL_SCHEMA_VERSION = 1`) — they cover different scopes (run-level metadata vs candidate diff payload).

## #39 — Expose all 9 missing `OptimizerConfig` fields as CLI flags

| Flag | Default | Type | Constraint |
|---|---|---|---|
| `--alpha` | 0.5 | float | [0, 1] |
| `--grid` | 0.5 0.75 1.25 1.5 2.0 | list[float] | each > 0 |
| `--eps-step` | 0.005 | float | ≥ 0 |
| `--eps-cumulative` | 0.005 | float | ≥ 0 |
| `--clamp-min` | 0.01 | float | > 0 |
| `--clamp-max` | 5.0 | float | > 0 |
| `--train-ratio` | 0.8 | float | (0, 1) — open interval |
| `--wall-clock-seconds` | 300.0 | float | > 0 |
| `--self-test-seed` | 7 | int | — |

Combined with the prior 5 (`--max-sweeps`, `--seed`, `--no-self-test`, `--proposal-path`, `--optimize-history`), **all 14 `OptimizerConfig` knobs are now CLI-tunable**. Agent-driven sweep pipelines can vary `alpha` (the objective blend) and `grid` (search resolution) without source edits — the two semantically most significant tuning levers per the original PR #27 brainstorm.

## Validation

Range checks at the CLI boundary via `_alpha`, `_ratio`, `_positive_float`, `_nonneg_float` type callables. Out-of-range values raise `argparse.ArgumentTypeError` with actionable messages — fails fast at parse time instead of crashing mid-run inside `OptimizerConfig` validation.

Companion-flag warning extended to all 14 flags + `--grid` (the latter needs special handling since lists can't use simple-equality default check).

## Test plan

5 new tests in `TestHandleOptimize`:

- `test_argparse_validates_alpha_range` — `--alpha` accepts 0.0 / 1.0; rejects 1.5 / -0.1
- `test_argparse_validates_train_ratio_open_interval` — accepts 0.5; rejects 0.0 / 1.0 endpoints
- `test_argparse_grid_accepts_multiple_values` — `nargs="+"` works; rejects non-positive grid values
- `test_companion_flag_warning_includes_new_flags` — passing `--alpha` without `--optimize` warns
- `test_format_json_emits_summary_to_stdout` — end-to-end shape check (mocked optimizer)

End-to-end smoke run on the 100-commander fixture: JSON summary on stdout with all expected fields, content matches prior runs (16 steps accepted, train Δ=+0.0083, held Δ=+0.0047). Determinism preserved.

- [x] `uv run pytest tests/` — 1798 passed (was 1793, +5 new), 2 skipped, 21 deselected
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run scripts/bench.py audit --expect-identity` — PASS
- [x] Pre-commit hooks all green
- [x] `bench.py audit --optimize --format json` end-to-end smoke (~3 min) — JSON line on stdout, identical proposal to prior runs

## Documentation

`CLAUDE.md` Common Commands now includes examples for the new flags.

## Residual after this PR

Of the original 24 residual findings, 10 still pending:
- **Batch C** test gaps: #23, #24, #25, #26, #31
- **Architectural**: #17 split `run_optimizer`, #18 `_fast_total` cached property, #19 public `_score_from_complements`, #20 atomic dict swap, #34 hoist imports, #38 context manager