### PR TITLE
refactor(bench): consolidate optimizer patch+restore + hoist imports + rename

### DIFF
--- a/src/mtg_synergy_graph/bench/optimize.py
+++ b/src/mtg_synergy_graph/bench/optimize.py
@@ -37,7 +37,16 @@ from dataclasses import dataclass
 from types import MappingProxyType
 from typing import TYPE_CHECKING
 
+from mtg_synergy_graph.complement_rules import find_all_complements
+from mtg_synergy_graph.engine import UNRANKED_EDHREC_SENTINEL
 from mtg_synergy_graph.penalties import build_candidate_cache
+from mtg_synergy_graph.universal_scorer import (
+    _compute_idf_basis,
+    _compute_pair_bonus,
+    patched_rule_quality_multiplier,
+    score_from_complements,
+)
+from mtg_synergy_graph.validate import compute_ndcg
 
 _logger = logging.getLogger(__name__)
 
@@ -352,8 +361,6 @@ def _fast_total_and_contribs(
           deduped exactly once. Zero-net entries are NOT dropped here —
           the caller filters them when assembling the contributions tuple.
     """
-    from mtg_synergy_graph.universal_scorer import _compute_pair_bonus
-
     total = 0.0
     seen: set[tuple[str, str, str, str, str]] = set()
     distinct_rules: set[str] = set()
@@ -409,7 +416,7 @@ def score_commander_from_complements(
     Reads the live ``_RULE_QUALITY_MULTIPLIER`` and ``_FLAT_WEIGHT_OVERRIDES``
     globals — the caller is responsible for patching them via
     ``.clear() + .update(weights)`` in a ``try/finally`` BEFORE this call
-    if grid-cell weights differ from baseline. ``_score_from_complements``
+    if grid-cell weights differ from baseline. ``score_from_complements``
     handles the staple/circuit/cmc/rank/embedding side-channels exactly
     as ``score_all_universal`` does.
 
@@ -424,10 +431,7 @@ def score_commander_from_complements(
     ``engine.SynergyEngine.page()`` — so the optimizer's view matches
     what ``recommend.py`` displays.
     """
-    from mtg_synergy_graph.engine import UNRANKED_EDHREC_SENTINEL
-    from mtg_synergy_graph.universal_scorer import _score_from_complements
-
-    results = _score_from_complements(
+    results = score_from_complements(
         conn,
         [commander],
         complements,
@@ -618,19 +622,11 @@ def _score_split(
     inner ``_compute_idf_weights`` walk is replaced by a per-key
     ``_RULE_QUALITY_MULTIPLIER`` lookup.
     """
-    from mtg_synergy_graph import universal_scorer
     from mtg_synergy_graph.bench.hidden_gems import (
         hidden_gem_hit_rate_for_commander,
     )
-    from mtg_synergy_graph.complement_rules import find_all_complements
-    from mtg_synergy_graph.universal_scorer import _compute_idf_basis
-    from mtg_synergy_graph.validate import compute_ndcg
 
-    baseline = dict(universal_scorer._RULE_QUALITY_MULTIPLIER)
-    try:
-        universal_scorer._RULE_QUALITY_MULTIPLIER.clear()
-        universal_scorer._RULE_QUALITY_MULTIPLIER.update(weights)
-
+    with patched_rule_quality_multiplier(weights):
         per_ndcg: dict[str, float] = {}
         per_gem: dict[str, float | None] = {}
         for cmdr in commanders:
@@ -666,9 +662,6 @@ def _score_split(
                 per_gem[cmdr] = gem_entry.rate if gem_entry is not None else None
             else:
                 per_gem[cmdr] = None
-    finally:
-        universal_scorer._RULE_QUALITY_MULTIPLIER.clear()
-        universal_scorer._RULE_QUALITY_MULTIPLIER.update(baseline)
 
     return composite_objective(per_ndcg, per_gem, alpha)
 
@@ -881,7 +874,7 @@ def run_optimizer(
     # Build the commander-independent candidate cache ONCE per run. Without this,
     # every grid-cell evaluation re-issues `SELECT name, cmc, edhrec_rank FROM
     # cards` (full ~32k-row scan) inside score_commander_from_complements +
-    # _score_from_complements. With ~26k grid evaluations per sweep, that's
+    # score_from_complements. With ~26k grid evaluations per sweep, that's
     # ~850M row reads → the bottleneck. The cache is reused across the full run.
     candidate_cache = build_candidate_cache(conn)
 
@@ -1212,22 +1205,15 @@ def _proposed_config_hash(proposed_weights: Mapping[str, float]) -> str:
     """Compute the config hash that the proposed weights would produce.
 
     Patches ``_RULE_QUALITY_MULTIPLIER`` to the proposed values, calls
-    ``compute_config_hash``, restores, and returns the hash. The
-    patch+hash+restore happens in a single ``try/finally`` so dict
-    identity is preserved on every exit path. Mirrors the established
-    test-fixture pattern (``tests/test_scoring_weights.py:309-324``).
+    ``compute_config_hash``, and restores via the
+    :func:`~mtg_synergy_graph.universal_scorer.patched_rule_quality_multiplier`
+    context manager. Dict identity preserved on every exit path
+    (including exceptions raised inside ``compute_config_hash``).
     """
-    from mtg_synergy_graph import universal_scorer
     from mtg_synergy_graph.bench.tensor import compute_config_hash
 
-    saved = dict(universal_scorer._RULE_QUALITY_MULTIPLIER)
-    try:
-        universal_scorer._RULE_QUALITY_MULTIPLIER.clear()
-        universal_scorer._RULE_QUALITY_MULTIPLIER.update(proposed_weights)
+    with patched_rule_quality_multiplier(proposed_weights):
         return compute_config_hash()
-    finally:
-        universal_scorer._RULE_QUALITY_MULTIPLIER.clear()
-        universal_scorer._RULE_QUALITY_MULTIPLIER.update(saved)
 
 
 def write_proposal_json(

--- a/src/mtg_synergy_graph/universal_scorer.py
+++ b/src/mtg_synergy_graph/universal_scorer.py
@@ -13,7 +13,8 @@ import logging
 import math
 import sqlite3
 from collections import defaultdict
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from functools import cached_property, lru_cache
 from pathlib import Path
@@ -592,6 +593,48 @@ _FLAT_WEIGHT_OVERRIDES: dict[str, float] = _LOADED_SCORING_WEIGHTS.flat_weight_o
 _RULE_QUALITY_MULTIPLIER: dict[str, float] = _LOADED_SCORING_WEIGHTS.rule_quality_multiplier
 
 
+@contextmanager
+def patched_rule_quality_multiplier(weights: Mapping[str, float]) -> Iterator[None]:
+    """Temporarily replace ``_RULE_QUALITY_MULTIPLIER`` with ``weights``; restore on exit.
+
+    The bench optimizer scores grid cells by patching the global
+    ``_RULE_QUALITY_MULTIPLIER`` dict, calling
+    :func:`score_from_complements`, and restoring the baseline. The
+    ``.clear() + .update()`` pattern preserves the dict's identity (so
+    callers holding a reference to the global keep seeing live values).
+
+    Identity preservation matters because:
+
+    * ``compute_config_hash`` and ``ScoringConfigInputs`` read the
+      module-level global by attribute access; rebinding to a new dict
+      would silently break observers.
+    * Test fixtures patch the global to install synthetic weights and
+      rely on the same dict object surviving across the fixture's yield.
+
+    The context manager consolidates the four-line ``baseline = dict(...);
+    try: clear+update; finally: clear+update`` pattern previously
+    duplicated across ``_score_split``, ``_proposed_config_hash``, the
+    ``patched_baseline_weights`` test fixture, and several individual
+    tests. One source of truth means future refactors (e.g., a future
+    atomic single-key swap) only touch this function.
+
+    Usage::
+
+        with patched_rule_quality_multiplier(weights):
+            score_from_complements(conn, [cmdr], complements)
+
+    Restores even if the body raises (try/finally semantics).
+    """
+    baseline = dict(_RULE_QUALITY_MULTIPLIER)
+    try:
+        _RULE_QUALITY_MULTIPLIER.clear()
+        _RULE_QUALITY_MULTIPLIER.update(weights)
+        yield
+    finally:
+        _RULE_QUALITY_MULTIPLIER.clear()
+        _RULE_QUALITY_MULTIPLIER.update(baseline)
+
+
 @dataclass(frozen=True)
 class IdfBasis:
     """Per-commander IDF basis: weight-independent components of ``_compute_idf_weights``.
@@ -733,7 +776,7 @@ def score_all_universal(
     identity invariant in the plan.
     """
     complements = find_all_complements(conn, commander_set, candidate_cache=candidate_cache)
-    return _score_from_complements(
+    return score_from_complements(
         conn,
         commander_set,
         complements,
@@ -742,7 +785,7 @@ def score_all_universal(
     )
 
 
-def _score_from_complements(
+def score_from_complements(
     conn: sqlite3.Connection,
     commander_set: Sequence[str],
     complements: Sequence[PortComplement],
@@ -753,12 +796,15 @@ def _score_from_complements(
 ) -> dict[str, UniversalScore]:
     """Build per-candidate ``UniversalScore`` results from precomputed complements.
 
-    Extracted from :func:`score_all_universal` so the weight optimizer
-    (``bench/optimize.py``) can score with patched ``_RULE_QUALITY_MULTIPLIER``
-    against cached complements without paying the ``find_all_complements`` cost
-    on every grid cell. Reads ``_RULE_QUALITY_MULTIPLIER``,
-    ``_FLAT_WEIGHT_OVERRIDES``, and the embedding/staple/circuit/cmc/rank
-    side-channels exactly as ``score_all_universal`` does.
+    Public counterpart to :func:`score_all_universal`: skip the
+    ``find_all_complements`` step when the caller already has the
+    complements list in hand. The bench optimizer
+    (``bench/optimize.py``) caches complements per commander and calls
+    this directly per grid cell with patched ``_RULE_QUALITY_MULTIPLIER``.
+
+    Reads ``_RULE_QUALITY_MULTIPLIER``, ``_FLAT_WEIGHT_OVERRIDES``, and
+    the embedding/staple/circuit/cmc/rank side-channels exactly as
+    ``score_all_universal`` does.
 
     When ``idf_basis`` is supplied, skip the per-call frequency-counting walk
     and apply the current ``_RULE_QUALITY_MULTIPLIER`` to the cached basis

--- a/tests/bench/test_optimize.py
+++ b/tests/bench/test_optimize.py
@@ -655,24 +655,23 @@ def _scripted_score_split(
 
 
 @pytest.fixture()
-def patched_baseline_weights(monkeypatch: pytest.MonkeyPatch) -> dict[str, float]:
+def patched_baseline_weights() -> Iterator[dict[str, float]]:
     """Replace ``_RULE_QUALITY_MULTIPLIER`` with a tiny, predictable dict for tests.
 
-    Restored at fixture teardown by monkeypatch.
+    Uses the production
+    :func:`~mtg_synergy_graph.universal_scorer.patched_rule_quality_multiplier`
+    context manager so tests exercise the same patch+restore path as the
+    bench optimizer. Restoration is automatic on yield/exception.
     """
-    from mtg_synergy_graph import universal_scorer
+    from mtg_synergy_graph.universal_scorer import patched_rule_quality_multiplier
 
     test_weights = {
         "alpha_rule": 1.0,
         "beta_rule": 1.0,
         "gamma_rule": 1.0,
     }
-    saved = dict(universal_scorer._RULE_QUALITY_MULTIPLIER)
-    universal_scorer._RULE_QUALITY_MULTIPLIER.clear()
-    universal_scorer._RULE_QUALITY_MULTIPLIER.update(test_weights)
-    yield dict(test_weights)
-    universal_scorer._RULE_QUALITY_MULTIPLIER.clear()
-    universal_scorer._RULE_QUALITY_MULTIPLIER.update(saved)
+    with patched_rule_quality_multiplier(test_weights):
+        yield dict(test_weights)
 
 
 @pytest.fixture()
@@ -729,11 +728,12 @@ class TestRunOptimizerControlLogic:
             _scripted_score_split(composite_for_weights=lambda w: 0.5),
         )
         # Pretend every rule fires, so no dead keys.
+        # find_all_complements is hoisted to module-level in optimize.py
+        # post-#34 — no need for raising=False anymore.
         monkeypatch.setattr(
             opt_mod,
             "find_all_complements",
             lambda conn, cmdrs: _make_complements_for_rules(list(patched_baseline_weights.keys())),
-            raising=False,
         )
         # Stub label loader.
         monkeypatch.setattr(opt_mod, "load_edhrec_labels", lambda c, n: opt_mod.EdhrecLabels({}, None))


### PR DESCRIPTION
## Summary

Three architectural-batch findings from the post-merge code-review residual list. **Bitwise-identical scoring preserved** (`audit --expect-identity` PASS); no behavior change.

## #19 — Rename `_score_from_complements` → `score_from_complements`

Cross-package import of an underscore-prefixed private symbol was flagged by the maintainability reviewer (M4): a future rename inside `universal_scorer.py` would silently break `optimize.py` with no static-analysis warning. Dropping the underscore makes the cross-module contract explicit. Updated all call sites and docstrings.

## #34 — Hoist deferred imports in `optimize.py` to module level

The 4 imports inside `_score_split` (and 2 in `score_commander_from_complements`, 1 in `_fast_total_and_contribs`) were marked "circular-import avoidance" — but the maintainability reviewer (M1) pointed out no cycle exists. Verified by grepping the candidate modules for back-imports of `bench.optimize`: **zero hits** in `validate.py`, `complement_rules/__init__.py`, `engine.py`.

Hoisted at module top:

```python
from mtg_synergy_graph.complement_rules import find_all_complements
from mtg_synergy_graph.engine import UNRANKED_EDHREC_SENTINEL
from mtg_synergy_graph.universal_scorer import (
    _compute_idf_basis,
    _compute_pair_bonus,
    patched_rule_quality_multiplier,
    score_from_complements,
)
from mtg_synergy_graph.validate import compute_ndcg
```

Performance impact is marginal (sys.modules caches the module after first import); the maintainability win is the real value.

Test fixture updated: `monkeypatch.setattr(opt_mod, "find_all_complements", ..., raising=False)` no longer needs `raising=False` since the attribute is now present at module level.

## #38 — Extract `patched_rule_quality_multiplier` context manager

The "snapshot baseline; clear+update; finally clear+update" pattern was duplicated across `_score_split`, `_proposed_config_hash`, and the `patched_baseline_weights` test fixture. New context manager in `universal_scorer.py` consolidates the dict-identity-preserving patch+restore.

```python
@contextmanager
def patched_rule_quality_multiplier(weights: Mapping[str, float]) -> Iterator[None]:
    baseline = dict(_RULE_QUALITY_MULTIPLIER)
    try:
        _RULE_QUALITY_MULTIPLIER.clear()
        _RULE_QUALITY_MULTIPLIER.update(weights)
        yield
    finally:
        _RULE_QUALITY_MULTIPLIER.clear()
        _RULE_QUALITY_MULTIPLIER.update(baseline)
```

Documented invariants:
- Identity matters because `compute_config_hash` and `ScoringConfigInputs` read the global by attribute access; rebinding would silently break observers.
- Tests can patch the global in-place via monkeypatch and rely on the same dict object surviving across yield.

The 3 partial-mutation TEST sites (`test_weight_shift_changes_ranking`, `test_patch_restore_on_caller_exception`, the idf_basis weight-shift test) are NOT converted — they exercise single-key mutation patterns outside the context manager's full-dict contract. Conversion would add noise without consolidation benefit.

## Why #20 + #18 are deferred

- **#20** (atomic single-key swap): conflicts with the #38 context-manager abstraction; single-process use makes the perf concern theoretical.
- **#18** (`_fast_total` cached property on `UniversalScore`): would defeat the #9 fused-walk by re-introducing two cached-property walks. Current shape is a deliberate fusion.

## Test plan

- [x] `uv run pytest tests/` — **1805 passed**, 2 skipped, 21 deselected (unchanged; pure refactor)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run scripts/bench.py audit --expect-identity` — **PASS** (bitwise-identical scoring across 100 commanders × 30 candidates)
- [x] Pre-commit hooks all green (including bench-audit)

## Residual after this PR

3 architectural items intentionally left for future:

- **#17** split `run_optimizer` (~250 lines, complexity ≥13) — separate PR, biggest refactor
- **#18** `_fast_total` cached property — would conflict with #9 fused-walk, current shape is deliberate
- **#20** atomic single-key swap — perf concern is theoretical for single-process use; conflicts with #38 abstraction