### PR TITLE
test(bench): batch C — close optimizer test gaps + fix cascade flake

### DIFF
--- a/tests/bench/test_optimize.py
+++ b/tests/bench/test_optimize.py
@@ -904,11 +904,23 @@ class TestRunOptimizerControlLogic:
         ALL accepts across all sweeps as reverted, so
         ``final_weights == baseline_weights`` and
         ``n_steps_accepted == 0`` after the trip.
+
+        Robustness: train and held are distinguished by commander identity
+        (``HELD_*`` prefix) instead of ``len(commanders) == 1``. The previous
+        test was fragile to fixture-size changes — if the test were updated
+        to a 10-commander fixture (held=2), the length check would
+        misclassify held calls as train, the drift scenario would never
+        trigger, and the test would silently pass.
         """
         from mtg_synergy_graph.bench import optimize as opt_mod
 
         train_calls = {"n": 0}
         held_calls = {"n": 0}
+
+        # Use a single named held commander; train commanders share no name
+        # with held. Distinguishing by identity is fixture-size-invariant.
+        held_name = "HELD_cmdr"
+        train_names = ["train_a", "train_b", "train_c", "train_d"]
 
         def _custom_score_split(
             conn,
@@ -931,8 +943,10 @@ class TestRunOptimizerControlLogic:
                 if cmdr not in labels_cache:
                     labels_cache[cmdr] = EdhrecLabels({}, None)
 
-            commanders_tuple = tuple(commanders)
-            is_held = len(commanders_tuple) == 1
+            # Identity-based train-vs-held detection: the held call passes
+            # the held commander; train calls don't include it. Robust
+            # against future fixture-size changes.
+            is_held = held_name in commanders
             if is_held:
                 held_calls["n"] += 1
                 # Baseline (call #1) = 0.5; subsequent held calls drop by 0.003.
@@ -947,14 +961,14 @@ class TestRunOptimizerControlLogic:
                 composite=composite,
                 mean_ndcg=composite,
                 gem_rate=composite,
-                n_commanders=len(commanders_tuple),
-                n_commanders_with_gem=len(commanders_tuple),
+                n_commanders=len(commanders),
+                n_commanders_with_gem=len(commanders),
             )
 
         monkeypatch.setattr(opt_mod, "_score_split", _custom_score_split)
 
         config = OptimizerConfig(run_self_test=False, max_sweeps=3, eps_cumulative=0.005)
-        result = run_optimizer(*fake_conns, ["a", "b", "c", "d", "e"], config=config)
+        result = run_optimizer(*fake_conns, [*train_names, held_name], config=config)
 
         # After revert: weights match baseline, no accepts survive.
         assert dict(result.final_weights) == patched_baseline_weights, (
@@ -968,6 +982,190 @@ class TestRunOptimizerControlLogic:
         # Metrics-vs-weights invariant: final composites match baseline composites.
         assert result.train_composite_final == result.train_composite_baseline
         assert result.held_composite_final == result.held_composite_baseline
+
+    def test_held_out_eps_rejects_step_when_held_drops_more_than_eps(
+        self,
+        patched_baseline_weights: dict[str, float],
+        fake_conns: tuple[object, object],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A step that improves train but drops held by > eps_step is rejected.
+
+        Coverage gap from the post-merge code-review (#23): all prior
+        control-logic tests used constant or always-improving composites,
+        so the ``held_delta < -eps_step`` branch (producing
+        ``reject_reason="held_out_eps"``) was never exercised end-to-end.
+        """
+        from mtg_synergy_graph.bench import optimize as opt_mod
+        from mtg_synergy_graph.bench.optimize import CompositeObjective, EdhrecLabels
+
+        held_name = "HELD_cmdr"
+        train_names = ["train_a", "train_b", "train_c", "train_d"]
+
+        def _custom_score_split(
+            conn,
+            edhrec_conn,
+            commanders,
+            weights,
+            *,
+            complements_cache,
+            labels_cache,
+            alpha,
+            candidate_cache=None,
+            idf_basis_cache=None,
+        ) -> CompositeObjective:
+            for cmdr in commanders:
+                if cmdr not in complements_cache:
+                    complements_cache[cmdr] = _make_complements_for_rules(list(weights.keys()))
+                if cmdr not in labels_cache:
+                    labels_cache[cmdr] = EdhrecLabels({}, None)
+            is_held = held_name in commanders
+            # Identify whether the call is for the BASELINE state (all weights
+            # at default 1.0) or a perturbed state. composite_for_weights-style
+            # check: if any weight differs from baseline 1.0, it's a perturbation.
+            is_perturbed = any(v != 1.0 for v in weights.values())
+            # Held: 0.5 at baseline; drops by 0.02 (>>eps_step=0.005) on perturbations.
+            # Train: monotonically improves on perturbation so a step IS
+            # proposed (gets to the held re-eval).
+            if not is_perturbed:
+                composite = 0.5  # baseline; both train and held start here
+            elif is_held:
+                composite = 0.48  # held drops on perturbation
+            else:
+                composite = 0.55  # train climbs on perturbation
+            return CompositeObjective(
+                composite=composite,
+                mean_ndcg=composite,
+                gem_rate=composite,
+                n_commanders=len(commanders),
+                n_commanders_with_gem=len(commanders),
+            )
+
+        monkeypatch.setattr(opt_mod, "_score_split", _custom_score_split)
+
+        config = OptimizerConfig(run_self_test=False, max_sweeps=1, eps_step=0.005)
+        result = run_optimizer(*fake_conns, [*train_names, held_name], config=config)
+
+        # No step accepted (every grid cell rejected at the held-eps gate).
+        assert result.n_steps_accepted == 0
+        assert result.n_steps_rejected > 0
+        # Every history entry was rejected with reason "held_out_eps".
+        assert all(not s.accepted for s in result.history)
+        assert {s.reject_reason for s in result.history} == {"held_out_eps"}, (
+            f"Expected only held_out_eps rejects, got: { {s.reject_reason for s in result.history} }"
+        )
+
+    def test_per_axis_gem_rate_regression_warning_fires_on_accept(
+        self,
+        patched_baseline_weights: dict[str, float],
+        fake_conns: tuple[object, object],
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """``run_optimizer`` warns when an accepted step drops train gem_rate by > 0.005.
+
+        Coverage gap from the post-merge code-review (#24): the per-axis
+        regression warning at ``optimize.py:909`` had no test. Here we
+        construct a step where composite improves AND the held-eps gate
+        passes BUT train gem_rate drops — the warning must fire and name
+        the rule.
+        """
+        from mtg_synergy_graph.bench import optimize as opt_mod
+        from mtg_synergy_graph.bench.optimize import CompositeObjective, EdhrecLabels
+
+        held_name = "HELD_cmdr"
+        train_names = ["train_a", "train_b", "train_c", "train_d"]
+
+        def _custom_score_split(
+            conn,
+            edhrec_conn,
+            commanders,
+            weights,
+            *,
+            complements_cache,
+            labels_cache,
+            alpha,
+            candidate_cache=None,
+            idf_basis_cache=None,
+        ) -> CompositeObjective:
+            for cmdr in commanders:
+                if cmdr not in complements_cache:
+                    complements_cache[cmdr] = _make_complements_for_rules(list(weights.keys()))
+                if cmdr not in labels_cache:
+                    labels_cache[cmdr] = EdhrecLabels({}, None)
+            is_held = held_name in commanders
+            is_perturbed = any(v != 1.0 for v in weights.values())
+            # Train: composite improves but gem_rate DROPS by > 0.005 on
+            # perturbation. The warning fires only when an accepted step
+            # has best_train.gem_rate < current_train_gem - 0.005.
+            if not is_held and is_perturbed:
+                composite = 0.6  # strictly better → accept
+                gem_rate = 0.7  # dropped from baseline 0.8 by 0.1 (> 0.005)
+            elif not is_held:
+                composite = 0.5  # baseline
+                gem_rate = 0.8
+            else:
+                # Held passes the eps gate either way.
+                composite = 0.5 if not is_perturbed else 0.499
+                gem_rate = 0.8
+            return CompositeObjective(
+                composite=composite,
+                mean_ndcg=composite,
+                gem_rate=gem_rate,
+                n_commanders=len(commanders),
+                n_commanders_with_gem=len(commanders),
+            )
+
+        monkeypatch.setattr(opt_mod, "_score_split", _custom_score_split)
+
+        config = OptimizerConfig(run_self_test=False, max_sweeps=1)
+        with caplog.at_level("WARNING", logger="mtg_synergy_graph.bench.optimize"):
+            result = run_optimizer(*fake_conns, [*train_names, held_name], config=config)
+
+        # At least one step accepted (composite strictly improved).
+        assert result.n_steps_accepted >= 1
+        # The warning fired at least once and names the gem_rate drop.
+        warnings = [r for r in caplog.records if "gem_rate" in r.getMessage()]
+        assert warnings, (
+            f"Expected at least one gem_rate-regression WARNING; got messages: "
+            f"{[r.getMessage() for r in caplog.records]}"
+        )
+
+    def test_proposed_config_hash_restores_global_on_compute_hash_exception(
+        self,
+        patched_baseline_weights: dict[str, float],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``_proposed_config_hash`` restores ``_RULE_QUALITY_MULTIPLIER`` even if compute raises.
+
+        Coverage gap from the post-merge code-review (#26): the existing
+        ``test_patch_restore_on_proposed_hash_compute`` only tested the
+        happy path. The try/finally exists precisely so a raise inside
+        ``compute_config_hash`` doesn't leave the global mutated. This
+        test forces that exception path.
+        """
+        from mtg_synergy_graph import universal_scorer
+        from mtg_synergy_graph.bench import optimize as opt_mod
+
+        baseline_snapshot = dict(universal_scorer._RULE_QUALITY_MULTIPLIER)
+        original_id = id(universal_scorer._RULE_QUALITY_MULTIPLIER)
+
+        # Force compute_config_hash to raise from inside _proposed_config_hash.
+        def _raising_compute_hash() -> str:
+            raise RuntimeError("simulated config-hash failure")
+
+        monkeypatch.setattr(
+            "mtg_synergy_graph.bench.tensor.compute_config_hash",
+            _raising_compute_hash,
+        )
+
+        proposed = {"alpha_rule": 99.0, "beta_rule": 99.0, "gamma_rule": 99.0}
+        with pytest.raises(RuntimeError, match="simulated config-hash failure"):
+            opt_mod._proposed_config_hash(proposed)
+
+        # Dict identity preserved AND values restored to baseline.
+        assert id(universal_scorer._RULE_QUALITY_MULTIPLIER) == original_id
+        assert dict(universal_scorer._RULE_QUALITY_MULTIPLIER) == baseline_snapshot
 
 
 def _make_complements_for_rules(rule_ids):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,42 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures"
 # exercise the real behavior.
 
 
+# ---------------------------------------------------------------------------
+# RuleInterpreter cache reset (per-test isolation)
+# ---------------------------------------------------------------------------
+#
+# ``complement_rules._interpreter_cache`` keys cached ``RuleInterpreter``
+# instances by ``id(conn)`` (CPython object address). The docstring there
+# warns: "id(conn) can be reused after a connection is closed and
+# garbage-collected. Always call clear_interpreter_cache before replacing
+# a connection object to avoid stale results."
+#
+# Without this autouse reset, test isolation across files breaks: when
+# ``tests/bench/test_audit_*.py`` opens a conn, builds a cached
+# interpreter, and then closes that conn, CPython can recycle the same
+# memory address for a fresh tmp_path conn opened by
+# ``tests/test_rules_migration_cascade.py``. The cascade test then gets
+# the OLD interpreter bound to the CLOSED conn and ``find_all_complements``
+# silently returns no rows. The cascade test was historically flaky for
+# exactly this reason — see the post-PR-#27 ce-code-review session notes.
+#
+# Clearing per-test is cheap (one ``dict.clear()``); the interpreter is
+# re-built lazily on the first ``find_all_complements`` call inside a
+# given test. This eliminates the address-recycling failure mode for all
+# future tests.
+
+
+@pytest.fixture(autouse=True)
+def _reset_interpreter_cache_between_tests() -> None:
+    from mtg_synergy_graph.complement_rules._interpreter_cache import (
+        clear_interpreter_cache,
+    )
+
+    clear_interpreter_cache()
+    yield
+    clear_interpreter_cache()
+
+
 @pytest.fixture(autouse=True)
 def _stub_forge_sha_when_checkout_absent(monkeypatch: pytest.MonkeyPatch) -> None:
     from mtg_synergy_graph.forge_oracle import version as fo_version


### PR DESCRIPTION
## Summary

Two changes in one PR because the second is a hard prerequisite for shipping the first cleanly.

### (1) Batch C optimizer test-coverage gaps (#23 #24 #26 #31)

Four test additions/refinements close coverage gaps the post-merge ce-code-review flagged.

- **#23** `held_out_eps` reject branch — all prior control-logic tests used constant or always-improving composites; the `held_delta < -eps_step` branch was never exercised. New test exercises it.
- **#24** Per-axis gem_rate regression warning — the `_logger.warning` that fires when accepted steps drop train gem_rate by > 0.005 had no test. New test uses `caplog` at WARNING level.
- **#26** `_proposed_config_hash` exception path — existing test covered only the happy path; the `try/finally` exists for exception cases. New test forces `compute_config_hash` to raise and asserts dict-identity preservation + value restoration.
- **#31** drift-revert test fragility — refactored to use commander identity (`held_name="HELD_cmdr"`) instead of `len(commanders) == 1`, so the test is fixture-size-invariant.

#25 was already covered by Batch D's `test_select_plant_*` tests.

### (2) Root-cause fix for the cascade-test flake

Cascade test `test_cascade_tribal_emits_one_complement_per_other_cascade_card` was intermittently failing all session (flagged as "pre-existing, out of scope" in PRs #30, #32, #34). Now fixed at the root.

**Root cause:** `complement_rules/_interpreter_cache.py` keys cached `RuleInterpreter` instances by `id(conn)`. The docstring there explicitly warns:

> id(conn) (CPython object address) can be reused after a connection is closed and garbage-collected. Always call clear_interpreter_cache before replacing a connection object to avoid stale results.

Without an autouse reset between tests, isolation across files breaks: when `tests/bench/test_audit_*.py` opens a conn, builds a cached interpreter, and closes that conn, CPython can recycle the same memory address for a fresh `tmp_path` conn opened later by `tests/test_rules_migration_cascade.py`. The cascade test then gets the OLD interpreter bound to a CLOSED conn, `find_all_complements` silently returns nothing, and the test fails with `assert set() == {'Bloodbraid Elf', 'Imoti Celebrant of Bounty', 'Shardless Agent'}`.

**Fix:** A new autouse fixture in `tests/conftest.py` calls `clear_interpreter_cache()` before AND after each test. Cost is one `dict.clear()` per test (~µs). Eliminates the address-recycling failure mode for the entire suite, not just the optimizer-related tests.

This fix unblocks every future PR that triggers the test-ordering condition. It was pre-existing — neither caused by nor specific to the optimizer work — but kept landing as a "won't fix" item because the trigger conditions were rare and unrelated to whatever PR was in flight.

## Test plan

- [x] `uv run pytest tests/` — **1805 passed**, 2 skipped, 21 deselected (was 1801; +4 are the cascade tests that now reliably run)
- [x] Re-ran to confirm deterministic — same result
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pyright tests/conftest.py` — 0 errors
- [x] Pre-commit hooks all green (the cascade fix means pytest passes deterministically through pre-commit now)
- [x] `bench.py audit --expect-identity` — PASS

## Residual after this PR

7 of the original 24 residual findings still pending — all architectural now:
- **#17** split `run_optimizer` (~250 lines, complexity ≥13)
- **#18** `_fast_total` cached property on `UniversalScore`
- **#19** make `_score_from_complements` public
- **#20** atomic dict swap (concurrency)
- **#34** hoist deferred imports
- **#38** clear+update context manager