### PR TITLE
feat: BM25 IDF probe (declined) + per-commander audit infra + META lesson

### DIFF
--- a/docs/brainstorms/2026-05-04-bm25-idf-requirements.md
+++ b/docs/brainstorms/2026-05-04-bm25-idf-requirements.md
@@ -1,0 +1,360 @@
+---
+last_updated: 2026-05-04
+type: requirements
+title: BM25 IDF reformulation for NDCG@30 lift
+tags:
+  - scoring
+  - idf
+  - universal-scorer
+  - audit-gated
+  - 500-cmdr-fixture
+status: open
+plan_ref: TBD (ce-plan to follow)
+session_ref: 2026-05-04 brainstorm — orthogonal-directions to lift recommendation model
+priors:
+  - docs/solutions/best-practices/scaffold-queue-generator-exhaustion-2026-04-24.md
+  - docs/solutions/best-practices/infrastructure-without-scoring-activation-2026-04-24.md
+  - docs/solutions/best-practices/optimizer-fixture-size-2026-04-30.md
+---
+
+# BM25 IDF reformulation for NDCG@30 lift
+
+## Problem Frame
+
+Three direct improvement levers for NDCG@30 / hidden_gem_hit_rate were
+proven exhausted in a single session on 2026-05-04:
+
+1. **Per-rule weight optimizer** — 4 sweeps with varied alpha/grid/seed
+   on the 500-cmdr fixture all produced sub-noise held-subset NDCG deltas
+   (+0.000175 to +0.000343), zero gem_rate movement.
+2. **Embedding contribution flip** — re-sweep on 500-cmdr (10 cells) was
+   uniformly negative (−0.0012 to −0.0101 vs flag-off). The prior
+   30-cmdr +0.0067 was sampling noise.
+3. **Walker rule-shipping with v1.0 Stage A pre-flight** — 0 attempted,
+   0 shipped. Queue exhaustion exactly as predicted by
+   `docs/solutions/best-practices/scaffold-queue-generator-exhaustion-2026-04-24.md`.
+
+The 2026-04-24 saturation diagnosis explicitly named "orthogonal
+directions": **better IDF weighting**, new commander-target composition
+for embeddings, and richer port-signature features.
+
+This document scopes the **first orthogonal direction probe** to attempt:
+**reformulating the per-rule IDF in `src/mtg_synergy_graph/universal_scorer.py`
+from the current `1/log2(1 + N)` to a BM25-style saturation IDF**.
+
+**Framing as "probe" not "first improvement attempt":** BM25 was chosen
+as the opening move because it is the cheapest of the 5 viable
+orthogonal directions, not because EV analysis ranks it highest. A null
+result from BM25 is informative (it tells us the BM25-style IDF curve
+is not the lever) but does NOT exhaust the IDF axis as a whole. Four
+alternative IDF formulations remain explicitly viable post-DECLINE
+(smoothed-frequency, structural-overlap, per-rule-cluster, rank-aware).
+
+**Why BM25 specifically (workload-fit honest disclosure):** Classical
+BM25 IDF was developed for natural-language information retrieval where
+(a) vocabulary is large (10k+ terms), (b) per-document term frequency
+matters and is multiplied by IDF (the "TF" half of BM25), and (c) df
+distributions follow heavy-tailed Zipfian patterns. This workload is
+different: (a) ~tens of rule_id-keyed firings (small vocabulary), (b)
+per-(rule, candidate) firing is essentially binary — there is no TF
+analog, so we use BM25's IDF half ONLY, (c) df distributions are shaped
+by mechanical port frequency and are likely less Zipfian than NL.
+
+**This means:** stripping TF from BM25 and applying its IDF to a small
+near-binary signal may behave very differently from how the IR
+literature describes BM25's gains over log2-IDF. The plan's audit will
+reveal whether the saturation curve change improves ranking for THIS
+workload — not whether BM25 in general is "better." A DECLINE outcome
+specifically rules out the BM25-IDF saturation curve, not the IDF axis.
+
+**Why this probe first (not anti-synergy or port-signature features):**
+- IDF reformulation is a single file change with audit-gated revert.
+- The current IDF formula is the central scoring knob; if there's lift
+  available without expanding what the system can model mechanically,
+  IDF is where it lives.
+- Anti-synergy rules and richer port-signature features both expand
+  the system's mechanical surface area; they are higher-EV for the
+  hidden_gem axis but require new templates, vocabulary bumps, or
+  mental model shifts. They're explicitly in the queue (see Out of
+  Scope), but BM25 is the right "is the cheap axis dead?" probe to
+  resolve before committing to the more expensive directions.
+
+If BM25 lifts NDCG@30 above the ship bar, the IDF saturation curve was
+a real lever and weight-tuning has more headroom than the optimizer
+sweeps suggested. If it doesn't, the cheap probe completed and the
+next brainstorm picks from the higher-effort orthogonal directions
+with sharper EV expectations.
+
+## Explicit Product Decision: NDCG@30 as primary metric (for this work)
+
+The owner explicitly chose NDCG@30 as the primary metric for BM25 IDF
+work during the 2026-05-04 ce-brainstorm session. This contrasts with
+`memory/feedback_edhrec_not_goal.md` ("EDHREC is sanity check only;
+goal is finding hidden gems from mechanics"). This brainstorm
+acknowledges the contrast openly:
+
+- **What the reframe accepts:** NDCG@30 measures EDHREC top-30
+  similarity by construction. Optimizing for it points the scoring
+  system toward EDHREC convergence — opposite to the original "find
+  gems EDHREC misses" positioning.
+- **What the reframe expects in return:** A measurable, communicable
+  optimization target that can be moved or proven unmovable in a
+  single session.
+- **Per-change ship bar is symmetric** (NDCG +0.010 / gem −0.010, see
+  Success Criteria) so this work does not silently ratchet gem rate
+  down.
+- **Scope of the reframe:** This decision applies to BM25 IDF
+  specifically. Future orthogonal-direction brainstorms must
+  re-justify the primary metric (do not assume NDCG@30 carries
+  forward).
+
+**Program-level constraints are out of scope for this brainstorm.**
+A cumulative gem-rate budget across the orthogonal-directions program
+was considered and rejected as scope creep — that belongs in a
+separate program-governance doc, not in a brainstorm for one work
+item. If the owner wants to track cumulative erosion, that needs its
+own decision artifact.
+
+**Memory follow-through:** As part of the SHIP commit (if BM25 ships),
+update `memory/feedback_edhrec_not_goal.md` with a dated note
+recording the reframe and its scope. If BM25 declines, append a dated
+note recording "on 2026-05-04 a brainstorm proposed reversing this
+framing for BM25 work; the work declined, framing remains unchanged."
+Either way the memory record stays current.
+
+## Goals
+
+- **G1.** Implement BM25-style IDF as an alternative to current
+  `1/log2(1 + N)` in `src/mtg_synergy_graph/universal_scorer.py`.
+- **G2.** Audit-gate the swap: compute scoring under both formulas,
+  measure NDCG@30 and hidden_gem_hit_rate deltas on the 500-cmdr held
+  set against the current pinned fixture.
+- **G3.** Ship BM25 if it clears the success bar; revert and document
+  null result if it doesn't.
+
+## Anti-Goals (Carryover, Not Up for Re-Litigation)
+
+- No EDHREC at inference. (BM25 IDF computes from candidate pool
+  statistics, no EDHREC data.)
+- No per-commander or per-archetype rules. (BM25 is a per-rule formula
+  applied universally.)
+- No training, no learned weights at inference. (BM25 has no
+  hyperparameters to tune in its IDF-only form.)
+- Forge DSL based, deterministic. (BM25 is deterministic given pool
+  statistics.)
+- `bench.py audit --expect-identity` will FAIL on this change by design
+  (BM25 changes scores). Re-pin via `bench.py audit --repin --yes` is
+  expected and required if BM25 ships.
+
+## Success Criteria
+
+**Threshold derivation (judgment-call disclosure):** The +0.010 NDCG
+bar is operationally chosen, not statistically derived. It's roughly
+5× today's optimizer noise floor for per-rule multiplier sweeps;
+structural IDF reformulation may have different noise characteristics.
+The plan should seed-vary the train/held split (~3 seeds) and report
+NDCG delta variance as a sanity check. If the spread exceeds the
+ship-bar margin, treat the result as inconclusive (a 4th outcome
+beyond SHIP/INVESTIGATE/DECLINE) and document accordingly. Bootstrap
+resampling is NOT required — seed-varying is enough for a probe-level
+precision check.
+
+### Three outcomes (evaluated in sequence)
+
+1. **Per-commander regression check (prerequisite, simple):**
+   - If ANY commander in the 500-cmdr held subset loses more than
+     0.05 NDCG@30 individually → **DECLINE** (regardless of aggregate
+     delta). The probe is rejected; tail-impact is too high to
+     ship. A separate brainstorm could reconsider with a hybrid or
+     per-rule-fallback approach, but that's not authorized here.
+   - Otherwise continue to aggregate check.
+   - Per-commander reporting via existing `bench.py audit --inspect`
+     if it surfaces NDCG diffs, or new reporting flag if not (see
+     Open Q2).
+
+2. **Aggregate metric check (after per-commander passes):**
+   - **SHIP** if BOTH:
+     - NDCG@30 delta ≥ +0.010 vs current pin
+     - hidden_gem_hit_rate delta ≥ −0.010 vs current pin (symmetric)
+   - **INVESTIGATE** if NDCG@30 delta is in [+0.005, +0.010) AND gem
+     stays within bound. Document the result, do NOT ship. The follow-on
+     decision (try a different IDF variant, accept saturation, etc.)
+     requires a NEW brainstorm. Do not let INVESTIGATE become implicit
+     authorization to swap IDF variants in-flight. Importantly: the
+     +0.005 lift is NOT pre-paid progress — the next IDF-variant
+     attempt must independently clear +0.010 from the (unchanged)
+     current pin.
+   - **DECLINE** if NDCG@30 delta < +0.005, OR gem regression beyond
+     bound. The DECLINE conclusion specifically rejects BM25-style
+     IDF for this workload. It does NOT rule out other IDF
+     alternatives (smoothed-frequency, structural-overlap,
+     per-rule-cluster, rank-aware) — those remain valid follow-on
+     directions and any of them could move the IDF lever where BM25
+     could not.
+
+### Sanity check (deferred to plan-time discretion)
+
+If the planner has capacity, sample 5-10 commanders BEFORE running
+the audit (lock the names into the plan doc as a pre-commit) and
+produce side-by-side top-30 diffs after the audit. This is a
+qualitative gut-check, not a hard gate — owner reviews whether the
+new lists pass intuition. Useful but not required to ship.
+
+## Per-Commander Regression Bound (consolidated into Success Criteria check #1)
+
+The per-commander bound semantics live in Success Criteria check #1
+above. Simple form: ANY commander loses more than 0.05 NDCG@30 →
+DECLINE.
+
+**Why 0.05 (caveat):** The bound is operationally chosen, not
+derived. A 0.05 NDCG@30 swing on a single commander roughly
+corresponds to "1-2 cards swap into/out of the top 30" or "noticeable
+top-3 reordering." If the natural per-commander NDCG volatility
+across audit reruns is observed to be ≥ 0.05, the bound is toothless
+and must tighten — but that calibration is a future-work item, not a
+prerequisite for THIS probe.
+
+**No per-archetype cohort analysis.** A per-archetype check was
+considered but dropped: `data/tags.db` does not contain commander→
+archetype labels (per `bench/optimize.py:153`), and adding them is
+its own work item that exceeds the scope of this probe. If
+systematic per-archetype skew turns out to be the dominant failure
+mode under BM25, that becomes the seed of a follow-on brainstorm
+("design archetype-aware audit gates"), not in-scope here.
+
+## Scope Boundaries
+
+**In scope:**
+- Replace the IDF formula in `_compute_idf_basis()` at
+  `src/mtg_synergy_graph/universal_scorer.py:702`. The wrapper
+  `_compute_idf_weights()` delegates to the basis function and does
+  not need separate changes.
+- Update tests that assert specific IDF values for known cases (these
+  will need new expected values).
+- **Seed-vary precision check (lightweight):** Run the audit under
+  3 train/held split seeds (e.g., 17, 42, 137); report mean and
+  spread of NDCG@30 delta. If spread exceeds the ship-bar margin
+  (~0.010), document the result as inconclusive. No bootstrap-resample
+  module required.
+- **FLAT_COUNT_RULES sanity check:** Confirm `_FLAT_WEIGHT_OVERRIDES`
+  rules continue to bypass IDF as expected (the existing if/else
+  branch in `_compute_idf_basis` does this; verify the branch is
+  preserved post-change). The 6 flat rules — `etb_self`, `evasion`,
+  `scaling`, `spell_density`, `token_producer`, `tribal_density` —
+  should not see IDF formula effects. No new tooling needed.
+- Resolve the calibration-confound (Open Q1): pick (a)/(b)/(c).
+- Run `bench.py audit` against current pin under chosen approach;
+  produce per-commander diff (extending `--inspect` if needed);
+  decide ship/no-ship per success criteria.
+- If shipping: re-pin BOTH the 500-cmdr and 100-cmdr fixtures
+  atomically (see Risks for why both are required); `bench.py audit
+  --repin --yes` for each; document any Stage A pre-flight verdict
+  shifts; rebuild `walker_outcomes.csv` baseline (see Risks); commit;
+  update `docs/RULE_HISTORY.md` with the IDF change as a single
+  entry; update `memory/feedback_edhrec_not_goal.md` with the dated
+  reframe note (per Product Decision section).
+
+**Out of scope:**
+- Other IDF alternatives (smoothed-frequency, structural-overlap,
+  per-rule-cluster, rank-aware). These are explicitly DEFERRED to
+  follow-on brainstorms IF BM25 declines.
+- Commander-target composition redesign. Separate orthogonal direction.
+- Port-signature feature richness (vocabulary expansion). Separate
+  orthogonal direction.
+- Anti-synergy rule system. Separate orthogonal direction.
+- Multi-card combo scoring. Separate orthogonal direction.
+- Tuning BM25's optional smoothing constants beyond defaults. **Locked
+  scope decision:** use pure classic BM25 IDF formula
+  `log((N − df + 0.5) / (df + 0.5) + 1)`. Variants are a separate
+  decision. (Replaces former "Open Question 1" which was self-answered.)
+- Changes to `_RULE_QUALITY_MULTIPLIER` or `_FLAT_WEIGHT_OVERRIDES`
+  in `data/scoring_weights.json` — EXCEPT to the extent that
+  resolving the calibration-confound (Q1) requires touching them.
+  See Open Q1 for the three options and which ones modify weights.
+- Permanent feature flag for the IDF formula. **Locked scope
+  decision:** implement BM25 directly with no `_ENABLE_*` switch.
+  Reverting is `git revert` or a one-line change regardless. The
+  flag adds a permanent code path that serves no consumer post-ship.
+
+## Carryover Constraints
+
+- Library shape: pure-function gates, severity tiers (PASS/WARN/REJECT),
+  audit-gated changes via `bench.py audit + repin` discipline.
+- 500-cmdr fixture is the calibration baseline; 100-cmdr is too small
+  per `optimizer-fixture-size-2026-04-30.md`.
+- The 100-cmdr canonical fixture stays for `bench.py audit` pre-commit
+  hooks; the 500-cmdr is for this NDCG@30 evaluation.
+
+## Implementation Hints (for ce-plan)
+
+These are NOT design decisions — they're observations from the brainstorm
+that the planner should verify:
+
+- **Current IDF location:** The live formula `1.0 / math.log2(1.0 + n)`
+  is materialized in `_compute_idf_basis()` at
+  `src/mtg_synergy_graph/universal_scorer.py:702`. Both this function
+  AND the legacy `_compute_idf_weights()` wrapper must change together;
+  the formula switch must happen at basis-build time so cached
+  `IdfBasis` instances reflect the chosen formula. `_idf_weights_from_basis()`
+  (line 709) remains the multiplier-application step and should NOT
+  contain the formula change. Per-commander basis cache is the hot path
+  for both audit and `--explain`; preserve the cache pattern.
+- **BM25 IDF formula:** `log((N - df + 0.5) / (df + 0.5) + 1)` where
+  `N` = total candidate pool size (need to verify universal_scorer has
+  this), `df` = candidate frequency for the (rule_id, cmdr_event,
+  cand_event, filter_group) key (current `N` in the formula).
+- **No switchable config constant.** Scope locks BM25 as a direct
+  formula replacement (see Out of Scope). Reverting is `git revert`
+  on the formula-change commit, not a flag flip.
+- **Audit invocation:** `uv run scripts/bench.py audit` with the
+  500-cmdr fixture. Per-commander breakdown via `--inspect` or similar.
+- **Score-tensor parity:** `bench.py audit --expect-identity` will fail.
+  Re-pin via `--repin --yes` is required if shipping.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| BM25 lifts aggregate but causes 1+ tail-commander regression >0.05 | Per-commander check #1 routes ANY violation to DECLINE. Simple, no hybrid escape. If tail regression turns out to be the dominant failure mode, follow-on brainstorm reconsiders with hybrid/per-rule-fallback design. |
+| BM25 lifts gem-rate but doesn't move NDCG | Symmetric ship bar (gem ≥−0.010 to match NDCG ≥+0.010) means a gem-positive / NDCG-flat result fails the SHIP gate; document as learnings outcome and feed into next brainstorm's direction selection. |
+| BM25 introduces scoring drift in tests | Tests asserting specific IDF values need new expected values. Plan should enumerate affected tests in advance and update them in the same commit as the formula change. |
+| Rule weight overrides calibrated to current IDF become miscalibrated under BM25 | `data/scoring_weights.json` contains **53 `rule_quality_multiplier` entries and 6 `flat_weight_overrides` entries** (verified 2026-05-04). The calibration-confound is real; resolved per Open Q1's three options (a)/(b)/(c). Plan picks one with rationale before evaluating ship bar. |
+| BM25 IDF scale shift breaks staple_bonus / anti-synergy / embedding scale calibration | Under log2: high-df rule (df=2000, N=5000) → IDF ≈ 0.091. Under BM25: → IDF ≈ 0.916 (~10× scale shift). Other scoring components (staple_bonus, anti-synergy, embedding contribution) were calibrated assuming log2 IDF magnitudes. Mitigation: the per-commander regression check (≤0.05 cliff) catches if scale shift causes catastrophic per-commander drops. If aggregate looks fine but the qualitative sanity check (deferred to plan discretion) reveals weird behavior, treat as evidence of scale-shift impact and DECLINE. Building IDF-distribution-histogram tooling preemptively is out of scope. |
+| BM25 IDF yields zero or near-zero for very common rules | The "+1" inside the log keeps BM25 IDF non-negative. Asymptotic-zero behavior for high-df rules is a different shape than log2; tail-commander regression check catches if it bites a real commander. |
+| Re-pin breaks Stage A pre-flight (PR #39 just shipped) | Stage A reads against the 100-cmdr canonical fixture in pre-commit hooks. **Plan MUST re-pin BOTH the 500-cmdr and 100-cmdr fixtures atomically as part of the BM25 ship commit, AND rebuild `walker_outcomes.csv` baseline.** Without rebuilding, the autonomous walker may inherit stale REJECT decisions from the log2-IDF era. Document any Stage A verdict shifts on prior scaffold proposals in the commit message. |
+| Performance regression from BM25's formula | Negligible per-call (one extra arithmetic op); IDF-basis cache pattern unchanged. Sanity-check with `bench.py audit` wall-time. |
+
+## Open Questions for ce-plan
+
+1. **Calibration-confound resolution (NEW, blocking — surfaced by doc-review):**
+   The 53 `rule_quality_multiplier` and 6 `flat_weight_overrides`
+   entries in `data/scoring_weights.json` were tuned against the
+   current IDF basis. The plan must pick ONE of:
+   (a) **Reset multipliers to 1.0** in the v1-vs-BM25 A/B to isolate the
+       IDF effect cleanly. Cleanest comparison; but the BM25 result is
+       not directly shippable as the new production weights.
+   (b) **Keep current multipliers**, accept that BM25 evaluation
+       conflates IDF change + multiplier mismatch. Risk: a positive BM25
+       result could be partial-credit to multiplier rescaling.
+   (c) **Re-run the optimizer under BM25** before the ship/decline call,
+       so the comparison is "current IDF + tuned multipliers" vs "BM25
+       IDF + freshly-tuned multipliers." Most realistic shipping path
+       but doubles compute cost and may exceed session capacity.
+   Recommendation: (c) is the cleanest shipping decision; (a) is the
+   cleanest scientific A/B. The plan should pick one with rationale.
+
+2. **Per-commander reporting format**: The success criteria require
+   per-commander analysis. Plan should specify whether
+   `bench.py audit --inspect` already produces per-commander NDCG@30
+   diffs across the held subset of the 500-cmdr fixture, or whether a new reporting flag is
+   needed. (`--inspect-gems` exists for hidden-gem diffs but not NDCG.)
+
+## References
+
+- Origin doc (saturation diagnosis): `docs/solutions/best-practices/scaffold-queue-generator-exhaustion-2026-04-24.md`
+- Sibling null result (embeddings): `docs/solutions/best-practices/infrastructure-without-scoring-activation-2026-04-24.md`
+- Fixture sizing lesson: `docs/solutions/best-practices/optimizer-fixture-size-2026-04-30.md`
+- Current IDF location: `src/mtg_synergy_graph/universal_scorer.py:319-323`, `:673`, `:709`, `:724`
+- Universal Port Matcher architecture: `CLAUDE.md` (Scoring Architecture section)
+- Memory: `memory/feedback_edhrec_not_goal.md` (NOW EXPLICITLY REVERSED for this brainstorm; see Product Decision section above)
+- Memory: `memory/feedback_audit_every_change.md` (this work IS gated by audit per the standing guardrail)

--- a/docs/plans/2026-05-04-001-feat-bm25-idf-probe-plan.md
+++ b/docs/plans/2026-05-04-001-feat-bm25-idf-probe-plan.md
@@ -1,0 +1,870 @@
+---
+title: BM25 IDF reformulation probe
+type: feat
+status: active
+date: 2026-05-04
+origin: docs/brainstorms/2026-05-04-bm25-idf-requirements.md
+---
+
+# BM25 IDF reformulation probe
+
+## Overview
+
+Replace the per-rule IDF formula in `src/mtg_synergy_graph/universal_scorer.py`
+from `1/log2(1 + N)` to BM25-style saturation IDF
+`log((N − df + 0.5) / (df + 0.5) + 1)`. Re-tune the
+`_RULE_QUALITY_MULTIPLIER` table under the new IDF basis (so the
+comparison is "current IDF + tuned weights" vs "BM25 IDF + freshly-tuned
+weights"). Audit on the 500-cmdr fixture; ship if the bar is met.
+
+This is a **probe**, not a feature: the goal is to learn whether the
+saturation curve change is a real lever, with three possible outcomes
+(SHIP / INVESTIGATE / DECLINE) defined by the origin requirements doc.
+
+## Problem Frame
+
+A 2026-05-04 session exhausted three direct improvement levers for
+NDCG@30 on the 500-cmdr held subset (per-rule weight optimizer,
+embedding contribution flip, walker rule-shipping queue). The
+`docs/solutions/best-practices/scaffold-queue-generator-exhaustion-2026-04-24.md`
+diagnosis identified "orthogonal directions" as the next class of
+moves; the 2026-05-04 brainstorm picked BM25 IDF reformulation as the
+cheapest probe.
+
+If BM25 lifts NDCG@30 above the ship bar, the IDF saturation curve was
+a real lever and weight-tuning has more headroom than the optimizer
+sweeps suggested. If not, the next brainstorm picks from the
+remaining four IDF alternatives or pivots to a higher-effort
+orthogonal direction (anti-synergy rules, port-signature feature
+expansion, commander-target redesign).
+
+(See origin: `docs/brainstorms/2026-05-04-bm25-idf-requirements.md`.)
+
+## Requirements Trace
+
+- R1. Implement BM25 IDF as a direct replacement for `1/log2(1 + N)` in
+  `src/mtg_synergy_graph/universal_scorer.py:702` (`_compute_idf_basis`).
+- R2. Per-commander NDCG@30 reporting infrastructure for the
+  prerequisite gate (any commander loses >0.05 → DECLINE).
+- R3. Audit-gated swap: comparison via `bench.py audit` against the
+  500-cmdr fixture; ship-bar evaluation per origin success criteria.
+- R4. Resolve calibration-confound (origin Q1) — see Key Technical
+  Decisions for the chosen approach.
+- R5. Atomic re-pin of BOTH 500-cmdr AND 100-cmdr fixtures on SHIP
+  outcome.
+- R6. Rebuild `.audit/walker_outcomes.csv` baseline on SHIP (otherwise
+  stale REJECT verdicts inherit from log2-IDF era).
+- R7. Update `memory/feedback_edhrec_not_goal.md` with dated reframe
+  note on SHIP, OR dated "declined" note on DECLINE.
+
+## Scope Boundaries
+
+- **Out of scope: alternative IDF formulations.** Smoothed-frequency,
+  structural-overlap, per-rule-cluster, and rank-aware variants stay
+  deferred per origin Out of Scope. If BM25 declines, those become
+  candidate follow-on brainstorms.
+- **Out of scope: hybrid IDF or per-commander overrides.** Per-commander
+  overrides directly violate the project's "no per-commander or
+  per-archetype rules" anti-goal. If BM25 lifts aggregate but creates
+  tail regressions, the outcome is DECLINE — not hybrid.
+- **Out of scope: per-archetype cohort analysis.** Per origin doc:
+  `data/tags.db` does not contain commander→archetype labels (per
+  `bench/optimize.py:153`). Adding them is its own work item.
+- **Out of scope: BM25 with TF.** This work uses BM25's IDF half only
+  (the project has no TF analog — per-(rule, candidate) firings are
+  binary).
+- **Out of scope: switchable config flag.** Per origin Out of Scope:
+  BM25 is a direct formula replacement; reverting is `git revert` on
+  the formula-change commit, not a flag flip.
+
+### Deferred to Separate Tasks
+
+- **Bootstrap-resample precision check infrastructure:** Origin doc
+  downgraded to seed-vary (no new tooling). If the seed-vary spread
+  reveals the +0.010 ship bar is in noise, a bootstrap module is its
+  own follow-on plan.
+- **IDF distribution histogram tooling:** Origin doc cut as
+  preemptive infrastructure; per-commander gate catches catastrophic
+  scale-shift impact. If the audit reveals subtle scale-shift issues
+  not caught by the per-commander gate, this becomes its own plan.
+- **Per-archetype audit gates:** See Out of Scope above. If BM25
+  declines and the failure mode is systematic per-archetype skew, a
+  follow-on brainstorm should design archetype-aware audit gates.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **`src/mtg_synergy_graph/universal_scorer.py:702`** — current
+  `1.0 / math.log2(1.0 + n)` lives inside `_compute_idf_basis()`.
+  This is the single formula site. The wrapper
+  `_compute_idf_weights()` (line 724) delegates to the basis function
+  and does not need separate changes.
+- **`src/mtg_synergy_graph/universal_scorer.py:693-702`** — `if rule_id
+  in _FLAT_COUNT_RULES:` branch. Flat rules (`etb_self`, `evasion`,
+  `scaling`, `spell_density`, `token_producer`, `tribal_density`)
+  bypass the formula entirely. This branch must remain untouched —
+  flat rules continue to bypass under BM25.
+- **`src/mtg_synergy_graph/universal_scorer.py:701`** — panharmonicon
+  special case `n = max(n, 30)`. A floor on `n` before applying the
+  formula. Preserve under BM25 (semantics: prevents IDF blow-up for
+  rare rules with very low candidate counts).
+- **`src/mtg_synergy_graph/bench/optimize.py:630-666`** — `compute_ndcg`
+  + `per_ndcg dict` patterns. Source for the new per-commander NDCG
+  reporting handler (Unit 1).
+- **`src/mtg_synergy_graph/bench/handlers.py:333`** — existing `--inspect`
+  handler. Pattern to follow for the new `--per-commander-ndcg` flag.
+- **`src/mtg_synergy_graph/bench/handlers.py:122-125`** —
+  `expect-identity` assertion. Will fail by design when BM25 ships;
+  re-pin via `bench.py audit --repin --yes` is required.
+- **`src/mtg_synergy_graph/bench/cli.py:302`** — default fixture is the
+  100-cmdr canonical (`tests/fixtures/golden_set_run.json`). Stage A
+  pre-flight reads against this in pre-commit hooks.
+- **`src/mtg_synergy_graph/bench/optimize.py:1477`** — `_CANONICAL_FIXTURE`
+  references the 100-cmdr canonical.
+- **`scripts/scaffold_rule.py`** — Stage A pre-flight integration
+  (PR #39, just shipped). Reads against the canonical fixture state.
+- **`data/scoring_weights.json`** — 53 `rule_quality_multiplier` + 6
+  `flat_weight_overrides` entries calibrated against the current IDF.
+  Re-tuned under BM25 in Unit 3.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/scaffold-queue-generator-exhaustion-2026-04-24.md` —
+  origin diagnosis that "orthogonal directions" are the next move
+  class.
+- `docs/solutions/best-practices/optimizer-fixture-size-2026-04-30.md` —
+  500-cmdr fixture is the calibration baseline; 100-cmdr is too small
+  for trustworthy gradient signal.
+- `docs/solutions/best-practices/infrastructure-without-scoring-activation-2026-04-24.md` —
+  null-result discipline; BM25 must follow same pattern (document and
+  decline explicitly if it doesn't clear the bar).
+
+### External References
+
+None. BM25 is a canonical IR formula; the brainstorm's workload-fit
+disclosure already addresses the small-vocabulary / no-TF caveats.
+External search would not change the implementation shape.
+
+## Key Technical Decisions
+
+- **Q1 (calibration confound) → option (c) re-tune under BM25.**
+  Cleanest shipping path. The current 53 `rule_quality_multiplier`
+  entries were tuned against `1/log2(1+N)` IDF; under BM25 their
+  effective contributions shift. Re-tuning produces an apples-to-apples
+  comparison ("current IDF + tuned weights" vs "BM25 IDF + tuned
+  weights"). Compute cost is ~5-15 min per optimizer run (per
+  2026-05-04 session evidence — implementer should re-confirm in Unit 3).
+- **Pre-Unit-3 baseline check (NEW per plan-review pass 1):** Before
+  running Unit 3, run the optimizer self-test against the CURRENT
+  (log2) IDF to confirm baseline pass behavior. If it fails on
+  current IDF too, the self-test instability is independent of the
+  IDF formula and Unit 3's fallback chain is just churn — restructure
+  Unit 3 to ship option (a) explicitly upfront with a documented
+  "self-test cannot validate optimizer under either IDF" caveat,
+  rather than pretend (c) is the path.
+- **Q1 fallback (rare path) → SHIP forbidden on fallback.** If
+  optimizer self-test fails under BM25 across 3 alternative
+  `--self-test-seed` values (`7`, `17`, `137`), fall back to option
+  (a) — reset multipliers to 1.0 in `data/scoring_weights.json`. **Under
+  this fallback, Unit 4's SHIP outcome is FORBIDDEN regardless of
+  point estimate.** Permitted outcomes are limited to INVESTIGATE-FOR-RETUNE
+  (a new outcome — see Success Criteria) or DECLINE. This prevents
+  shipping a production scoring config the plan itself flagged as
+  "not directly shippable."
+- **Q2 (per-commander NDCG reporting) → new flag.**
+  `bench.py audit --inspect` does NOT surface per-commander NDCG@30
+  diffs (verified in origin doc-review pass 2 — it's per-(rule,
+  candidate) tensor rows scoped to one rule_id). Build a new
+  `--per-commander-ndcg` flag that lifts the `compute_ndcg + per_ndcg`
+  pattern from `bench/optimize.py:630-666` into a new reporting
+  handler. Output sorted ascending by NDCG delta. The per-commander
+  prerequisite gate (any commander >-0.05 → DECLINE) is unimplementable
+  without this.
+- **Outcome branching.** Five outcomes per Success Criteria below:
+  SHIP, INVESTIGATE, INCONCLUSIVE (precision check failed),
+  INVESTIGATE-FOR-RETUNE (Q1 fallback fired), DECLINE. Outcome
+  handling (Unit 5) executes the appropriate branch based on Unit 4's
+  verdict. The plan scopes all five paths. The base SHIP/INVESTIGATE/DECLINE
+  trio comes from the brainstorm; INCONCLUSIVE and
+  INVESTIGATE-FOR-RETUNE were added in plan-review pass 1 to close
+  identified gaps (precision-routing collision and Q1 fallback escape
+  hatch).
+- **Atomic re-pin requires both fixtures.** The 100-cmdr canonical
+  feeds Stage A pre-flight in pre-commit hooks; if only the 500-cmdr
+  re-pins, Stage A inherits stale verdicts from the log2-IDF era and
+  the autonomous walker may skip proposals that would now PASS.
+  "Atomic" here means: both fixtures re-pinned in the SAME commit
+  (no commit may exist where one fixture is BM25-pinned and the
+  other is log2-pinned). The walker_outcomes.csv "rebuild" is
+  separate operational housekeeping (gitignored, not part of the
+  commit). **Pre-flight verification (NEW per plan-review pass 1):**
+  Implementer must verify experimentally before the SHIP commit that
+  two back-to-back `bench.py audit --repin --yes` invocations are
+  idempotent — run on a scratch branch first, examine working-tree
+  state after each, confirm both fixtures land in their expected
+  states without one's state contaminating the other. If
+  non-idempotent, escalate to extending `bench.py audit --repin` to
+  accept multiple `--fixture` arguments in a single invocation.
+- **Unit 1 is bundled but separable.** Unit 1 (per-commander NDCG
+  reporting) is general-purpose audit infrastructure that survives
+  this plan's outcome. It IS bundled here for sequencing simplicity
+  — the BM25 probe needs it as a prerequisite. But it ships in its
+  own commit (NOT bundled with the BM25 formula commit), and its
+  output schema must be designed for general "compare two scoring
+  configurations on per-commander NDCG" use, not specialized to
+  BM25's needs. If a future audit task needs the same reporting,
+  it should reuse Unit 1's flag without modification.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Q1 (calibration confound):** Resolved → option (c) re-tune
+  optimizer under BM25 (see Key Technical Decisions).
+- **Q2 (per-commander NDCG reporting):** Resolved → new flag required
+  (see Key Technical Decisions).
+
+### Deferred to Implementation
+
+- **Optimizer self-test stability under BM25:** The 2026-05-04 session
+  observed self-test failures on alpha 0.3 and fine-grid optimizer
+  runs (one specific rule —
+  `etbreplacement_other_choosect_tribal` — couldn't be recovered).
+  Whether BM25 changes which rule the self-test selects, and whether
+  the new selection passes, is unknown until Unit 3 runs. Fallback
+  pre-defined (3 alternative `--self-test-seed` values, then option
+  (a) reset).
+- **Whether BM25 produces large per-rule contribution shifts that
+  trip Stage A pre-flight verdicts on prior scaffold proposals:**
+  Unknown until Unit 5 runs. The atomic re-pin + walker_outcomes
+  rebuild handles the consequences, not the prediction.
+- **Final shape of the per-commander NDCG output (CSV vs Markdown vs
+  JSON):** Implementer's call. Match existing audit output
+  conventions (likely Markdown table for human review).
+- **Whether a SHIP outcome warrants any change to `CLAUDE.md`'s
+  scoring documentation.** Likely yes — IDF formula description in
+  the "Algorithm" section would need update. Determine in Unit 5.
+
+## Implementation Units
+
+- [ ] **Unit 1: Per-commander NDCG@30 audit reporting**
+
+**Goal:** Add a `--per-commander-ndcg` flag (or extend `--inspect`)
+that emits per-commander NDCG@30 deltas across the held subset of the
+audited fixture, sorted ascending. Required prerequisite for the
+per-commander gate in Unit 4.
+
+**Requirements:** R2
+
+**Dependencies:** None — can run in parallel with Unit 2.
+
+**Files:**
+- Modify: `src/mtg_synergy_graph/bench/cli.py` (add CLI flag)
+- Modify: `src/mtg_synergy_graph/bench/handlers.py` (new handler)
+- Modify: `scripts/bench.py` (wire flag through)
+- Test: `tests/test_bench_per_commander_ndcg.py` (new)
+
+**Approach:**
+- Reuse `compute_ndcg` (already public in `mtg_synergy_graph.validate`,
+  imported at `bench/optimize.py:49`) and extract the per-commander
+  loop pattern from `_score_split_with_weights()` at
+  `bench/optimize.py:629-666` into a new handler in
+  `bench/handlers.py`. The handler does not need to touch the
+  optimizer's weight-patching context (no `patched_rule_quality_multiplier`)
+  — it just iterates commanders in the held subset, scores each,
+  computes per-commander NDCG vs the pinned reference, and emits the
+  table.
+- Emit per-commander NDCG@30 (current pin vs live scoring) sorted by
+  delta ascending. Format: Markdown table for human review (matches
+  `--inspect` convention).
+- The handler reads pinned fixture + live scoring; doesn't mutate state.
+- Output schema: `commander | pinned_ndcg | live_ndcg | delta` with N
+  rows where N = held-subset size.
+- The flag accepts the standard `--fixture PATH` argument so it can
+  be run against either the 100-cmdr or 500-cmdr fixture.
+
+**Patterns to follow:**
+- `bench/handlers.py:333` — existing `--inspect` handler pattern.
+- `bench/optimize.py:630-666` — `compute_ndcg + per_ndcg` lifting source.
+
+**Test scenarios:**
+- Happy path: 500-cmdr fixture, identity scoring (same as pin) →
+  emits all-zero deltas across N rows.
+- Happy path: synthetic perturbation in scoring → emits non-zero
+  deltas in expected commanders.
+- Edge case: empty held subset (e.g., train_ratio = 1.0) → emits
+  empty table with informative message, not a crash.
+- Edge case: held subset with single commander → emits one row.
+- Integration: invoked via `bench.py audit --per-commander-ndcg
+  --fixture tests/fixtures/golden_set_run_500.json` → produces output
+  consumable by Unit 4's gate evaluation.
+
+**Verification:**
+- `uv run scripts/bench.py audit --per-commander-ndcg --fixture
+  tests/fixtures/golden_set_run_500.json` produces a sorted-ascending
+  Markdown table.
+- New tests pass; full test suite stays green.
+- No change to scoring or audit identity (this is a read-only
+  reporting addition). `bench.py audit --expect-identity` continues
+  to pass.
+
+---
+
+- [ ] **Unit 2: BM25 IDF formula in `_compute_idf_basis`**
+
+**Goal:** Replace the live `1.0 / math.log2(1.0 + n)` with classic BM25
+IDF `log((N − df + 0.5) / (df + 0.5) + 1)`. Update tests asserting
+specific IDF values. Preserve the FLAT_COUNT_RULES bypass and the
+panharmonicon `max(n, 30)` floor.
+
+**Requirements:** R1
+
+**Dependencies:** None — can run in parallel with Unit 1.
+
+**Files:**
+- Modify: `src/mtg_synergy_graph/universal_scorer.py` (formula site
+  at line 702 inside `_compute_idf_basis`)
+- Modify: existing tests asserting specific IDF values (enumerate
+  during execution; likely `tests/test_universal_scorer.py` and
+  similar)
+- Test: `tests/test_universal_scorer_bm25.py` (new) for BM25-specific
+  invariants
+
+**Approach:**
+- Identify `N` for BM25's formula. Current `_compute_idf_basis` uses
+  `n = len(candidates)` per (rule_id, cmdr_event, cand_event,
+  filter_group) key — this is the per-key df, not a corpus-wide N.
+  For BM25 to make semantic sense, **N must be the total candidate
+  pool size for the commander** (cards considered across all rules
+  for that commander), and df remains the per-key match count.
+- **N-source decision (locked):** Use **strict N** = total distinct
+  candidates considered for that commander (sum of distinct
+  candidates across all (rule_id, cmdr_event, cand_event,
+  filter_group) keys for the commander, deduplicated). This requires
+  new plumbing into `_compute_idf_basis` (either pass total N as a
+  parameter, or compute it from the candidates collection in the same
+  scope). The previously-considered "approximate N = max(n_per_key)"
+  is rejected because (a) it produces a per-commander scaling that
+  conflicts with the no-per-commander-rules anti-goal, and (b) it's
+  not BM25 — it's a different formula that happens to share BM25's
+  log structure. A DECLINE outcome under approximate-N would not
+  rule out BM25; it would rule out a different formula. Strict N
+  preserves the probe's epistemic value.
+- Preserve the `if rule_id in _FLAT_COUNT_RULES:` branch entirely —
+  flat rules continue to bypass the formula.
+- Preserve `n = max(n, 30)` panharmonicon floor before applying BM25.
+- Direct replacement; no `_ENABLE_BM25_IDF` flag (per Out of Scope).
+
+**Execution note:** Test-first for the BM25 formula computation.
+Write `tests/test_universal_scorer_bm25.py` with known (df, N) →
+expected IDF pairs FIRST, then implement. The formula is small and
+math-verifiable; test-first catches arithmetic errors immediately.
+
+**Patterns to follow:**
+- `src/mtg_synergy_graph/universal_scorer.py:693-702` — the existing
+  if/else branch structure that protects FLAT_COUNT_RULES.
+
+**Test scenarios:**
+- Happy path: BM25 IDF for (df=10, N=5000) → matches hand-computed
+  value to 6 decimal places.
+- Happy path: BM25 IDF for (df=2000, N=5000) → matches hand-computed
+  value (tests the high-df / low-IDF tail).
+- Edge case: BM25 IDF for (df=1, N=5000) → very large IDF (rare
+  rule).
+- Edge case: BM25 IDF for (df=N, N=5000) → IDF approaches 0 but stays
+  ≥ 0 (validates the +1 inside the log).
+- Edge case: BM25 IDF for (df=0, N=5000) → handle gracefully (likely
+  doesn't occur in practice but protective).
+- Invariant: BM25 IDF is non-negative for all valid (df, N) where
+  0 ≤ df ≤ N.
+- Invariant: FLAT_COUNT_RULES rules bypass — assert that scoring for
+  `etb_self` (or another flat rule) produces identical contribution
+  before and after the formula change.
+- Invariant: Panharmonicon floor preserved — assert `n = max(n, 30)`
+  applies before BM25.
+- Cache discipline: After the formula swap, `IdfBasis` cache keys
+  produce different values than before; existing cached entries from
+  before the swap should not contaminate (verify via fresh
+  `_compute_idf_basis` invocation).
+- Integration: `bench.py audit --expect-identity` against current
+  pin FAILS by design (scores are different); `bench.py audit
+  --repin` regenerates the pinned fixture under BM25 (verify in Unit
+  5, not here — Unit 2 is just the formula).
+
+**Verification:**
+- `tests/test_universal_scorer_bm25.py` passes.
+- Existing IDF-value tests updated to new expected values; full test
+  suite stays green.
+- `bench.py audit --expect-identity` FAILS as expected against
+  current pin (this is the design — re-pin happens in Unit 5).
+- The 6 flat rules show identical contributions pre- and post-change
+  (proves bypass is preserved).
+
+---
+
+- [ ] **Unit 3: Re-tune `_RULE_QUALITY_MULTIPLIER` under BM25
+  (calibration-confound resolution)**
+
+**Goal:** Run `bench.py audit --optimize` with BM25 IDF active to
+re-tune the 53 multipliers in `data/scoring_weights.json`. Capture the
+proposal as the new "BM25-tuned" weight set. Self-test must pass (or
+fallback documented per Q1 fallback).
+
+**Requirements:** R4
+
+**Dependencies:** Unit 2 (BM25 formula must be live).
+
+**Files:**
+- Read: `src/mtg_synergy_graph/bench/optimize.py` (existing optimizer)
+- Modify: `data/scoring_weights.json` (write proposal contents to
+  this file as the new calibration; keep an inline comment
+  documenting "tuned under BM25 IDF on 2026-05-04 via Unit 3")
+- Read: `.audit/optimize_proposal.json` (proposal sink path)
+- Read: `.audit/optimize_history.csv` (audit log)
+
+**Approach:**
+- Run: `uv run scripts/bench.py audit --optimize` against the 500-cmdr
+  fixture. Defaults are correct: alpha=0.5, default grid, default
+  seed=42.
+- Inspect `.audit/optimize_proposal.json`. If self-test passed and
+  the proposal looks reasonable (no clamp_max=5.0 runaways, sensible
+  per-rule_quality_multiplier diffs), accept by writing the new
+  multipliers into `data/scoring_weights.json`.
+- If self-test fails: try `--self-test-seed 7`, then `--self-test-seed
+  17`, then `--self-test-seed 137`. If any pass, accept that
+  proposal.
+- If all 3 self-test attempts fail: fall back to Q1 option (a) —
+  reset all 53 multipliers to 1.0 in `data/scoring_weights.json`.
+  Document in commit message that calibration-confound resolution
+  fell back from option (c) to option (a) due to optimizer self-test
+  instability under BM25, and the comparison in Unit 4 should be
+  treated as scientific-only (not directly shippable; SHIP outcome
+  routes to a follow-on optimizer-tuning task).
+- This unit modifies `data/scoring_weights.json` even though Out of
+  Scope normally excludes it — origin doc explicitly allows
+  modifications "to the extent that resolving the calibration-confound
+  (Q1) requires touching them."
+
+**Patterns to follow:**
+- `bench/optimize.py` existing optimizer invocation; CLI documented in
+  `CLAUDE.md`.
+
+**Test scenarios:**
+- Test expectation: none — this unit is one-shot data generation
+  (running the optimizer to produce a calibration). The optimizer
+  itself has its own test suite. The output is reviewed manually; no
+  new automated test is appropriate.
+- Self-test pass/fail is verified by the optimizer itself; the unit's
+  job is to invoke it and act on the outcome.
+
+**Verification:**
+- `data/scoring_weights.json` updated with new BM25-tuned multipliers
+  (or reset to 1.0 if fallback fired).
+- `.audit/optimize_history.csv` shows the run with passing self-test
+  (or 3 failed seed attempts + fallback).
+- Commit message clearly documents which path was taken.
+- Full test suite passes after `data/scoring_weights.json` update.
+
+---
+
+- [ ] **Unit 4: Audit + evaluate against success criteria**
+
+**Goal:** Run `bench.py audit --fixture tests/fixtures/golden_set_run_500.json`
+under BM25 IDF + new multipliers (or reset multipliers if fallback
+fired). Capture per-commander NDCG diff (via Unit 1 reporting) and
+aggregate metrics. Apply success criteria gates. Produce verdict:
+SHIP / INVESTIGATE / DECLINE.
+
+**Requirements:** R3
+
+**Dependencies:** Units 1, 2, 3.
+
+**Files:**
+- Read: `tests/fixtures/golden_set_run_500.json` (audit fixture)
+- Read: existing pinned fixture state (current pin)
+- Write: `.audit/last.md` (audit output)
+- Write: working notes documenting the verdict
+
+**Approach:**
+- Step 1: Seed-vary precision check. Run audit under 3 train/held
+  split seeds (17, 42, 137). Report mean NDCG@30 delta and spread
+  (max - min across seeds).
+- Step 2: Run `bench.py audit --per-commander-ndcg --fixture
+  tests/fixtures/golden_set_run_500.json` (Unit 1 flag). Inspect the
+  worst-regressing commanders.
+- Step 3: Apply outcome-routing checks in this order. The first
+  matching condition determines the outcome.
+  - **Q1-fallback gate:** If Unit 3 fell back to option (a)
+    (multipliers reset to 1.0), permitted outcomes are limited to
+    **INVESTIGATE-FOR-RETUNE** (if numerics would otherwise route to
+    SHIP) or **DECLINE** (if numerics route to DECLINE). SHIP is
+    forbidden under fallback regardless of numerics.
+  - **Per-commander prerequisite:** If ANY commander in the held
+    subset shows NDCG@30 delta < -0.05 → **DECLINE**. Stop.
+  - **Precision-inconclusive guard:** If seed-vary spread (Step 1)
+    exceeds 0.010 → **INCONCLUSIVE**. Document the spread and
+    point-estimate; do not revert; do not ship. Defer to a follow-on
+    plan that gathers more seeds.
+  - **Aggregate SHIP:** If NDCG@30 delta ≥ +0.010 AND
+    hidden_gem_hit_rate delta ≥ -0.010 → **SHIP**.
+  - **Aggregate INVESTIGATE:** If NDCG@30 delta in [+0.005, +0.010)
+    AND gem within bound → **INVESTIGATE**.
+  - **Aggregate DECLINE:** Else → **DECLINE**.
+- Step 4: Document the verdict (which gate fired, exact deltas,
+  worst-regressing commander, seed-spread) in working notes for use
+  by Unit 5.
+
+**Patterns to follow:**
+- `CLAUDE.md` Common Commands section — `bench.py audit` invocation
+  patterns.
+
+**Test scenarios:**
+- Test expectation: none — this unit is one-shot evaluation. The
+  audit itself has its own test suite. The verdict is a manual
+  decision based on the output; no new automated test is appropriate.
+
+**Verification:**
+- Audit runs cleanly under BM25 IDF + new multipliers, producing
+  `.audit/last.md`.
+- 3-seed precision spread documented.
+- Per-commander NDCG diff captured and inspected.
+- Verdict explicitly recorded (one of SHIP / INVESTIGATE / DECLINE)
+  with exact numerical justification.
+
+---
+
+- [ ] **Unit 5: Outcome handling (conditional on Unit 4 verdict)**
+
+**Goal:** Execute one of five branches per Unit 4 verdict: SHIP,
+INVESTIGATE, INCONCLUSIVE, INVESTIGATE-FOR-RETUNE, or DECLINE. Each
+branch leaves the repo and institutional record in a coherent state.
+
+**Pre-Unit-2 baseline tag (NEW per plan-review pass 1):** Before
+starting any code changes in Unit 2, create a git tag
+`pre-bm25-baseline` on the current HEAD. The DECLINE and
+INVESTIGATE branches reset to this tag rather than relying on
+`git revert` (which can produce conflicts if intervening commits
+touched the same files). This is a 5-second prerequisite that makes
+the DECLINE/INVESTIGATE paths reliable.
+
+**Requirements:** R5, R6, R7
+
+**Dependencies:** Unit 4 verdict.
+
+**Files (SHIP branch):**
+- Modify: `tests/fixtures/golden_set_run_500.json` (re-pin via
+  `bench.py audit --repin --yes --fixture
+  tests/fixtures/golden_set_run_500.json`)
+- Modify: `tests/fixtures/golden_set_run.json` (re-pin via
+  `bench.py audit --repin --yes` — uses default 100-cmdr fixture)
+- Modify: `.audit/walker_outcomes.csv` (rebuild — likely just delete
+  and let it regenerate on next walker run, or add column noting
+  IDF-formula-version transition)
+- Modify: `docs/RULE_HISTORY.md` (single entry documenting BM25 IDF
+  swap, date, audit deltas, multiplier-tuning approach)
+- Modify: `memory/feedback_edhrec_not_goal.md` (dated reframe note
+  per origin Product Decision section)
+- Modify: `CLAUDE.md` (update Algorithm section IDF formula
+  description if the new formula is named in CLAUDE.md)
+
+**Files (DECLINE branch):**
+- Revert: `data/scoring_weights.json` (restore pre-Unit-3 state via
+  git revert of Unit 3 commit, OR reset multipliers if Unit 3 used
+  fallback)
+- Revert: `src/mtg_synergy_graph/universal_scorer.py` (revert Unit 2
+  formula change)
+- Revert: any test changes from Unit 2 that asserted BM25-specific
+  values
+- Modify: `memory/feedback_edhrec_not_goal.md` (dated "declined" note
+  per origin Product Decision section)
+- Create: `docs/solutions/best-practices/bm25-idf-null-result-2026-05-04.md`
+  (null-result writeup following
+  `infrastructure-without-scoring-activation-2026-04-24.md`
+  template; document the precise deltas, the fallback path if any,
+  and what's NOT ruled out — the four other IDF alternatives)
+
+**Files (INVESTIGATE branch):**
+- Same as DECLINE for code reverts. **Pinned fixture stays UNCHANGED**
+  — current pin remains current; BM25 numbers do NOT become the
+  new baseline. (Per origin doc: the +0.005 lift is NOT pre-paid
+  progress for the next IDF-variant attempt.)
+- Create: `docs/solutions/best-practices/bm25-idf-marginal-result-2026-05-04.md`
+  (similar to null-result, but explicitly noting the +0.005 to
+  +0.010 zone and the recommendation to attempt a different IDF
+  variant in a new brainstorm — explicitly noting that the +0.005
+  lift is NOT pre-paid progress for that next attempt)
+- Modify: `memory/feedback_edhrec_not_goal.md` (dated "investigated,
+  did not ship" note, scoped textually to BM25 work only)
+
+**Files (INCONCLUSIVE branch — NEW):**
+- Same as INVESTIGATE for code reverts (formula reverts; pinned
+  fixture stays unchanged).
+- Create: `docs/solutions/best-practices/bm25-idf-inconclusive-2026-05-04.md`
+  (documents seed-spread > 0.010, point-estimate, and what would be
+  needed to disambiguate — likely "a follow-on plan that runs more
+  seeds OR scales the fixture beyond 500-cmdr").
+- Modify: `memory/feedback_edhrec_not_goal.md` (dated "inconclusive
+  precision; did not ship" note, scoped to BM25 work only).
+
+**Files (INVESTIGATE-FOR-RETUNE branch — NEW):**
+- Same as INVESTIGATE for code reverts.
+- Create: `docs/solutions/best-practices/bm25-idf-fallback-retune-needed-2026-05-04.md`
+  (documents that Q1 fallback fired, multipliers were reset to 1.0,
+  numerics would have routed to SHIP, but production calibration
+  cannot ship under reset multipliers; recommends a follow-on
+  optimizer-tuning plan that re-tunes weights under BM25 IDF before
+  shipping).
+- Modify: `memory/feedback_edhrec_not_goal.md` (dated "fallback
+  fired; needs follow-on retune" note, scoped to BM25 work only).
+
+**Approach:**
+
+**SHIP branch (~20 min):**
+0. **Atomic re-pin verification (NEW per plan-review pass 1):** On a
+   scratch branch (e.g., `tmp/bm25-repin-test`), run two back-to-back
+   `bench.py audit --repin --yes` invocations (one per fixture).
+   Inspect working-tree state after each. Confirm both fixtures land
+   in their expected states without one's state contaminating the
+   other (verify by re-running on a fresh clone). If non-idempotent,
+   STOP — extend `bench.py audit --repin` to accept multiple
+   `--fixture` arguments before continuing. Discard the scratch branch.
+1. Stage A pre-flight verdict shift survey: before re-pinning the
+   100-cmdr fixture, run `gap_report.py` and capture the current
+   PASS/WARN/REJECT distribution.
+2. Re-pin the 500-cmdr fixture: `uv run scripts/bench.py audit --repin
+   --yes --fixture tests/fixtures/golden_set_run_500.json`.
+3. Re-pin the 100-cmdr fixture: `uv run scripts/bench.py audit --repin
+   --yes` (uses default fixture).
+4. Re-run `gap_report.py`; document any PASS/WARN/REJECT verdict
+   shifts in the commit message. (Heuristic: if >10% of prior PASS
+   verdicts flip, flag in the commit message and consider follow-on
+   Stage A re-evaluation as a separate task.)
+5. Update `memory/feedback_edhrec_not_goal.md`: prepend or append a
+   dated note acknowledging the metric reframe **scoped to BM25 work
+   only**. Suggested text: "2026-05-04: BM25 IDF reformulation work
+   shipped. **For BM25-IDF-related decisions only**, NDCG@30 was
+   treated as primary metric and gem-rate non-regression was
+   symmetric at -0.010. This scoped reframe does NOT extend to other
+   scoring-axis decisions; future orthogonal-direction brainstorms
+   must re-justify the primary metric independently. Prior framing
+   ('EDHREC is sanity check only; goal is finding hidden gems from
+   mechanics') remains the project-wide default."
+6. Update `docs/RULE_HISTORY.md`: single entry documenting the
+   change.
+7. Update `CLAUDE.md` Algorithm section if the IDF formula is
+   described there.
+8. Commit: single conventional commit message: `feat(scoring): BM25
+   IDF reformulation (probe shipped)`. The atomic re-pin is the both
+   fixtures landing in this single commit.
+9. **Operational housekeeping (separate from the commit):** Delete
+   `.audit/walker_outcomes.csv` (gitignored, append-only; will
+   regenerate on next walker run). Document in commit message that
+   the historical baseline was rebuilt due to IDF transition; prior
+   walker REJECT verdicts may not apply to BM25-era proposals.
+
+**DECLINE branch (~10 min):**
+1. Reset to `pre-bm25-baseline` tag (created in Unit 5 prerequisite):
+   `git reset --hard pre-bm25-baseline` (on a feature branch only —
+   never on main). This cleanly reverts Units 2-4 changes including
+   formula, weights, and tests in one step. No conflict resolution
+   needed.
+2. **Preserve Unit 1**: Cherry-pick or rebase Unit 1's commit on top
+   of `pre-bm25-baseline`. Unit 1 (per-commander NDCG reporting) is
+   general-purpose audit infrastructure that survives the BM25
+   decline.
+3. Run full test suite to verify the resulting state is clean.
+4. Run `bench.py audit --expect-identity` to verify production scoring
+   matches pre-change state.
+5. Append dated note to `memory/feedback_edhrec_not_goal.md`:
+   "2026-05-04: BM25 IDF reformulation brainstorm proposed reversing
+   this framing **for BM25-related work only**; the work declined
+   due to [exact reason from Unit 4 verdict]; project-wide framing
+   remains unchanged (gem-rate-primary)."
+6. Write `docs/solutions/best-practices/bm25-idf-null-result-2026-05-04.md`
+   following the `infrastructure-without-scoring-activation-2026-04-24.md`
+   template. (Optional: if the only takeaway is "BM25 didn't move
+   the needle," the memory note + commit message may be sufficient
+   institutional record. Implementer judgment.)
+7. Commit: `docs(scoring): BM25 IDF probe declined — null result`.
+
+**INVESTIGATE branch (~10 min):**
+1. Reset to `pre-bm25-baseline` tag (same as DECLINE step 1).
+2. Cherry-pick Unit 1 (same as DECLINE step 2).
+3. Run full test suite + `bench.py audit --expect-identity` (same as
+   DECLINE).
+4. Append dated note to `memory/feedback_edhrec_not_goal.md`:
+   "2026-05-04: BM25 IDF reformulation showed marginal result
+   (+0.005 to +0.010 NDCG@30) below ship bar **for BM25-related
+   work only**; investigated, did not ship; pinned fixture
+   unchanged so the +0.005 lift does NOT carry forward as pre-paid
+   progress for the next IDF-variant attempt."
+5. Write `docs/solutions/best-practices/bm25-idf-marginal-result-2026-05-04.md`
+   noting precise deltas and recommending the next IDF variant for a
+   fresh brainstorm.
+6. Commit: `docs(scoring): BM25 IDF probe — marginal, not shipped`.
+
+**INCONCLUSIVE branch (~10 min, NEW per plan-review pass 1):**
+Fires when seed-vary precision check (Unit 4 step 1) returns spread
+> 0.010 — result is too noisy to interpret regardless of point estimate.
+1. Reset to `pre-bm25-baseline` tag (same as DECLINE step 1).
+2. Cherry-pick Unit 1 (same as DECLINE step 2).
+3. Run full test suite + `bench.py audit --expect-identity`.
+4. Append dated note to `memory/feedback_edhrec_not_goal.md`:
+   "2026-05-04: BM25 IDF reformulation produced inconclusive result
+   (seed-spread > 0.010, point estimate [exact value]); precision
+   too low to disambiguate; pinned fixture unchanged. **For BM25
+   work only**, did not ship pending follow-on plan with more seeds
+   or larger fixture."
+5. Write `docs/solutions/best-practices/bm25-idf-inconclusive-2026-05-04.md`
+   documenting the seed-spread, point-estimate, and what would be
+   needed to disambiguate (e.g., "a follow-on plan that runs 10+
+   seeds or scales the fixture to 1000-cmdr").
+6. Commit: `docs(scoring): BM25 IDF probe — inconclusive, not shipped`.
+
+**INVESTIGATE-FOR-RETUNE branch (~10 min, NEW per plan-review pass 1):**
+Fires when Q1 fallback fired (Unit 3 reset multipliers to 1.0) AND
+Unit 4 numerics would otherwise route to SHIP. Production scoring
+cannot ship under reset multipliers; explicit "needs follow-on
+retune" outcome instead of silent SHIP-with-bad-config.
+1. Reset to `pre-bm25-baseline` tag (same as DECLINE step 1).
+2. Cherry-pick Unit 1 (same as DECLINE step 2).
+3. Run full test suite + `bench.py audit --expect-identity`.
+4. Append dated note to `memory/feedback_edhrec_not_goal.md`:
+   "2026-05-04: BM25 IDF reformulation showed promising numerics
+   (+[exact NDCG] / [exact gem]) but optimizer self-test failed
+   under BM25 (multipliers were reset to 1.0 as fallback); cannot
+   ship untuned weights as production scoring. **For BM25 work
+   only**, did not ship pending follow-on optimizer-tuning plan."
+5. Write `docs/solutions/best-practices/bm25-idf-fallback-retune-needed-2026-05-04.md`
+   documenting that Q1 fallback fired, the numerics that would have
+   routed to SHIP, and the recommended follow-on plan
+   ("optimizer-tuning under BM25 IDF, then re-evaluate ship gate").
+6. Commit: `docs(scoring): BM25 IDF probe — fallback fired, retune
+   needed`.
+
+**Patterns to follow:**
+- `docs/solutions/best-practices/infrastructure-without-scoring-activation-2026-04-24.md` —
+  null-result writeup template.
+- `CLAUDE.md` Common Commands — re-pin invocation.
+
+**Test scenarios:**
+- Test expectation: none — this unit is one-shot operational work.
+  Verification is by audit identity check (DECLINE/INVESTIGATE
+  branches) or successful re-pin (SHIP branch).
+
+**Verification:**
+- SHIP: `bench.py audit --expect-identity` passes against the
+  newly-pinned fixtures; `tests/` passes; commit lands cleanly.
+  `gap_report.py` runs and any Stage A verdict shifts are documented
+  in commit message. Atomic re-pin verification (Step 0) completed
+  on scratch branch.
+- DECLINE: `bench.py audit --expect-identity` passes against the
+  unchanged pre-existing pin (post-reset to `pre-bm25-baseline`);
+  `tests/` passes; Unit 1 cherry-picked and committed; null-result
+  doc written (or memory note + commit message judged sufficient);
+  memory updated with scoped reframe note.
+- INVESTIGATE: same as DECLINE plus marginal-result doc written;
+  memory updated; pinned fixture confirmed unchanged.
+- INCONCLUSIVE: same as INVESTIGATE plus inconclusive doc documents
+  seed-spread + disambiguation requirements.
+- INVESTIGATE-FOR-RETUNE: same as INVESTIGATE plus fallback-retune
+  doc documents the numerics that would have routed to SHIP and the
+  follow-on optimizer-tuning task needed.
+
+**Across all branches:** `pre-bm25-baseline` git tag must exist
+(created in Unit 5 prerequisite). Unit 1 commits separately from
+Unit 2 (per "Unit 1 is bundled but separable" in Key Technical
+Decisions).
+
+## System-Wide Impact
+
+- **Interaction graph:** BM25 IDF change touches every scoring path
+  that flows through `_compute_idf_basis`. That includes
+  `score_all_universal`, `engine.SynergyEngine.page`, the audit
+  harness, the optimizer, the embedding-contribution path (when
+  flag-on, currently off), and the `--explain` renderer. None of
+  these are mutated by Units 1-2 individually; the formula change
+  propagates through them. Unit 3's optimizer re-tune is what
+  exercises the propagation.
+- **Error propagation:** No new error paths. BM25 formula is total
+  (defined for all valid (df, N)). Self-test failure in Unit 3 is
+  handled by fallback to option (a). Audit identity failure post-pin
+  in Unit 5 SHIP branch indicates a re-pin bug, not a feature failure;
+  block the commit.
+- **State lifecycle risks:** `_RULE_QUALITY_MULTIPLIER` calibration
+  is the central state risk. Unit 3's re-tune (or fallback reset)
+  produces a new calibration set; if the optimizer self-test fails
+  silently or produces a runaway proposal (clamp_max=5.0 cells), Unit
+  3's "looks reasonable" gate must catch it before writing to
+  `scoring_weights.json`. Walker_outcomes.csv rebuild risks losing
+  historical preflight data; mitigated by gitignored append-only
+  semantics — re-builds naturally on next walker run.
+- **API surface parity:** No changes to `engine.SynergyEngine.page`
+  contract. No changes to CLI surfaces other than the new
+  `--per-commander-ndcg` flag. No changes to embedding contribution,
+  Stage A pre-flight, or recommend.py user-facing surfaces.
+- **Integration coverage:** Unit 4's audit is the integration test —
+  it exercises the full scoring path under BM25 + new multipliers
+  against the 500-cmdr fixture. Cross-layer scenarios (formula
+  change + multiplier re-tune + per-commander reporting) are all
+  exercised together.
+- **Unchanged invariants:**
+  - Anti-Goals: deterministic, no EDHREC at inference, rule-based,
+    Forge DSL based, no learned weights at inference. BM25 IDF
+    preserves all of these.
+  - Stage A pre-flight (PR #39) library shape: pure functions,
+    severity tiers, `walker_outcomes.csv` schema. Stage A code
+    unchanged; only its baseline shifts (handled by atomic re-pin).
+  - `bench.py audit --expect-identity` semantics unchanged; the gate
+    correctly detects the BM25 swap as a score-drift event and
+    requires re-pin.
+  - `complement_rules/` rule logic unchanged. The 62-rule catalogue
+    fires the same on the same inputs; only the IDF weight on each
+    firing changes.
+  - `port_graph/` substrate unchanged. Declarative rules in
+    `data/rules_seed.json` continue to work identically.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Optimizer self-test fails under BM25 across all 3 alternative seeds | Pre-defined fallback to Q1 option (a) (reset multipliers to 1.0). Comparison becomes scientific-only; SHIP outcome routes to a follow-on optimizer-tuning task rather than direct ship. Documented in Unit 3. |
+| BM25 lifts aggregate but causes a single tail-commander regression >0.05 | Per-commander prerequisite (Unit 4) routes to DECLINE. Simple, no hybrid escape per origin doc. If tail regression turns out to be the dominant failure mode, follow-on brainstorm reconsiders. |
+| Re-pinning the 100-cmdr fixture shifts Stage A verdicts unpredictably | Unit 5 SHIP branch survey: capture pre-/post-pin gap_report distribution; document shifts in commit message. Walker_outcomes.csv rebuild prevents stale REJECT inheritance. |
+| BM25 N-source: strict N requires new plumbing into `_compute_idf_basis` | Locked to strict N (see Unit 2 Approach). Implementer adds the plumbing — pass total candidate count or compute it from candidates collection in scope. Approximate-N option rejected (different formula; conflicts with no-per-commander-rules anti-goal). |
+| Test coverage drift: existing tests assert specific IDF values | Unit 2 enumerates affected tests in advance; updates them in the same commit as the formula change. Test expectations must move atomically with the formula change. |
+| Atomic re-pin lands inconsistently (e.g., 500 re-pinned but commit fails before 100 re-pin) | Single commit with both fixtures + walker_outcomes rebuild + memory update. If anything fails mid-flow, revert the partial state via git. |
+| BM25 IDF scale shift breaks staple_bonus / anti-synergy / embedding scale calibration | Per-commander gate (>-0.05 → DECLINE) catches catastrophic per-commander impact. Subtle systematic skew not caught by per-commander bound is documented as a deferred risk; future audit gate work could add per-archetype cohort analysis if warranted. |
+| Performance regression from BM25's slightly more expensive formula | Negligible per-call (one extra arithmetic op). IDF-basis cache pattern unchanged. Sanity-check with `bench.py audit` wall-time in Unit 4. |
+
+## Documentation / Operational Notes
+
+- `docs/RULE_HISTORY.md` gets a single entry on SHIP outcome.
+- `CLAUDE.md` Algorithm section may need update on SHIP outcome
+  (verify in Unit 5).
+- `docs/solutions/best-practices/` gets a new entry on DECLINE or
+  INVESTIGATE outcome (template:
+  `infrastructure-without-scoring-activation-2026-04-24.md`).
+- `memory/feedback_edhrec_not_goal.md` gets a dated note on EVERY
+  outcome (SHIP, INVESTIGATE, or DECLINE) — this is mandatory per
+  origin doc Product Decision section.
+- No external-facing documentation changes (no public API change).
+- No rollout plan needed — this is an audit-gated formula swap; the
+  re-pin IS the rollout.
+- Pre-commit hooks remain on the 100-cmdr canonical fixture; SHIP
+  outcome's atomic re-pin keeps them aligned.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-04-bm25-idf-requirements.md](../brainstorms/2026-05-04-bm25-idf-requirements.md)
+- **Saturation diagnosis:** `docs/solutions/best-practices/scaffold-queue-generator-exhaustion-2026-04-24.md`
+- **Embedding null result (template for our DECLINE/INVESTIGATE writeup):** `docs/solutions/best-practices/infrastructure-without-scoring-activation-2026-04-24.md`
+- **Fixture sizing rationale:** `docs/solutions/best-practices/optimizer-fixture-size-2026-04-30.md`
+- **PR #39 (Stage A pre-flight, just shipped):** affects re-pin atomicity in Unit 5 SHIP branch
+- **Current IDF formula:** `src/mtg_synergy_graph/universal_scorer.py:702` (`_compute_idf_basis`)
+- **Optimizer + per_ndcg pattern source:** `src/mtg_synergy_graph/bench/optimize.py:630-666`
+- **Audit handlers + --inspect pattern:** `src/mtg_synergy_graph/bench/handlers.py:333`
+- **expect-identity gate semantics:** `src/mtg_synergy_graph/bench/handlers.py:122-125`
+- **Project memory (NDCG-not-goal context):** `memory/feedback_edhrec_not_goal.md`
+- **Project architecture overview:** `CLAUDE.md` Scoring Architecture section

--- a/docs/solutions/best-practices/bm25-idf-null-result-2026-05-04.md
+++ b/docs/solutions/best-practices/bm25-idf-null-result-2026-05-04.md
@@ -1,0 +1,218 @@
+---
+last_updated: 2026-05-04
+module: scoring
+title: BM25 IDF probe declined — per-commander cliff fired (null result)
+tags:
+  - scoring
+  - idf
+  - null-result
+  - audit-gate
+  - bm25
+  - plan-2026-05-04-001
+problem_type: best_practice
+resolution_type: reference
+applies_when:
+  - Considering BM25-style IDF as a replacement for the current 1/log2(1+N) formula
+  - Looking at "orthogonal directions to lift the recommendation model" and tempted to re-try BM25
+  - Designing a future IDF-axis probe (the IDF axis is NOT exhausted; only BM25-style is)
+created: 2026-05-04
+plan_ref: docs/plans/2026-05-04-001-feat-bm25-idf-probe-plan.md
+brainstorm_ref: docs/brainstorms/2026-05-04-bm25-idf-requirements.md
+---
+
+# BM25 IDF probe declined — per-commander cliff fired
+
+The BM25 IDF probe (plan `docs/plans/2026-05-04-001-feat-bm25-idf-probe-plan.md`)
+shipped Unit 1 (per-commander NDCG@30 reporting infrastructure) but
+declined the formula change at Unit 4. The per-commander prerequisite
+gate fired catastrophically: 65 of 500 commanders regressed beyond the
+0.05 NDCG@30 threshold, with the worst at −0.5283 (Ghoulcaller Gisa).
+
+This note captures the result so future engineers reaching for BM25 as
+an "orthogonal direction" can read first and either re-evaluate or
+pick a different IDF variant.
+
+## Context
+
+Plan `docs/plans/2026-05-04-001-feat-bm25-idf-probe-plan.md` was the
+first orthogonal-direction probe after a 2026-05-04 session exhausted
+three direct improvement levers (per-rule weight optimizer, embedding
+contribution flip, walker rule-shipping queue). BM25 was chosen as
+the cheapest probe of the IDF axis, with NDCG@30 explicitly elevated
+to primary metric (a scoped reframe of
+`memory/feedback_edhrec_not_goal.md`).
+
+Five outcomes were pre-committed: SHIP / INVESTIGATE / INCONCLUSIVE /
+INVESTIGATE-FOR-RETUNE / DECLINE.
+
+## Result
+
+Outcome: **DECLINE**.
+
+| Metric | Pinned (log2 IDF + tuned weights) | Live (BM25 IDF + freshly-tuned weights) | Δ |
+|---|---|---|---|
+| Aggregate NDCG@30 (500-cmdr) | 0.094208 | 0.087245 | **−0.006963** |
+| hidden_gem_hit_rate (500-cmdr) | 0.7128 | 0.7535 | **+0.0407** |
+| Per-commander violations (delta < −0.05) | — | **65 of 500** | — |
+| Worst per-commander regression | — | Ghoulcaller Gisa **−0.5283** | — |
+| Aggregate score Δ (sum of contributions) | — | +187,961 | — |
+| Histogram (rank_shuffle_across_top30) | — | **332 of 500** | — |
+
+**The per-commander prerequisite gate fired.** Per the plan's hard
+gate #1 in Success Criteria: ANY commander losing more than 0.05
+NDCG@30 → DECLINE. We had 65.
+
+The aggregate also fails the SHIP gate independently (NDCG delta is
+negative; SHIP requires ≥+0.010).
+
+## Per-commander failure pattern
+
+The 65 violations cluster around two archetypes:
+
+- **Tribal commanders** with very high pinned NDCG: Edgar Markov
+  (−0.298), Krenko, Mob Boss (−0.218), Lathril (−0.327), Hakbal of
+  the Surging Soul (−0.218), Ezuri, Renegade Leader (−0.163).
+- **Graveyard / aristocrats**: Ghoulcaller Gisa (−0.528, worst),
+  Gisa, the Hellraiser (−0.450), Wilhelt (−0.298), Tegwyll (−0.294),
+  Tormod (−0.377), Kess (−0.356), Yuriko (−0.146).
+
+Best gains are scattered across less-supported commanders: Sakashima
+the Impostor (+0.344), Trostani, Selesnya's Voice (+0.285), The
+Necrobloom (+0.215). The pattern: BM25's flatter saturation curve
+hurts commanders whose top-30 was carried by a few high-IDF rare
+rules (tribal/graveyard density) and helps commanders whose top-30
+was undifferentiated under the steeper log2 curve.
+
+## What's interesting
+
+**hidden_gem_hit_rate INCREASED by +0.0407** — well above the SHIP
+gate's −0.010 floor. Under a hidden-gem-primary framing
+(consistent with `memory/feedback_edhrec_not_goal.md`'s prior
+position), this would be a SHIP-worthy result. BM25 is finding more
+mechanically-plausible cards EDHREC's top-30 doesn't list, even as
+NDCG@30 (EDHREC similarity) regresses.
+
+The BM25 IDF probe was framed as NDCG-primary per the brainstorm's
+explicit owner reframe (scoped to BM25 work only). The DECLINE
+verdict honors that framing. **A future hidden-gem-primary probe
+might want to revisit BM25 with different success criteria.**
+
+## What this rules out
+
+This DECLINE specifically rejects:
+- BM25 IDF formula `log((N − df + 0.5) / (df + 0.5) + 1)` with strict
+  N (total distinct candidates per commander) and df (per-key match
+  count)
+- For an NDCG@30-primary success target on the 500-cmdr fixture
+- With audit-gated multipliers re-tuned by the optimizer (seed 17)
+
+This DECLINE does **NOT** rule out:
+- Other IDF formulations (smoothed-frequency, structural-overlap,
+  per-rule-cluster, rank-aware) — the plan's deferred siblings
+- BM25 IDF itself under hidden-gem-primary framing — the +0.0407 gem
+  lift suggests a re-probe with different success criteria could
+  ship
+- Other orthogonal directions (richer commander-target composition
+  for embeddings, port-signature feature expansion, anti-synergy
+  rules, multi-card combo scoring)
+
+## Why per-commander cliff fires under BM25
+
+The current `1/log2(1+n)` IDF gives very rare rules (n=1, 2, 3) IDF
+values around 1.0, 0.63, 0.5. BM25's saturation curve at strict
+N=500 (typical for the 500-cmdr fixture) gives n=1 → IDF ≈ 5.5,
+n=2 → IDF ≈ 4.8, n=3 → IDF ≈ 4.4. So **BM25 increases the absolute
+scale of rare-rule IDF by ~5×** while leaving common-rule IDF
+roughly comparable to log2.
+
+Per-commander effect: commanders whose top-30 was carried by a
+narrow tribal-density rule (n=1-3 specific Goblins / Zombies that
+matched the lord-style payoff) saw those rules' contributions surge
+by ~5× under BM25. That moved different cards into the top-30
+positions. Some of those new cards happen to NOT be in EDHREC's
+top-30 (driving the hidden-gem improvement) and ALSO not relevant
+to the commander's actual mechanical synergy axis (driving the
+per-commander NDCG cliff).
+
+The optimizer's re-tuning (5 multipliers changed) didn't compensate
+because the multipliers are per-RULE, not per-commander. The cliff
+is structural to BM25 + this rule library + this fixture
+composition.
+
+## Reproduce
+
+```bash
+# 1. Apply the formula change (Unit 2 of the plan).
+# Edit src/mtg_synergy_graph/universal_scorer.py:702:
+#   bm25_idf = math.log(((total_n - df + 0.5) / (df + 0.5)) + 1.0)
+#   base_idf_non_flat[key] = bm25_idf * cond_mult
+# (Replace 1.0 / math.log2(1.0 + n) and add total_n computation upstream
+# in _compute_idf_basis. See plan Unit 2 for details.)
+
+# 2. Re-tune multipliers under BM25 (Unit 3).
+uv run scripts/bench.py audit --optimize --self-test-seed 17
+
+# 3. Apply the proposal to data/scoring_weights.json.
+# Manual edit of the 5 rule multipliers per the proposal JSON.
+
+# 4. Audit on 500-cmdr fixture.
+uv run scripts/bench.py audit --fixture tests/fixtures/golden_set_run_500.json
+uv run scripts/bench.py audit --per-commander-ndcg --fixture tests/fixtures/golden_set_run_500.json
+
+# 5. Compare against the success criteria in the plan.
+```
+
+Expected outcome from these steps as of 2026-05-04:
+- NDCG@30 aggregate delta ≈ −0.007 (negative)
+- hidden_gem_hit_rate delta ≈ +0.04 (positive)
+- ~65 commanders exceed the −0.05 per-commander cliff
+- Per the plan's gate, this routes to DECLINE
+
+## Next-step options for IDF-axis exploration
+
+If a future probe wants to keep working on the IDF axis, the
+documented alternatives (deferred per the BM25 plan's Out of Scope)
+are:
+
+1. **Smoothed-frequency IDF** — minor variant of current; smoothing
+   constant `1 / log2(1 + α + n)` where α tunes the rare-rule slope.
+   Doesn't have BM25's ~5× scale shift problem.
+2. **Structural-overlap-corrected IDF** — collinearity correction
+   when rules co-fire on the same candidates. Most novel,
+   highest-effort.
+3. **Per-rule-cluster IDF** — rules in same family share IDF basis
+   (axis_feeders, peer_tribal_keyword, primitives). Reduces
+   double-counting.
+4. **Rank-aware IDF (TF-IDF dual)** — weight by per-commander
+   rule-activation rarity. Targets selectivity-within-commander.
+
+Any of these is a candidate for the next orthogonal-direction
+brainstorm. None inherits the +0.005 NDCG lift from this probe — that
+lift was nonexistent (BM25's NDCG was negative). Each must
+independently clear the +0.010 ship bar.
+
+## What was kept
+
+- **Unit 1 (per-commander NDCG audit reporting):** general-purpose
+  audit infrastructure that survives this probe's outcome. Lives at
+  `src/mtg_synergy_graph/bench/per_commander_ndcg.py` with the CLI
+  flag `bench.py audit --per-commander-ndcg`. Useful for any future
+  audit-gated probe needing a per-commander prerequisite check.
+
+What was reverted:
+- BM25 IDF formula change in `src/mtg_synergy_graph/universal_scorer.py`
+- Re-tuned `_RULE_QUALITY_MULTIPLIER` entries in `data/scoring_weights.json`
+- `_PRODUCTION_HASH` pin in `tests/test_scoring_weights.py`
+
+Reset was via `git reset --hard pre-bm25-baseline` followed by
+cherry-pick of the Unit 1 commit. Clean revert verified by
+`bench.py audit --expect-identity` PASS + full test suite PASS
+(1837 tests).
+
+## Sources
+
+- Plan: [`docs/plans/2026-05-04-001-feat-bm25-idf-probe-plan.md`](../../plans/2026-05-04-001-feat-bm25-idf-probe-plan.md)
+- Brainstorm: [`docs/brainstorms/2026-05-04-bm25-idf-requirements.md`](../../brainstorms/2026-05-04-bm25-idf-requirements.md)
+- Sibling null-result template: [`infrastructure-without-scoring-activation-2026-04-24.md`](infrastructure-without-scoring-activation-2026-04-24.md)
+- Sibling: [`scaffold-queue-generator-exhaustion-2026-04-24.md`](scaffold-queue-generator-exhaustion-2026-04-24.md) — original "orthogonal directions" diagnosis
+- Memory: [`feedback_edhrec_not_goal.md`](../../../memory/feedback_edhrec_not_goal.md) — gem-primary framing remains the project default; the BM25 reframe was explicitly scoped to that work only

--- a/docs/solutions/best-practices/read-sibling-solutions-before-improvement-levers-2026-05-05.md
+++ b/docs/solutions/best-practices/read-sibling-solutions-before-improvement-levers-2026-05-05.md
@@ -1,0 +1,321 @@
+---
+title: Read sibling solutions docs before running improvement levers
+date: 2026-05-05
+category: best-practices
+module: development_workflow
+problem_type: best_practice
+component: development_workflow
+severity: high
+applies_when:
+  - About to run a recommendation-quality improvement lever (per-rule weight optimizer, embedding contribution flip, walker rule-shipping, second-oracle probe, scoring-formula swap)
+  - Considering re-running any audit-gated tool whose inputs (fixture, code, data, weights) have not materially changed since its last run
+  - Starting a new ce-brainstorm whose subject overlaps an existing docs/solutions/best-practices/ doc
+  - Planning a multi-outcome probe with revert risk on a tagged baseline
+symptoms:
+  - Compute and wall-clock spent re-discovering an outcome already documented in a sibling solutions doc
+  - "What's next?" framing that bypasses the doc-search step and goes straight to tool invocation
+  - Plan documents that cite no prior solutions docs in their preamble
+related_components:
+  - tooling
+  - documentation
+tags:
+  - workflow
+  - institutional-knowledge
+  - audit-gated-probe
+  - improvement-levers
+  - prior-art
+  - null-results
+  - revert-discipline
+---
+
+# Read sibling solutions docs before running improvement levers
+
+## Context
+
+The repo accumulates `docs/solutions/best-practices/` entries every
+time a probe, sweep, or rule-shipping experiment terminates — including
+null results and DECLINE verdicts. These docs aren't decorative: they
+encode preconditions ("re-sweep only when X, Y, or Z changes"), prior
+measured deltas ("+0.0067 NDCG, below shipping threshold"), and explicit
+"don't repeat this" instructions. (auto memory [claude]:
+`feedback_audit_every_change.md` records the standing rule that every
+scoring-path change is audit-gated; this lesson is a procedural
+prerequisite to that rule — read sibling docs *before* the audit-gated
+change so you're not re-running an audit whose answer is already
+captured.)
+
+But the natural agent reflex when handed an "improvement lever"
+(optimizer, embedding sweep, walker rule-shipping, IDF reformulation)
+is to *run the lever and see what happens*. Each lever costs real
+compute (minutes to an hour) and real tokens (thousands per output
+digest). Re-running a lever whose null result is already documented is
+pure waste — and worse, it can reset the institutional memory ("we just
+tried it, got nothing, moved on") even though nothing in the world
+changed since the last run.
+
+A 2026-05-04 session contained three back-to-back instances of exactly
+that pattern within ~90 minutes:
+
+| Lever | Wasted compute | Prior doc that predicted the outcome |
+|---|---|---|
+| Optimizer retune (4 sweeps with varied alpha/grid/seed) | ~20 min | `docs/solutions/best-practices/optimizer-fixture-size-2026-04-30.md` + prior `.audit/optimize_history.csv` evidence — the 500-cmdr fixture had already exposed that current weights were near-optimal |
+| Embedding contribution flip (10-cell sweep on 500-cmdr) | ~45 min | `docs/solutions/best-practices/infrastructure-without-scoring-activation-2026-04-24.md` — explicitly recorded +0.0067 null and listed three preconditions for re-sweep, none of which had changed |
+| Walker rule-shipping pass (`scaffold_rule.py --apply --walk N`) | ~10 min | `docs/solutions/best-practices/scaffold-queue-generator-exhaustion-2026-04-24.md` — explicit verbatim text: *"If [no inputs change], re-running the walker will return the same exhaustion. Don't."* |
+
+In all three cases the prior doc not only predicted the outcome but
+*explicitly told the agent not to re-run absent specific deltas* — and
+in all three cases the agent re-ran anyway. The deltas the docs
+required (new rule families, vocabulary expansion, fixture refresh,
+dependency rebuild) had not occurred.
+
+The user's first-person framing of the lesson, after the third
+exhaustion: *"I should have read the existing institutional knowledge
+BEFORE running each lever."*
+
+## Guidance
+
+**Before invoking any improvement lever, read the sibling docs in
+`docs/solutions/best-practices/` for the touched module.**
+
+Concretely, before running:
+
+| Tool / change | Grep `docs/solutions/` for |
+|---|---|
+| `bench.py audit --optimize` (or any flag that triggers a multi-sweep) | `optimizer`, `weight`, `multiplier`, `fixture-size` |
+| `sweep_embedding_weights.py` or flipping `_ENABLE_EMBEDDING_CONTRIBUTION` | `embedding`, `infrastructure-without-scoring`, `flag-gated` |
+| `scaffold_rule.py --apply --walk` for an autonomous rule-shipping pass | `walker`, `scaffold`, `queue`, `gap-report` |
+| Any reformulation of an IDF / weight / scoring formula | The formula name (`bm25`, `idf`, `log2`), adjacent rule families, `null-result` |
+| Building or rebuilding any sidecar oracle (`forge_oracle.py build`, `build_embeddings.py`) | The oracle name + `hash`, `rebuild`, `version` |
+| Re-pinning the audit baseline (`bench.py audit --repin --yes`) | `repin`, `pin`, `expect-identity` |
+
+If a sibling doc exists, decide one of:
+
+1. **Skip the lever** — the prior null result still applies (no
+   upstream input has changed since the prior run). Cite the doc by
+   path in the chat / commit message and move on.
+2. **Re-run with a documented delta** — explicitly cite *what changed
+   since the prior run* that justifies re-execution (new fixture, new
+   rule family, new vocabulary expansion, new dependency version,
+   etc.). Note the cited delta in the run output or commit message.
+3. **Promote the prior doc to a hard gate** — if the doc says "don't
+   re-run unless X" and X hasn't happened, the gate should be enforced
+   in tooling: a precommit check, a flag in the script's `--help`, or
+   an explicit refusal in the CLI's startup banner. Each manual re-run
+   is evidence the gate is missing.
+
+The check is fast (Grep on `docs/solutions/`, ~2 seconds) and pays for
+itself the first time it prevents one wasted sweep.
+
+### Why `ce-learnings-researcher` doesn't already cover this (session history)
+
+`ce-learnings-researcher` IS dispatched today, but only by
+`ce-brainstorm` and `ce-plan` for **forward planning of new
+features** (verified across 3 prior session traces — see Session
+History below). When the trigger is "let's run the lever again" or
+"what's next?", no brainstorm is invoked, no learnings researcher
+fires, and the prior docs go unread. The gap is not in the tools —
+it's in the workflow trigger.
+
+The fix is to apply the same `docs/solutions/` lookup discipline at
+**lever-invocation time**, not just at feature-planning time.
+
+## Why This Matters
+
+Compound engineering's whole premise is that prior work — including
+failed work — accrues value. A failed probe that was documented becomes
+negative-cost guidance for the next agent. But that value is only
+realized if the next agent **reads the doc before re-running the
+experiment**.
+
+The 2026-05-04 session burned an estimated **75 minutes of wall-clock
++ ~25k tokens** re-confirming three null results that were already
+documented. None of the re-runs surfaced a new finding; all three
+matched the prior docs' predictions to within their reported precision.
+
+Beyond the direct compute cost, re-running null experiments creates
+two compounding harms:
+
+- **Reframe contamination**: the latest null measurement becomes "the
+  current state" and the prior doc's measurement becomes "stale," even
+  though nothing changed. (auto memory [claude]:
+  `feedback_edhrec_not_goal.md` was updated this same session with a
+  textually-scoped note acknowledging the BM25 reframe applied **only
+  to BM25 work**, precisely to prevent this kind of leak — that
+  scoping discipline is the consumption-side mirror of this
+  production-side rule.)
+- **Audit-history pollution**: each lever appends to
+  `.audit/history.csv`, `.audit/optimize_history.csv`, etc. Repeated
+  null entries dilute the signal-to-noise of the history when later
+  agents try to read trends.
+
+A precedent for this kind of "systemic blind spot" lesson exists in
+`docs/solutions/best-practices/sweep-writers-not-just-readers-on-source-of-truth-refactor-2026-04-25.md`,
+which explicitly notes that **the SAME blind spot already bit a prior
+externalization three days earlier — systemic, not one-off**. The
+lesson here generalizes one level higher: the writer/reader sweep
+discipline applies to refactors; the docs-lookup discipline applies
+to lever invocations. Both are about *checking what's already known
+before acting*.
+
+## When to Apply
+
+Apply this rule **unconditionally** before any of the following:
+
+- Running `bench.py audit --optimize` (or any flag that triggers a
+  multi-sweep)
+- Running `sweep_embedding_weights.py` or modifying
+  `_ENABLE_EMBEDDING_CONTRIBUTION`
+- Running `scaffold_rule.py --apply --walk` for an autonomous
+  rule-shipping pass
+- Modifying any IDF, weight, or scoring formula in
+  `universal_scorer.py` or `complement_rules/`
+- Building or rebuilding any sidecar oracle (`forge_oracle.py build`,
+  `build_embeddings.py`)
+- Re-pinning the audit baseline (`bench.py audit --repin --yes`)
+
+The check is **not required** for:
+
+- Pure-infrastructure refactors (where `bench.py audit --expect-identity`
+  will hold by construction)
+- Bug fixes responding to a fresh, named test failure
+- Adding genuinely new rule kinds (no prior null result can apply to
+  a rule family that didn't exist)
+
+## Examples
+
+### Anti-pattern (what happened in the 2026-05-04 session)
+
+```
+User: "Try the embedding flip."
+Agent: [runs sweep_embedding_weights.py, 10 cells, ~45 min]
+Agent: "Best cell w_emb=0.5, k=2.0 → +0.0089 hidden_gem_hit_rate, -0.0021 NDCG. DECLINE."
+[Later]
+User: "Wait, we already tried this in April."
+Agent: [reads infrastructure-without-scoring-activation-2026-04-24.md]
+Agent: "Yes — prior doc recorded +0.0067 null and listed three preconditions
+for re-sweep, none of which have changed. The 45 minutes was wasted."
+```
+
+### Correct pattern
+
+```
+User: "Try the embedding flip."
+Agent: [Grep docs/solutions/ for "embedding"]
+Agent: "Found infrastructure-without-scoring-activation-2026-04-24.md.
+It records a +0.0067 null result and says re-sweep is justified only if:
+  (a) new card embeddings rebuilt against an updated cardsfolder, OR
+  (b) new event_match_seed entries added since 2026-04-24, OR
+  (c) the candidate-frequency distribution shifted by >10%.
+Checking: cardsfolder unchanged, no new seed entries since 04-24,
+no fixture refresh. None of (a)/(b)/(c) holds. Skipping the sweep.
+Want me to flag the precondition in sweep_embedding_weights.py --help
+so the next agent doesn't re-run either?"
+```
+
+The correct pattern costs ~30 seconds of Grep + reasoning and saves
+~45 minutes of compute. Even when the doc *doesn't* prevent the re-run
+(sometimes a delta does justify it), reading it improves the run: the
+new measurement gets compared against the prior one, the cited delta
+is logged, and the audit history becomes self-explanatory rather than
+a string of unattributed numbers.
+
+### Trigger phrases that should force the lookup
+
+The 2026-05-04 session showed that certain user prompts bypassed the
+lookup step and went straight to tool invocation. Future occurrences
+of these (or close paraphrases) should *force* the
+`docs/solutions/` Grep before any lever runs:
+
+- "What's next for v1.x?" / "What's next to improve the recommendation model?"
+- "Let's try the [optimizer | embedding flip | walker | …]."
+- "What if we tweak the [IDF | multiplier | weight | …]?"
+- "Re-run the [optimizer | sweep | walker]."
+- "Try [BM25 | a different formula | a different fixture]."
+
+These framings are the symptom; the underlying cause is the missing
+docs-first discipline at lever-invocation time.
+
+## What good looked like in the same session (contrast pair)
+
+The same 2026-05-04 / 2026-05-05 session that exhibited the lever-exhaustion
+anti-pattern *also* contained a clean execution under formal discipline:
+the BM25 IDF probe. The contrast is instructive because it shows the
+same agent + same user can do this right when the workflow forces it:
+
+- `ce-brainstorm` → 2 doc-review passes + scope-stripping surgery
+- `ce-plan` → 1 doc-review pass + 5 P1 refinements
+- `ce-work` → 5 implementation units shipped cleanly
+- 5 outcomes pre-committed (SHIP / INVESTIGATE / INCONCLUSIVE /
+  INVESTIGATE-FOR-RETUNE / DECLINE) with explicit routing logic
+- `pre-bm25-baseline` git tag pre-positioned for clean revert
+- Per-commander prerequisite gate fired correctly (65/500 commanders
+  regress >0.05 NDCG@30 → DECLINE)
+- Recovery via `git reset --hard pre-bm25-baseline` + cherry-pick of
+  Unit 1 (general-purpose audit infra preserved) — clean revert in
+  ~5 minutes, `bench.py audit --expect-identity` PASSED post-recovery
+- Memory update scoped textually ("for BM25-related work only") to
+  prevent reframe contamination
+
+The discipline difference: the BM25 arc started with `ce-brainstorm`,
+which by protocol dispatches `ce-learnings-researcher` to scan
+`docs/solutions/`. The lever runs started with raw "let's try X"
+prompts that skipped the brainstorm and the lookup with it.
+
+The full procedural pattern (pre-baseline tag + N-outcome routing +
+bundled-but-separable units + scoped memory) is documented in
+`docs/solutions/best-practices/bm25-idf-null-result-2026-05-04.md`
+and the plan at `docs/plans/2026-05-04-001-feat-bm25-idf-probe-plan.md`.
+
+## Session History (prior context)
+
+(Section sourced from `ce-session-historian` search across 3 prior
+Claude Code sessions on this repo, 2026-04-21 through 2026-05-01.)
+
+All three predicting docs (`optimizer-fixture-size-2026-04-30.md`,
+`infrastructure-without-scoring-activation-2026-04-24.md`,
+`scaffold-queue-generator-exhaustion-2026-04-24.md`) were written by
+`ce-compound` invocations at the END of the sessions that produced the
+findings. The docs were discoverable from `CLAUDE.md` as of at least
+2026-04-24, but the triggering sessions never instructed the agent to
+read sibling docs *before* re-running a lever.
+
+The Apr 21-24 session demonstrated the available discipline: before
+**building** the content-embeddings feature, it dispatched a
+`ce-learnings-researcher` sub-agent to "search `docs/solutions/` for
+prior institutional learnings." This pre-planning lookup was applied
+to *new feature design* but not to *re-running an existing lever*. The
+distinction was never surfaced as a gap until the 2026-05-04 session
+made the cost visible.
+
+**No prior session contained an explicit statement like "I should
+check `docs/solutions/` before re-running this lever."** This META
+lesson is genuinely novel — prior sessions captured the individual
+null-result findings but not the second-order pattern of "read
+sibling docs before activating any lever." (session history)
+
+## Related
+
+- `docs/solutions/best-practices/scaffold-queue-generator-exhaustion-2026-04-24.md`
+  — predicted the 2026-05-04 walker exhaustion (verbatim "Don't
+  re-run" guidance).
+- `docs/solutions/best-practices/infrastructure-without-scoring-activation-2026-04-24.md`
+  — predicted the 2026-05-04 embedding flip null (with explicit
+  re-sweep preconditions).
+- `docs/solutions/best-practices/optimizer-fixture-size-2026-04-30.md`
+  — established that current weights are near-optimal on the 500-cmdr
+  fixture; predicted the 2026-05-04 optimizer near-zero deltas.
+- `docs/solutions/best-practices/bm25-idf-null-result-2026-05-04.md`
+  — case study of the contrast pattern: full audit-gated probe
+  discipline, 5-outcome routing, clean revert via baseline tag.
+- `docs/solutions/best-practices/sweep-writers-not-just-readers-on-source-of-truth-refactor-2026-04-25.md`
+  — prior art for the "systemic blind spot" framing; the closest
+  existing doc to a META "check what's already known before acting"
+  rule.
+- `docs/plans/2026-05-04-001-feat-bm25-idf-probe-plan.md` — the BM25
+  probe's plan; reference for the audit-gated N-outcome probe pattern.
+- `memory/feedback_audit_every_change.md` — every scoring-path change
+  is audit-gated; this lesson is the procedural prerequisite to that
+  rule.
+- `memory/feedback_edhrec_not_goal.md` — updated 2026-05-04 with
+  textually-scoped reframe; consumption-side mirror of this
+  production-side rule.

--- a/src/mtg_synergy_graph/bench/__init__.py
+++ b/src/mtg_synergy_graph/bench/__init__.py
@@ -35,6 +35,7 @@ from mtg_synergy_graph.bench.handlers import (
 )
 from mtg_synergy_graph.bench.histogram import Bucket, Histogram, Verdict
 from mtg_synergy_graph.bench.optimize import handle_optimize
+from mtg_synergy_graph.bench.per_commander_ndcg import handle_per_commander_ndcg
 from mtg_synergy_graph.bench.report import AuditReport, build_report
 from mtg_synergy_graph.bench.tensor import (
     TensorWriter,
@@ -66,6 +67,10 @@ _cli.register("vs_forge_oracle", handle_vs_forge_oracle)
 _cli.register("embedding_dedup", handle_embedding_dedup)
 # Plan 2026-04-26-001 Unit 4 — Coordinate Ascent weight optimizer.
 _cli.register("optimize", handle_optimize)
+# BM25 IDF probe (plan 2026-05-04-001) Unit 1 — per-commander NDCG@30
+# diff handler. Required by the BM25 probe's per-commander prerequisite
+# gate; general-purpose audit infra that survives the probe outcome.
+_cli.register("per_commander_ndcg", handle_per_commander_ndcg)
 
 __all__ = [
     "AuditReport",

--- a/src/mtg_synergy_graph/bench/_stubs.py
+++ b/src/mtg_synergy_graph/bench/_stubs.py
@@ -63,3 +63,7 @@ def embedding_dedup_stub(args: argparse.Namespace) -> int:
 
 def optimize_stub(args: argparse.Namespace) -> int:
     _unimplemented("bench.py audit --optimize")
+
+
+def per_commander_ndcg_stub(args: argparse.Namespace) -> int:
+    _unimplemented("bench.py audit --per-commander-ndcg")

--- a/src/mtg_synergy_graph/bench/cli.py
+++ b/src/mtg_synergy_graph/bench/cli.py
@@ -120,6 +120,10 @@ _HANDLERS: dict[str, Callable[[Namespace], int]] = {
     # every other mode above. The real handler lives in
     # ``mtg_synergy_graph.bench.optimize.handle_optimize``.
     "optimize": _stubs.optimize_stub,
+    # BM25 IDF probe (plan 2026-05-04-001) — per-commander NDCG@30
+    # diff handler. Stubbed here, real handler at
+    # ``mtg_synergy_graph.bench.per_commander_ndcg.handle_per_commander_ndcg``.
+    "per_commander_ndcg": _stubs.per_commander_ndcg_stub,
 }
 
 
@@ -246,6 +250,15 @@ def _build_parser() -> argparse.ArgumentParser:
         "parallel in embedding space (read-only diagnostic). Requires "
         "card_embeddings to be populated — run `scripts/build_embeddings.py` "
         "first. See plan 2026-04-23-003 FR5.",
+    )
+    mode.add_argument(
+        "--per-commander-ndcg",
+        dest="per_commander_ndcg",
+        action="store_true",
+        help="Per-commander NDCG@30 deltas (live - pinned) sorted ascending. "
+        "Read-only diagnostic. Used by audit-gated probes that need a "
+        "per-commander prerequisite check (e.g., BM25 IDF probe — any "
+        "commander losing >0.05 NDCG@30 routes to DECLINE).",
     )
 
     # Shared flags.
@@ -504,6 +517,8 @@ def _resolve_mode(args: Namespace) -> str:
         return "embedding_dedup"
     if getattr(args, "optimize", False):
         return "optimize"
+    if getattr(args, "per_commander_ndcg", False):
+        return "per_commander_ndcg"
     return "audit"
 
 

--- a/src/mtg_synergy_graph/bench/per_commander_ndcg.py
+++ b/src/mtg_synergy_graph/bench/per_commander_ndcg.py
@@ -1,0 +1,198 @@
+"""Per-commander NDCG@30 audit reporting (``bench.py audit --per-commander-ndcg``).
+
+Emits a sorted-ascending table of per-commander NDCG@30 deltas
+(live - pinned) so reviewers can quickly spot regressions. Built to
+support the BM25 IDF probe's per-commander prerequisite gate (any
+commander losing more than 0.05 NDCG@30 → DECLINE outcome), but the
+handler is general-purpose: it works for any audit comparing live
+scoring to a pinned fixture.
+
+Read-only diagnostic. Does not mutate the DB or the pinned fixture.
+
+Data flow:
+- Load pinned fixture (``PinnedFixture.load(path)``).
+- For each commander:
+  - Compute pinned NDCG@30 from ``FixtureEntry.scores`` against EDHREC
+    graded labels.
+  - Compute live NDCG@30 from a fresh re-score against the same labels.
+  - Delta = live - pinned.
+- Render as Markdown table sorted ascending by delta (worst first).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from mtg_synergy_graph.bench.fixture import FixtureEntry, PinnedFixture, score_commander
+from mtg_synergy_graph.bench.optimize import load_edhrec_labels
+from mtg_synergy_graph.db import open_db
+from mtg_synergy_graph.validate import compute_ndcg
+
+#: Per-commander regression threshold flagged in the output. Matches
+#: the BM25 IDF probe plan's hard prerequisite gate (any commander
+#: losing more than 0.05 NDCG@30 → DECLINE).
+PER_COMMANDER_REGRESSION_THRESHOLD: float = -0.05
+
+
+@dataclass(frozen=True)
+class PerCommanderNdcgRow:
+    """One commander's pinned/live/delta NDCG@30 numbers."""
+
+    commander: str
+    pinned_ndcg: float
+    live_ndcg: float
+    delta: float
+
+
+def sort_rows_ascending(rows: list[PerCommanderNdcgRow]) -> list[PerCommanderNdcgRow]:
+    """Sort rows by delta ascending; tiebreak by commander name."""
+    return sorted(rows, key=lambda r: (r.delta, r.commander))
+
+
+def render_per_commander_ndcg_markdown(
+    rows: list[PerCommanderNdcgRow],
+    *,
+    fixture_path: str,
+    config_hash: str,
+) -> str:
+    """Render rows as a Markdown table.
+
+    Caller decides the order; this function preserves the input order
+    (use ``sort_rows_ascending`` first for the worst-first convention
+    the BM25 probe's per-commander gate expects).
+    """
+    lines: list[str] = []
+    lines.append("# bench.py audit --per-commander-ndcg")
+    lines.append("")
+    lines.append(f"fixture: {fixture_path}")
+    lines.append(f"config_hash: {config_hash[:12]}...")
+    lines.append("")
+    lines.append(
+        f"Threshold: rows with delta < {PER_COMMANDER_REGRESSION_THRESHOLD:+.2f} "
+        f"would fail the BM25 IDF probe's per-commander prerequisite gate."
+    )
+    lines.append("")
+
+    if not rows:
+        lines.append("No commanders in fixture (empty result).")
+        return "\n".join(lines)
+
+    lines.append(f"{'commander':<40} {'pinned':>10} {'live':>10} {'delta':>10}")
+    lines.append(f"{'-' * 40} {'-' * 10} {'-' * 10} {'-' * 10}")
+    for row in rows:
+        flag = " ⚠" if row.delta < PER_COMMANDER_REGRESSION_THRESHOLD else ""
+        lines.append(
+            f"{row.commander[:40]:<40} {row.pinned_ndcg:>10.4f} {row.live_ndcg:>10.4f} {row.delta:>+10.4f}{flag}"
+        )
+    return "\n".join(lines)
+
+
+def _ndcg_for_entry(
+    entry: FixtureEntry,
+    graded_labels: dict[str, float],
+) -> float:
+    """Compute NDCG@30 for a fixture entry against EDHREC graded labels."""
+    top_30 = list(entry.scores.keys())[:30]
+    return compute_ndcg(top_30, graded_labels)
+
+
+def compute_per_commander_ndcg_rows(
+    conn: sqlite3.Connection,
+    edhrec_conn: sqlite3.Connection,
+    pinned: PinnedFixture,
+) -> list[PerCommanderNdcgRow]:
+    """Compute pinned/live/delta NDCG@30 rows for every commander in the fixture.
+
+    Live re-scoring uses :func:`score_commander` against the current DB
+    + scoring config. EDHREC graded labels are the same source the
+    optimizer uses (3.0 for high-synergy cards, 1.0 for other on-page
+    cards, 0 elsewhere).
+    """
+    rows: list[PerCommanderNdcgRow] = []
+    for entry in pinned.entries:
+        labels = load_edhrec_labels(edhrec_conn, entry.commander)
+        graded = dict(labels.graded_labels)
+
+        pinned_ndcg = _ndcg_for_entry(entry, graded)
+
+        live_scores, _live_rows = score_commander(conn, entry.commander)
+        live_top_30 = list(live_scores.keys())[:30]
+        live_ndcg = compute_ndcg(live_top_30, graded)
+
+        rows.append(
+            PerCommanderNdcgRow(
+                commander=entry.commander,
+                pinned_ndcg=pinned_ndcg,
+                live_ndcg=live_ndcg,
+                delta=live_ndcg - pinned_ndcg,
+            )
+        )
+    return rows
+
+
+def handle_per_commander_ndcg(args: argparse.Namespace) -> int:
+    """Handle ``bench.py audit --per-commander-ndcg``.
+
+    Loads the pinned fixture at ``--fixture``, re-scores each commander
+    live, computes per-commander NDCG@30 deltas against EDHREC labels
+    from ``--edhrec-db``, and emits a Markdown table sorted ascending
+    by delta (worst regression first).
+
+    Exit codes:
+    * ``0`` — report emitted successfully (regardless of whether any
+      commander exceeds the threshold; callers interpret the table).
+    * ``2`` — usage error (missing fixture, missing EDHREC DB, etc.).
+    """
+    fixture_path = Path(args.fixture)
+    if not fixture_path.exists():
+        print(
+            f"error: pinned fixture {fixture_path} not found.",
+            file=sys.stderr,
+        )
+        return 2
+
+    pinned = PinnedFixture.load(fixture_path)
+    if not pinned.entries:
+        print(f"error: fixture {fixture_path} has no entries.", file=sys.stderr)
+        return 2
+
+    edhrec_db_path = Path(getattr(args, "edhrec_db", "data/tags.db"))
+    if not edhrec_db_path.exists():
+        print(
+            f"error: EDHREC DB {edhrec_db_path} not found. Required for NDCG@30 labels.",
+            file=sys.stderr,
+        )
+        return 2
+
+    conn = open_db(args.db)
+    edhrec_conn = sqlite3.connect(edhrec_db_path)
+    edhrec_conn.row_factory = sqlite3.Row
+    try:
+        rows = compute_per_commander_ndcg_rows(conn, edhrec_conn, pinned)
+    finally:
+        conn.close()
+        edhrec_conn.close()
+
+    sorted_rows = sort_rows_ascending(rows)
+    rendered = render_per_commander_ndcg_markdown(
+        sorted_rows,
+        fixture_path=str(fixture_path),
+        config_hash=pinned.config_hash,
+    )
+
+    output_target = getattr(args, "output", None)
+    if output_target is None or output_target == "-":
+        print(rendered, file=sys.stdout)
+    else:
+        output_path = Path(output_target)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(rendered, encoding="utf-8")
+        print(
+            f"bench.py audit --per-commander-ndcg: written to {output_path}",
+            file=sys.stderr,
+        )
+    return 0

--- a/tests/test_bench_per_commander_ndcg.py
+++ b/tests/test_bench_per_commander_ndcg.py
@@ -1,0 +1,96 @@
+"""Tests for ``bench.py audit --per-commander-ndcg`` reporting handler.
+
+The handler emits per-commander NDCG@30 deltas (live - pinned) sorted
+ascending so the worst regressions surface first. It exists to support
+the BM25 IDF probe's per-commander prerequisite gate (any commander
+losing more than 0.05 NDCG@30 → DECLINE).
+
+Tests use synthetic fixtures + a stub EDHREC labels source to keep
+the unit isolated from the production DB.
+"""
+
+from __future__ import annotations
+
+from mtg_synergy_graph.bench.per_commander_ndcg import (
+    PerCommanderNdcgRow,
+    render_per_commander_ndcg_markdown,
+    sort_rows_ascending,
+)
+
+
+def test_sort_rows_ascending_worst_first():
+    """Worst-regression commanders surface first."""
+    rows = [
+        PerCommanderNdcgRow(commander="A", pinned_ndcg=0.30, live_ndcg=0.31, delta=+0.01),
+        PerCommanderNdcgRow(commander="B", pinned_ndcg=0.40, live_ndcg=0.35, delta=-0.05),
+        PerCommanderNdcgRow(commander="C", pinned_ndcg=0.20, live_ndcg=0.20, delta=0.00),
+    ]
+    sorted_rows = sort_rows_ascending(rows)
+    assert [r.commander for r in sorted_rows] == ["B", "C", "A"]
+
+
+def test_sort_rows_ascending_stable_on_ties():
+    """Ties broken by commander name for stable output."""
+    rows = [
+        PerCommanderNdcgRow(commander="Z", pinned_ndcg=0.5, live_ndcg=0.5, delta=0.0),
+        PerCommanderNdcgRow(commander="A", pinned_ndcg=0.5, live_ndcg=0.5, delta=0.0),
+        PerCommanderNdcgRow(commander="M", pinned_ndcg=0.5, live_ndcg=0.5, delta=0.0),
+    ]
+    sorted_rows = sort_rows_ascending(rows)
+    assert [r.commander for r in sorted_rows] == ["A", "M", "Z"]
+
+
+def test_render_markdown_table_shape():
+    """Markdown table has expected columns and rows."""
+    rows = [
+        PerCommanderNdcgRow(commander="Korvold, Fae-Cursed King", pinned_ndcg=0.300, live_ndcg=0.250, delta=-0.050),
+        PerCommanderNdcgRow(commander="Atraxa, Praetors' Voice", pinned_ndcg=0.200, live_ndcg=0.220, delta=+0.020),
+    ]
+    md = render_per_commander_ndcg_markdown(
+        rows,
+        fixture_path="tests/fixtures/golden_set_run_500.json",
+        config_hash="abc123def456",
+    )
+    assert "# bench.py audit --per-commander-ndcg" in md
+    assert "tests/fixtures/golden_set_run_500.json" in md
+    assert "abc123def456" in md or "abc123def456"[:12] in md
+    # Both commanders in output; worst-first ordering preserved by caller.
+    assert "Korvold, Fae-Cursed King" in md
+    assert "Atraxa, Praetors' Voice" in md
+    # Table header: commander, pinned, live, delta
+    assert "commander" in md.lower()
+    assert "pinned" in md.lower()
+    assert "live" in md.lower()
+    assert "delta" in md.lower()
+
+
+def test_render_markdown_handles_empty_rows():
+    """Empty fixture (or audit produced no commanders) yields informative empty output."""
+    md = render_per_commander_ndcg_markdown(
+        [],
+        fixture_path="tests/fixtures/empty.json",
+        config_hash="zerohash",
+    )
+    assert "no commanders" in md.lower() or "0 commanders" in md.lower() or "empty" in md.lower()
+
+
+def test_per_commander_ndcg_row_delta_consistency():
+    """Delta should equal live - pinned (sanity check on the data shape)."""
+    row = PerCommanderNdcgRow(commander="X", pinned_ndcg=0.40, live_ndcg=0.38, delta=-0.02)
+    assert abs(row.delta - (row.live_ndcg - row.pinned_ndcg)) < 1e-9
+
+
+def test_render_markdown_includes_threshold_legend():
+    """Output should signal the per-commander threshold (-0.05) for context."""
+    rows = [
+        PerCommanderNdcgRow(commander="X", pinned_ndcg=0.5, live_ndcg=0.4, delta=-0.10),
+        PerCommanderNdcgRow(commander="Y", pinned_ndcg=0.5, live_ndcg=0.5, delta=0.0),
+    ]
+    md = render_per_commander_ndcg_markdown(
+        rows,
+        fixture_path="tests/fixtures/golden_set_run_500.json",
+        config_hash="hash",
+    )
+    # Legend or summary should mention the -0.05 threshold so reviewers
+    # can quickly spot violations.
+    assert "0.05" in md


### PR DESCRIPTION
## Summary

- Audit-gated BM25 IDF probe completed end-to-end through `ce-brainstorm` → `ce-plan` → `ce-work`. Verdict: **DECLINE** (per-commander prerequisite gate fired: 65 of 500 commanders regressed >0.05 NDCG@30; aggregate NDCG delta −0.007). Code reverted via `pre-bm25-baseline` tag; `bench.py audit --expect-identity` PASSES post-recovery; full test suite green.
- Unit 1 (per-commander NDCG@30 audit reporting) preserved as general-purpose audit infra — new `bench.py audit --per-commander-ndcg` flag with 6 unit tests.
- Two `docs/solutions/best-practices/` entries written: BM25-specific null-result + a META lesson on reading sibling solutions docs before running improvement levers.

## What's in this PR

| Commit | Description |
|---|---|
| `4442b85` | brainstorm + plan documents (2 doc-review passes + scope-stripping surgery; 5-outcome routing) |
| `f9a9416` | Unit 1: per-commander NDCG@30 audit reporting (`bench.py audit --per-commander-ndcg`) — kept on DECLINE |
| `647a90d` | DECLINE outcome doc: `docs/solutions/best-practices/bm25-idf-null-result-2026-05-04.md` |
| `df73cfd` | META lesson doc: `docs/solutions/best-practices/read-sibling-solutions-before-improvement-levers-2026-05-05.md` |

## BM25 probe result (numerical)

| Metric (500-cmdr fixture) | Pinned | Live (BM25 + re-tuned weights) | Δ |
|---|---|---|---|
| Aggregate NDCG@30 | 0.0942 | 0.0872 | **−0.0070** (fails SHIP gate of ≥+0.010) |
| hidden_gem_hit_rate | 0.7128 | 0.7535 | **+0.0407** (improved — interesting side-result) |
| Per-commander violations (delta < −0.05) | — | **65 of 500** | hard prerequisite gate fired |
| Worst per-commander regression | — | Ghoulcaller Gisa **−0.5283** | — |

The +0.0407 hidden_gem_hit_rate lift suggests a future hidden-gem-primary probe might want to revisit BM25 with different success criteria. Documented in the null-result writeup.

## What this rules out (and what it doesn't)

**Rules out:** BM25 IDF formula `log((N − df + 0.5) / (df + 0.5) + 1)` with strict N + audit-gated retuned multipliers, for an NDCG@30-primary success target on the 500-cmdr fixture.

**Does NOT rule out:** Other IDF formulations (smoothed-frequency, structural-overlap, per-rule-cluster, rank-aware) — those remain viable IDF-axis follow-on candidates. BM25 itself under hidden-gem-primary framing. Other orthogonal directions (richer commander-target composition, port-signature feature expansion, anti-synergy rules, multi-card combo scoring).

## Process discipline that worked

- 5 outcomes pre-committed (SHIP / INVESTIGATE / INCONCLUSIVE / INVESTIGATE-FOR-RETUNE / DECLINE) — no post-hoc judgment under sunk-cost pressure
- `pre-bm25-baseline` git tag pre-positioned — clean revert without `git revert` conflicts
- "Bundled but separable" Unit 1 — preserved as general-purpose infra via cherry-pick on DECLINE
- Memory updates scoped textually ("for BM25-related work only") — prevents reframe contamination

## META lesson captured (the bigger learning)

The session that produced this probe ALSO had three back-to-back lever-exhaustion experiments (optimizer, embedding flip, walker) that re-ran levers whose null results had already been documented in `docs/solutions/best-practices/`. Estimated waste: ~75 min wall-clock + ~25k tokens re-confirming what was already known.

The new META doc captures the procedural rule: **before invoking any improvement lever, Grep `docs/solutions/` for the lever's name + adjacent keywords**. Cross-references the 3 predicting docs that ALL forecasted their respective lever's null result.

## Test plan

- [x] `uv run pytest tests/` — 1837 passed, 2 skipped, 21 deselected
- [x] `uv run scripts/bench.py audit --expect-identity` — PASS (verifies clean revert)
- [x] `uv run scripts/bench.py audit --per-commander-ndcg --fixture tests/fixtures/golden_set_run.json` — emits sorted-ascending Markdown table with threshold legend
- [x] CI: lint + test (will run on push)

## Out of scope / follow-on tasks

- `ce-compound-refresh best-practices` to add cross-references from the 3 predicting docs back to the new META doc (optional — closes the cross-doc loop)
- Next probe direction: per the brainstorm's deferred siblings, candidate orthogonal directions are richer commander-target composition for embeddings, port-signature feature expansion, anti-synergy rules, or multi-card combo scoring. Each requires its own `ce-brainstorm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)