### PR TITLE
feat(scoring): capture Prepared / AlternateMode:Prepare mechanic

### DIFF
--- a/docs/RULE_HISTORY.md
+++ b/docs/RULE_HISTORY.md
@@ -5,6 +5,49 @@ impact notes. See `scripts/_audit_rule_impact.py` for the per-rule impact
 methodology (NDCG@30 metric + golden-set safety net + CONTENTIOUS verdict).
 See `docs/RULE_PLANNING.md` for the forward-looking planning workflow.
 
+## 2026-05-19
+
+### `prepared_mechanic` rule (LANDED)
+
+Captures the new `AlternateMode:Prepare` / `Attributes$ Prepared` mechanic
+introduced by ~48 cards in the 2026-05-19 Forge refresh (SHA `f42b9abc1`).
+See `docs/brainstorms/2026-05-19-prepared-mechanic-requirements.md`.
+
+- **Importer extension**: `extract_alternate_mode_ports` emits a synthetic
+  `static AlternateMode Prepare` port for every card with the top-level
+  `AlternateMode:Prepare` header (47 cards). Restricted to the `Prepare`
+  value via `_ALTERNATE_MODE_PORT_VALUES` frozenset so other AlternateMode
+  values (DoubleFaced, Adventure, Split, Modal, Flip, Specialize, Omen,
+  Meld) are intentionally **not** surfaced as ports — emitting for those
+  perturbed the depth-2 cascade walker's Stage-1 relevant-event prefilter
+  (caught Tergrid in the audit before the narrowing fix).
+- **`port_attributes` extension**: every `AlterAttribute` effect port's
+  `Attributes$ <V>` value is exploded into `port_attributes` with
+  `attr_kind='attribute'`. Surfaces Prepared (29 ports), Suspected (25),
+  Solved (15), Plotted (4), Commander (3), Saddled (3), Harnessed (2).
+- **Rule**: `complement_rules/prepared.py::_find_prepared_mechanic_complements`.
+  Dual-path commander detection: cheap path on the synthetic AlternateMode
+  static port (covers all 47 Prepared payoff creatures including those
+  that self-prepare via `K:ETBReplacement:Other:DBPrepare` which doesn't
+  walk SVars), slow path via SQL join through `port_attributes` for
+  AlterAttribute Prepared (covers enabler-only commanders like a future
+  legendary version of Skycoach Waypoint).
+- **`rule_quality_gate.py --rule prepared_mechanic`**: WARN
+  (47 targets, cov=2.0, cv=0.613). Same shape as the documented-
+  acceptable `ward_2_tribal` WARN — new-mechanic targets are
+  intentionally thinly covered by existing rules.
+- **`bench.py audit`**: aggregate Δ = **+0.0000** on the 100-cmdr golden
+  set (100/100 no_change). Rule does not fire on historical commanders
+  by design — none of the 100 are Prepared payoff cards.
+- **Qualitative validation**: `recommend.py "Abigale, Poet Laureate"
+  --top 60` shows the rule contributing `port_match = 0.180` per
+  Prepared candidate (Bloodline Recollector, Adventurous Eater,
+  Cheerful Osteomancer, Defacing Duskmage, Emeritus of Truce/Woe,
+  Spiritcall Enthusiast, …). Total scores sit at ~0.187 vs ~0.516 for
+  generic WB staples (Bontu's Monument); rule magnitude can be tuned
+  via `_RULE_QUALITY_MULTIPLIER` in a follow-up if Prepared commanders
+  should weight Prepared-tribal cards above generic mana-rock staples.
+
 ## 2026-04-23
 
 ### Forge-Second-Oracle design-time pipeline (LANDED, plan 2026-04-23-002)

--- a/docs/brainstorms/2026-05-19-prepared-mechanic-requirements.md
+++ b/docs/brainstorms/2026-05-19-prepared-mechanic-requirements.md
@@ -1,0 +1,142 @@
+# Prepared / AlternateMode:Prepare mechanic — requirements
+
+**Date**: 2026-05-19
+**Trigger**: Forge refresh `f42b9abc1` introduced ~48 cards with a new
+`Attributes$ Prepared` state + `AlternateMode:Prepare` alt-face mechanic
+that the importer currently captures only as raw text in `card_ports.raw_line`
+(via `event_class='AlterAttribute'`) without surfacing the attribute value
+or the alt-face existence as queryable signal.
+
+## What "Prepared" does (Forge corpus reading)
+
+A creature has two faces. The front face is the creature. The back face is
+a stored spell. When the creature becomes **prepared**, you may cast a copy
+of the back-face spell at no extra cost. Casting the copy unprepares the
+creature.
+
+Two roles in the ecosystem:
+
+1. **Prepared-payoff cards** — creatures with `AlternateMode:Prepare`.
+   The back face is the payoff (a P+1/+1 spell, removal, Reanimate,
+   Brainstorm, Demonic Tutor, …). Each card has a built-in
+   "self-prepare" mechanism — a trigger / ETB replacement / activated
+   ability / conditional upkeep — that prepares **Self** on some condition.
+2. **Prepare-enablers** — cards (currently only **Skycoach Waypoint**, a
+   land) that prepare **other creatures** via
+   `A: AB$ AlterAttribute | ValidTgts$ Creature | Attributes$ Prepared`.
+
+The mechanic is gated by reciprocity: "Only creatures with prepare spells
+can become prepared." So an enabler is useful **only** when the deck
+contains payoff cards. This is a tribal-style synergy: Prepared cards
+co-deck.
+
+### Self-prepare trigger shapes observed in 6-card sample
+
+| Card | Mechanism |
+|---|---|
+| Abigale, Poet Laureate | `T: SpellCast (Creature)` → `DB AlterAttribute Prepared on Self` |
+| Adventurous Eater | `K: ETBReplacement:Other:DBPrepare` → ETB prepared |
+| Harmonized Trio | `A: AB AlterAttribute Cost$ T tapXType<2/Creature>` (activated; tap 2 other creatures) |
+| Grave Researcher | `T: Upkeep` → Surveil → conditional `DBPrepare if Creature.YouOwn GE 3 in Graveyard` |
+| Emeritus of Woe | `R: Event$ Moved Destination$ Battlefield ReplaceWith$ TrigPrepare` (replacement ETB-prepared) + `T: End of Turn` conditional (2+ creatures died) |
+| Skycoach Waypoint | `A: AB AlterAttribute ValidTgts$ Creature` (land that prepares **other** creatures) |
+
+### Alt-face structure
+
+The back face is either:
+
+- A **bespoke spell** with `A:SP$ <Effect>` (e.g., Heroic Stanza =
+  `SP$ PutCounter | CounterType$ P1P1`).
+- A **reference** via `CopyFaceFrom:<ExistingCardName>` (Brainstorm,
+  Reanimate, Demonic Tutor are reused this way).
+
+The Forge parser already merges back-face abilities into the front-face
+card on import (`_ALTERNATE_MARKER` in `parser.py`), so functionally
+Abigale's port set today *includes* a `SP$ PutCounter` effect port from
+the merged Heroic Stanza face. This is convenient — the alt-face payoff
+is already a port — but the importer has no way to know which ports
+came from the alt face vs the front face.
+
+## What's missing from the data model
+
+1. **`Attributes$ Prepared` is not exploded into `port_attributes`.**
+   The importer captures the value only inside `card_ports.raw_line`
+   as JSON text. Cannot be queried efficiently. Same gap applies to
+   `Attributes$ Suspected` (existing mechanic, ~48 cards) and any future
+   `AlterAttribute Attributes$` extension.
+2. **`AlternateMode:Prepare` is not captured at all.** The top-level
+   `AlternateMode:` header is silently dropped by the parser (it's not in
+   `_LINE_DISPATCH` or the ability prefixes). We have no way to flag
+   "this card has a Prepare alt-face" without re-reading the source file.
+
+## v1 design
+
+### Data-layer
+
+1. **`port_attributes` extension**: when an effect port has
+   `event_class='AlterAttribute'` and the raw_line carries `Attributes$ <V>`,
+   explode each comma-separated value into a `port_attributes` row with
+   `attr_kind='attribute'`, `attr_value=<V>`. Covers `Prepared`, `Suspected`,
+   and any future attributes uniformly. No new schema, no new attr_kind
+   string lookup at scoring time — it joins through the same shape as
+   `change_type`, `token_color`, etc.
+
+2. **Synthetic `AlternateMode` port**: parser recognizes the `AlternateMode:`
+   top-level header and stashes `card["alternate_mode"]=<Value>`. Ports
+   extractor adds one synthetic `port_type='static'`,
+   `event_class='AlternateMode'`, `granted_keyword=<Value>` port per card
+   that has the header. This matches the existing keyword-port shape (one
+   row per top-level marker) and keeps the queryable surface uniform.
+
+### Complement rule (Python helper)
+
+One rule, `prepared_mechanic`, in `complement_rules/prepared.py`:
+
+> A `(commander, candidate)` pair is a Prepared-synergy match when:
+> - The commander has an AlterAttribute port with `attr_kind='attribute',
+>   attr_value='Prepared'` (covers self-preparers AND other-preparers), AND
+> - The candidate has a static port `event_class='AlternateMode'`
+>   with `granted_keyword='Prepare'`.
+
+IDF-weighted like every other rule. No special weight knob. The Prepared
+universe is small (~48 cards) so IDF will be high — each match is
+high-value when it fires.
+
+### Out of scope for v1
+
+- Self-vs-other distinction at the gate level. A creature commander that
+  only self-prepares still benefits from sharing the deck with other
+  prepared-payoff creatures (the enabler-payoff reciprocity is at the deck
+  level, not the per-pair level). The rule should match symmetrically;
+  per-pair refinement can come in a future iteration with more data.
+- Reanimator / Brainstorm / Demonic Tutor sub-synergies inherited from the
+  `CopyFaceFrom` references. Those already feed existing rules through the
+  merged-face port extraction; no new logic needed.
+- Promoting the rule from Python-helper to declarative
+  (`port_graph/rules_schema.py`). The interpreter gate grammar doesn't yet
+  cover "candidate has port with attribute X" queries — adding a
+  `has_port_attribute` predicate is a separate brainstorm/plan cycle.
+
+## Acceptance
+
+- `bench.py audit` verdict POSITIVE or NEUTRAL on 100-cmdr golden set
+  (most golden commanders are pre-Prepared-era, so signal will be small
+  but should not regress).
+- `rule_quality_gate.py --rule prepared_mechanic` passes (no vacuum-fill).
+- `scripts/recommend.py --commander "Abigale, Poet Laureate" --explain`
+  shows `prepared_mechanic` firing on candidates that share the Prepare
+  mechanic, and the top-30 surfaces other Prepared creatures with
+  plausible mechanical fit (high cmc alt-mode > low cmc alt-mode).
+- Brand-new commanders that EDHREC has no data for (Abigale, Augusta,
+  Emeritus of Woe, …) get a non-trivial scoring profile rather than
+  collapsing to the generic creature baseline.
+
+## Open question deferred to follow-up
+
+Whether `CopyFaceFrom:<Name>` resolution should be done at import time
+(materialize the back-face spell into the merged port set) or at scoring
+time (look up the referenced card's ports on demand). Today it's
+implicit — Forge's runtime resolves the reference but the importer does
+not, so a `CopyFaceFrom:Reanimate` card carries no Reanimate ports. Most
+golden-set rules will fail to fire on these. Out of scope for v1; needs
+its own brainstorm.

--- a/src/mtg_synergy_graph/complement_rules/core.py
+++ b/src/mtg_synergy_graph/complement_rules/core.py
@@ -1071,6 +1071,7 @@ from .panharmonicon import (  # noqa: E402
     _find_panharmonicon_stacking,
     _find_reverse_panharmonicon,
 )
+from .prepared import _find_prepared_mechanic_complements  # noqa: E402
 from .statics import (  # noqa: E402
     _find_affinity_archetype,
     _find_cost_reduction_synergy,
@@ -1287,6 +1288,7 @@ def find_all_complements(
         out.extend(_find_land_bounce_feeders(conn, cmdr_ports, cmdr_set))
         out.extend(_find_creature_died_feeders(conn, cmdr_ports, cmdr_set))
         out.extend(_find_damage_doubler_synergy(conn, cmdr_ports, cmdr_set))
+        out.extend(_find_prepared_mechanic_complements(conn, cmdr_ports, cmdr_set))
         # Plan 2026-04-23-001: depth-2 self-bridging pathway rule
         # family. Gated behind pathway._ENABLE_PATHWAY_RULES (default
         # False) until Unit 6's bench.py audit produces a landing

--- a/src/mtg_synergy_graph/complement_rules/prepared.py
+++ b/src/mtg_synergy_graph/complement_rules/prepared.py
@@ -1,0 +1,105 @@
+"""Prepared / AlternateMode:Prepare mechanic synergy.
+
+Captures the new mechanic added in the 2026-05-19 Forge refresh
+(brainstorm: ``docs/brainstorms/2026-05-19-prepared-mechanic-requirements.md``).
+
+A creature with the top-level header ``AlternateMode:Prepare`` has a
+stored back-face spell castable when it becomes "prepared" (a state set
+via ``DB$ AlterAttribute | Attributes$ Prepared``). Two roles in the
+ecosystem:
+
+1. **Prepared-payoff cards** — creatures with ``AlternateMode:Prepare``.
+   The importer emits a synthetic ``static`` port ``event_class='AlternateMode'``
+   with ``granted_keyword='Prepare'`` for each one (see ``ports.py``
+   ``extract_alternate_mode_ports``).
+2. **Prepare-enablers** — abilities that grant the Prepared state via
+   ``AlterAttribute``. The importer explodes the ``Attributes$ Prepared``
+   value into ``port_attributes`` under ``attr_kind='attribute'`` so the
+   rule can join on it.
+
+A commander is in the Prepared ecosystem when **either** signal is
+present on its port set. Every other Prepared-payoff card in the legal
+universe is a complement — the mechanic is gated by reciprocity
+("only creatures with prepare spells can become prepared"), so Prepared
+cards co-deck like a tribe.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from .core import PortComplement, PortRow
+
+_RULE_ID = "prepared_mechanic"
+
+
+def _commander_has_alternate_mode_prepare(cmdr_ports: list[PortRow]) -> bool:
+    """Cheap path — commander itself is a Prepared-payoff card.
+
+    Covers all 47 self-preparing creatures (including the ~20 that
+    self-prepare via ``K:ETBReplacement:Other:DBPrepare`` which doesn't
+    surface an AlterAttribute port on the commander side).
+    """
+    for p in cmdr_ports:
+        if (p.get("port_type") or "").strip() != "static":
+            continue
+        if (p.get("event_class") or "").strip() != "AlternateMode":
+            continue
+        if (p.get("granted_keyword") or "").strip() == "Prepare":
+            return True
+    return False
+
+
+def _commander_prepares_creatures(conn: sqlite3.Connection, cmdr_set: set[str]) -> bool:
+    """Slow path — commander has an AlterAttribute effect that grants
+    Prepared. Covers prepare-enabler commanders that aren't themselves
+    Prepared-payoff cards.
+
+    Runs at most once per commander (gated by the cheap path missing)
+    and uses the indexed ``port_attributes`` lookup.
+    """
+    placeholders = ",".join("?" * len(cmdr_set))
+    row = conn.execute(
+        f"SELECT 1 FROM card_ports cp "
+        f"JOIN port_attributes pa ON pa.port_id = cp.id "
+        f"WHERE cp.card_name IN ({placeholders}) "
+        f"AND cp.event_class = 'AlterAttribute' "
+        f"AND pa.attr_kind = 'attribute' "
+        f"AND pa.attr_value = 'Prepared' "
+        f"LIMIT 1",
+        tuple(cmdr_set),
+    ).fetchone()
+    return row is not None
+
+
+def _find_prepared_mechanic_complements(
+    conn: sqlite3.Connection,
+    cmdr_ports: list[PortRow],
+    cmdr_set: set[str],
+) -> list[PortComplement]:
+    in_ecosystem = _commander_has_alternate_mode_prepare(cmdr_ports)
+    if not in_ecosystem:
+        in_ecosystem = _commander_prepares_creatures(conn, cmdr_set)
+    if not in_ecosystem:
+        return []
+
+    placeholders = ",".join("?" * len(cmdr_set))
+    rows = conn.execute(
+        f"SELECT DISTINCT card_name FROM card_ports "
+        f"WHERE port_type = 'static' "
+        f"AND event_class = 'AlternateMode' "
+        f"AND granted_keyword = 'Prepare' "
+        f"AND card_name NOT IN ({placeholders})",
+        tuple(cmdr_set),
+    ).fetchall()
+
+    return [
+        PortComplement(
+            rule_id=_RULE_ID,
+            direction="synergy",
+            candidate=r["card_name"],
+            cmdr_event="Prepared_ecosystem",
+            cand_event="AlternateMode_Prepare",
+        )
+        for r in rows
+    ]

--- a/src/mtg_synergy_graph/complement_rules/registry.py
+++ b/src/mtg_synergy_graph/complement_rules/registry.py
@@ -97,6 +97,24 @@ _MODIFIED_QUALIFIER_RE = re.compile(r"(?<![A-Za-z])modified(?![A-Za-z])")
 _COUNTER_GATE_RE = re.compile(r"counters_GE\d*_[A-Z0-9]+")
 
 
+def _prepared_mechanic_gate(port: PortRow) -> bool:
+    """Mirror of ``_find_prepared_mechanic_complements``'s commander-side
+    activation signature.
+
+    Attributes the rule to a commander's ``static AlternateMode Prepare``
+    port — the cheap-path signal that covers all 47 Prepared-payoff cards.
+    The slow-path (AlterAttribute on enabler-only commanders) is not
+    captured by a single-port predicate; per-port attribution there is
+    deferred (same posture as life_total_feeder etc. — see the
+    'Gate-miss' comment above).
+    """
+    if (port.get("port_type") or "").strip() != "static":
+        return False
+    if (port.get("event_class") or "").strip() != "AlternateMode":
+        return False
+    return (port.get("granted_keyword") or "").strip() == "Prepare"
+
+
 def _damage_doubler_gate(port: PortRow) -> bool:
     if (port.get("port_type") or "").strip() != "replacement":
         return False
@@ -731,6 +749,7 @@ _CARD_ATTR_GATES: tuple[RuleGate, ...] = (
     # the canonical attribution source. Per-port auditor attribution
     # through the interpreter is a deferred follow-up item in plan
     # 003 Open Questions.
+    RuleGate("prepared_mechanic", _prepared_mechanic_gate),
 )
 
 

--- a/src/mtg_synergy_graph/importer.py
+++ b/src/mtg_synergy_graph/importer.py
@@ -401,7 +401,7 @@ _PORT_INSERT_SQL = (
 #: Keys the importer consumes from the port dict but does NOT persist
 #: on card_ports. Producers attach these; import_card must pop them
 #: before calling _normalise_port.
-_TRANSIENT_PORT_KEYS: frozenset[str] = frozenset({"_change_type", "_token_script"})
+_TRANSIENT_PORT_KEYS: frozenset[str] = frozenset({"_change_type", "_token_script", "_attributes"})
 
 #: BuffedBy SVar tokens classified by explode_filter → card_hints.category.
 #: attr_kinds not in this map (controller, cmc_cmp, etc.) are skipped —
@@ -514,6 +514,7 @@ def import_card(
     for port in ports:
         change_type = port.pop("_change_type", "")
         token_script = port.pop("_token_script", "")
+        attributes_csv = port.pop("_attributes", "")
         cur = conn.execute(_PORT_INSERT_SQL, _normalise_port(port))
         port_id = cur.lastrowid
         inserted += 1
@@ -543,6 +544,18 @@ def import_card(
                     "(port_id, attr_kind, attr_value, is_negated) VALUES (?, ?, ?, ?)",
                     (port_id, attr_kind, attr_value, False),
                 )
+        # AlterAttribute Attributes$ values (Prepared, Suspected, …) — one
+        # port_attributes row per comma-separated entry under attr_kind=
+        # 'attribute'. Joined by the prepared_mechanic complement rule.
+        if attributes_csv:
+            for raw in attributes_csv.split(","):
+                attr_value = raw.strip()
+                if attr_value:
+                    conn.execute(
+                        "INSERT OR IGNORE INTO port_attributes "
+                        "(port_id, attr_kind, attr_value, is_negated) VALUES (?, ?, ?, ?)",
+                        (port_id, "attribute", attr_value, False),
+                    )
 
     return inserted
 

--- a/src/mtg_synergy_graph/parser.py
+++ b/src/mtg_synergy_graph/parser.py
@@ -132,6 +132,10 @@ _LINE_DISPATCH: tuple[tuple[str, str, int, str], ...] = (
     ("DeckHints:", "deck_hints", 10, "deck_hints"),
     ("DeckNeeds:", "deck_needs", 10, "deck_hints"),
     ("DeckHas:", "deck_has", 8, "deck_hints"),
+    # `AlternateMode:Prepare` marks a card whose back face is a stored
+    # spell castable when the front-face creature is prepared. Captured
+    # here so the importer can emit a synthetic AlternateMode port.
+    ("AlternateMode:", "alternate_mode", 14, "scalar"),
 )
 
 #: Map of ability prefixes (``T:``/``A:``/``S:``/``R:``) to the kind label

--- a/src/mtg_synergy_graph/ports.py
+++ b/src/mtg_synergy_graph/ports.py
@@ -374,6 +374,10 @@ def extract_effect_ports(
     # explode it into port_attributes under attr_kind='change_type'.
     change_type = parsed.get("ChangeType", "") if verb == "ChangeZone" else ""
     token_script = parsed.get("TokenScript", "") if verb == "Token" else ""
+    # AlterAttribute effects carry their attribute state in Attributes$
+    # (Prepared, Suspected, …). Store it on the port so the importer can
+    # explode it into port_attributes under attr_kind='attribute'.
+    attributes_csv = parsed.get("Attributes", "") if verb == "AlterAttribute" else ""
 
     port: PortRow = {
         "card_name": card_name,
@@ -391,6 +395,7 @@ def extract_effect_ports(
         "raw_line": repr(parsed),
         "_change_type": change_type,  # consumed by importer, stripped before insert
         "_token_script": token_script,  # same
+        "_attributes": attributes_csv,  # same
         **branch,
     }
 
@@ -679,6 +684,42 @@ def extract_keyword_ports(card_name: str, keyword_lines: list[str]) -> list[Port
     return ports
 
 
+#: AlternateMode values that emit a synthetic static port. Restricted to
+#: ``Prepare`` for the 2026-05-19 Prepared-mechanic capture; broader
+#: emission (DoubleFaced, Adventure, Split, Modal, …) is deferred —
+#: those cards already surface their alt-face abilities through the
+#: existing ALTERNATE-block parser merge, and emitting a static port for
+#: them shifts the relevant-event set of commanders like Tergrid (Modal
+#: DFC) which perturbs the depth-2 cascade walker's Stage-1 prefilter.
+#: See ``docs/brainstorms/2026-05-19-prepared-mechanic-requirements.md``.
+_ALTERNATE_MODE_PORT_VALUES: frozenset[str] = frozenset({"Prepare"})
+
+
+def extract_alternate_mode_ports(card_name: str, alternate_mode: str) -> list[PortRow]:
+    """Emit a synthetic static port for ``AlternateMode:<Value>``.
+
+    Mirrors the keyword-port shape (one row per top-level header marker).
+    The mode value lives in ``granted_keyword`` so the complement rules can
+    join on it with the same idiom as keyword matching.
+
+    Restricted to ``_ALTERNATE_MODE_PORT_VALUES`` so adding support for a
+    new mechanic is an explicit one-line vocabulary extension.
+    """
+    value = (alternate_mode or "").strip()
+    if value not in _ALTERNATE_MODE_PORT_VALUES:
+        return []
+    return [
+        {
+            "card_name": card_name,
+            "port_type": "static",
+            "event_class": "AlternateMode",
+            "granted_keyword": value,
+            "raw_line": f"AlternateMode:{value}",
+            **_branch_defaults(),
+        }
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Scaling ports (§5.5)
 # ---------------------------------------------------------------------------
@@ -786,5 +827,6 @@ def extract_all_ports(card: dict[str, Any]) -> list[PortRow]:
         ports.extend(extractor(name, parsed, svars))
 
     ports.extend(extract_keyword_ports(name, card.get("keywords", [])))
+    ports.extend(extract_alternate_mode_ports(name, card.get("alternate_mode") or ""))
     ports.extend(extract_scaling_ports(name, svars))
     return ports

--- a/src/mtg_synergy_graph/universal_scorer.py
+++ b/src/mtg_synergy_graph/universal_scorer.py
@@ -159,6 +159,8 @@ _RULE_TO_BUCKET: dict[str, str] = {
     "cascade_tribal": "port_match",
     # Plan 2026-04-23-001 depth-2 self-bridging pathway.
     "self_bridging_cascade": "port_match",
+    # Plan 2026-05-19 Prepared / AlternateMode:Prepare mechanic capture.
+    "prepared_mechanic": "port_match",
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -371,3 +371,192 @@ def test_buffed_by_svar_skips_non_type_tokens(tmp_path):
     assert "YouCtrl" not in values
     assert "cmcLE3" not in values
     conn.close()
+
+
+# ---------------------------------------------------------------------------
+# AlterAttribute Attributes$ → port_attributes (Prepared mechanic, plan 2026-05-19)
+# ---------------------------------------------------------------------------
+
+
+@_integration
+@_requires_cardsfolder
+def test_alter_attribute_prepared_exposed_on_abigale(tmp_path):
+    """Abigale's TrigPrepare SubAbility (DB$ AlterAttribute | Attributes$ Prepared)
+    must land in port_attributes with attr_kind='attribute' so the prepared_mechanic
+    rule can join on it.
+    """
+    db_path = tmp_path / "test.db"
+    conn = open_db(db_path)
+    card_path = _FORGE_CARDSFOLDER / "a" / "abigale_poet_laureate_heroic_stanza.txt"
+    card = parse_card_file(card_path)
+    import_card(conn, card, oracle_id_resolver=None)
+
+    rows = conn.execute(
+        "SELECT pa.attr_value FROM port_attributes pa "
+        "JOIN card_ports cp ON pa.port_id = cp.id "
+        "WHERE cp.card_name=? AND cp.event_class='AlterAttribute' "
+        "AND pa.attr_kind='attribute'",
+        ("Abigale, Poet Laureate",),
+    ).fetchall()
+    values = {r[0] for r in rows}
+    assert values == {"Prepared"}, f"Expected attribute Prepared, got {values}"
+    conn.close()
+
+
+@_integration
+@_requires_cardsfolder
+def test_alter_attribute_suspected_exposed_on_existing_card(tmp_path):
+    """The same code path must surface the pre-existing Suspected attribute.
+    Repeat Offender (Murders at Karlov Manor) is the canonical example.
+    """
+    db_path = tmp_path / "test.db"
+    conn = open_db(db_path)
+    card_path = _FORGE_CARDSFOLDER / "r" / "repeat_offender.txt"
+    card = parse_card_file(card_path)
+    import_card(conn, card, oracle_id_resolver=None)
+
+    rows = conn.execute(
+        "SELECT pa.attr_value FROM port_attributes pa "
+        "JOIN card_ports cp ON pa.port_id = cp.id "
+        "WHERE cp.card_name=? AND cp.event_class='AlterAttribute' "
+        "AND pa.attr_kind='attribute'",
+        ("Repeat Offender",),
+    ).fetchall()
+    values = {r[0] for r in rows}
+    assert "Suspected" in values, f"Expected Suspected attribute, got {values}"
+    conn.close()
+
+
+@_integration
+@_requires_cardsfolder
+def test_alter_attribute_prepared_exposed_on_other_targeter(tmp_path):
+    """Skycoach Waypoint prepares OTHER creatures (ValidTgts$ Creature). The
+    attribute must still land in port_attributes — the rule joins on the
+    attribute, not on the targeter shape.
+    """
+    db_path = tmp_path / "test.db"
+    conn = open_db(db_path)
+    card_path = _FORGE_CARDSFOLDER / "s" / "skycoach_waypoint.txt"
+    card = parse_card_file(card_path)
+    import_card(conn, card, oracle_id_resolver=None)
+
+    rows = conn.execute(
+        "SELECT pa.attr_value FROM port_attributes pa "
+        "JOIN card_ports cp ON pa.port_id = cp.id "
+        "WHERE cp.card_name=? AND cp.event_class='AlterAttribute' "
+        "AND pa.attr_kind='attribute'",
+        ("Skycoach Waypoint",),
+    ).fetchall()
+    values = {r[0] for r in rows}
+    assert values == {"Prepared"}, f"Expected attribute Prepared, got {values}"
+    conn.close()
+
+
+def test_alter_attribute_attributes_unit_synthetic(tmp_path):
+    """Unit test on a synthetic card dict — confirms the explode path works
+    independent of the Forge .txt parser.
+    """
+    from mtg_synergy_graph.parser import parse_forge_line
+
+    db_path = tmp_path / "test.db"
+    conn = open_db(db_path)
+    card = {
+        "name": "Test Prepare Caster",
+        "types": "Creature",
+        "abilities": [
+            (
+                "ability",
+                parse_forge_line("AB$ AlterAttribute | Cost$ 2 | ValidTgts$ Creature | Attributes$ Prepared"),
+            ),
+        ],
+        "svars": {},
+        "keywords": [],
+    }
+    import_card(conn, card, oracle_id_resolver=None)
+
+    rows = conn.execute(
+        "SELECT pa.attr_value FROM port_attributes pa "
+        "JOIN card_ports cp ON pa.port_id = cp.id "
+        "WHERE cp.card_name=? AND pa.attr_kind='attribute'",
+        ("Test Prepare Caster",),
+    ).fetchall()
+    assert {r[0] for r in rows} == {"Prepared"}
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# AlternateMode:Prepare → synthetic static port (Prepared mechanic, plan 2026-05-19)
+# ---------------------------------------------------------------------------
+
+
+@_integration
+@_requires_cardsfolder
+def test_alternate_mode_prepare_surfaced_as_port_for_abigale(tmp_path):
+    """Abigale's top-level `AlternateMode:Prepare` header must surface as a
+    queryable port — a synthetic static port with event_class='AlternateMode'
+    and granted_keyword='Prepare'. Mirrors the keyword-port shape so the
+    prepared_mechanic rule can join uniformly.
+    """
+    db_path = tmp_path / "test.db"
+    conn = open_db(db_path)
+    card_path = _FORGE_CARDSFOLDER / "a" / "abigale_poet_laureate_heroic_stanza.txt"
+    card = parse_card_file(card_path)
+    import_card(conn, card, oracle_id_resolver=None)
+
+    row = conn.execute(
+        "SELECT port_type, event_class, granted_keyword FROM card_ports "
+        "WHERE card_name=? AND event_class='AlternateMode'",
+        ("Abigale, Poet Laureate",),
+    ).fetchone()
+    assert row is not None, "Expected one AlternateMode port for Abigale"
+    assert row["port_type"] == "static"
+    assert row["granted_keyword"] == "Prepare"
+    conn.close()
+
+
+def test_alternate_mode_absent_when_card_has_no_alternate_mode(tmp_path):
+    """Cards without an AlternateMode header must NOT get a synthetic port."""
+    db_path = tmp_path / "test.db"
+    conn = open_db(db_path)
+    card = {
+        "name": "Test Plain Creature",
+        "types": "Creature",
+        "abilities": [],
+        "svars": {},
+        "keywords": [],
+    }
+    import_card(conn, card, oracle_id_resolver=None)
+
+    rows = conn.execute(
+        "SELECT 1 FROM card_ports WHERE card_name=? AND event_class='AlternateMode'",
+        ("Test Plain Creature",),
+    ).fetchall()
+    assert rows == [], "Plain card must not have AlternateMode synthetic port"
+    conn.close()
+
+
+def test_alternate_mode_synthetic_unit(tmp_path):
+    """Unit test on a synthetic card dict — confirms the synthesis path
+    works independent of the Forge .txt parser.
+    """
+    db_path = tmp_path / "test.db"
+    conn = open_db(db_path)
+    card = {
+        "name": "Test Prepare Payoff",
+        "types": "Creature",
+        "alternate_mode": "Prepare",
+        "abilities": [],
+        "svars": {},
+        "keywords": [],
+    }
+    import_card(conn, card, oracle_id_resolver=None)
+
+    row = conn.execute(
+        "SELECT port_type, event_class, granted_keyword FROM card_ports "
+        "WHERE card_name=? AND event_class='AlternateMode'",
+        ("Test Prepare Payoff",),
+    ).fetchone()
+    assert row is not None
+    assert row["port_type"] == "static"
+    assert row["granted_keyword"] == "Prepare"
+    conn.close()

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -560,3 +560,34 @@ def test_alternate_mode_synthetic_unit(tmp_path):
     assert row["port_type"] == "static"
     assert row["granted_keyword"] == "Prepare"
     conn.close()
+
+
+@pytest.mark.parametrize("value", ["Modal", "Adventure", "Split", "Flip", "Specialize", "Omen", "Meld", "DoubleFaced"])
+def test_alternate_mode_non_prepare_values_do_not_emit_port(tmp_path, value):
+    """Regression for ``_ALTERNATE_MODE_PORT_VALUES``: only ``Prepare``
+    emits a synthetic AlternateMode port. Other values (Modal/Adventure/
+    Split/Flip/Specialize/Omen/Meld/DoubleFaced) must NOT — emitting for
+    them previously perturbed the depth-2 cascade walker's Stage-1
+    relevant-event prefilter, causing a -0.21 regression on Tergrid.
+
+    See ``docs/RULE_HISTORY.md`` 2026-05-19 entry and
+    ``ports.py::_ALTERNATE_MODE_PORT_VALUES``.
+    """
+    db_path = tmp_path / "test.db"
+    conn = open_db(db_path)
+    card = {
+        "name": f"Test {value} DFC",
+        "types": "Creature",
+        "alternate_mode": value,
+        "abilities": [],
+        "svars": {},
+        "keywords": [],
+    }
+    import_card(conn, card, oracle_id_resolver=None)
+
+    rows = conn.execute(
+        "SELECT 1 FROM card_ports WHERE card_name=? AND event_class='AlternateMode'",
+        (f"Test {value} DFC",),
+    ).fetchall()
+    assert rows == [], f"AlternateMode:{value} must not emit a synthetic port"
+    conn.close()

--- a/tests/test_prepared_rules.py
+++ b/tests/test_prepared_rules.py
@@ -1,0 +1,383 @@
+"""Tests for the Prepared / AlternateMode:Prepare complement rule.
+
+Builds a small in-memory SQLite database with synthetic ``card_ports`` and
+``port_attributes`` rows to exercise both detection paths of
+``_find_prepared_mechanic_complements`` and its associated registry gate:
+
+  - Cheap path: commander has a ``static AlternateMode Prepare`` port.
+  - Slow path: commander has an ``effect AlterAttribute`` port whose
+    ``port_attributes`` contains ``(attribute, Prepared)``.
+
+The in-memory schema is the minimum subset the rule's two SQL queries
+touch — kept narrow on purpose so a future schema change to ``card_ports``
+doesn't drag this test file with it.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from mtg_synergy_graph.complement_rules.prepared import (
+    _commander_has_alternate_mode_prepare,
+    _find_prepared_mechanic_complements,
+)
+from mtg_synergy_graph.complement_rules.registry import RULE_GATES
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def conn():
+    """In-memory SQLite with the minimum schema the rule's SQL touches."""
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    c.executescript(
+        """
+        CREATE TABLE card_ports (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            card_name       TEXT NOT NULL,
+            port_type       TEXT NOT NULL,
+            event_class     TEXT NOT NULL,
+            granted_keyword TEXT
+        );
+        CREATE TABLE port_attributes (
+            port_id    INTEGER NOT NULL,
+            attr_kind  TEXT NOT NULL,
+            attr_value TEXT NOT NULL,
+            is_negated BOOLEAN DEFAULT FALSE
+        );
+        """
+    )
+    yield c
+    c.close()
+
+
+def _port_row(**kwargs) -> dict:
+    """Build a PortRow dict with neutral defaults."""
+    defaults = {
+        "card_name": "",
+        "port_type": "",
+        "event_class": "",
+        "granted_keyword": "",
+        "valid_filter": "",
+        "raw_line": "",
+    }
+    defaults.update(kwargs)
+    return defaults
+
+
+def _insert_alternate_mode_prepare_port(conn: sqlite3.Connection, card_name: str) -> int:
+    """Insert a synthetic ``static AlternateMode Prepare`` port. Returns port id."""
+    cur = conn.execute(
+        "INSERT INTO card_ports (card_name, port_type, event_class, granted_keyword) VALUES (?, ?, ?, ?)",
+        (card_name, "static", "AlternateMode", "Prepare"),
+    )
+    return cur.lastrowid
+
+
+def _insert_alter_attribute_prepared(conn: sqlite3.Connection, card_name: str) -> int:
+    """Insert a synthetic ``effect AlterAttribute`` port + matching
+    ``port_attributes`` row. Returns port id."""
+    cur = conn.execute(
+        "INSERT INTO card_ports (card_name, port_type, event_class, granted_keyword) VALUES (?, ?, ?, ?)",
+        (card_name, "effect", "AlterAttribute", None),
+    )
+    port_id = cur.lastrowid
+    conn.execute(
+        "INSERT INTO port_attributes (port_id, attr_kind, attr_value) VALUES (?, ?, ?)",
+        (port_id, "attribute", "Prepared"),
+    )
+    return port_id
+
+
+# ---------------------------------------------------------------------------
+# _find_prepared_mechanic_complements — cheap path
+# ---------------------------------------------------------------------------
+
+
+class TestCheapPathPreparedPayoffCommander:
+    """Commander has the synthetic ``static AlternateMode Prepare`` port.
+
+    This is the path covering the 47 Prepared payoff creatures including
+    the ~20 that self-prepare via ``K:ETBReplacement:Other:DBPrepare``
+    (which doesn't surface an AlterAttribute port).
+    """
+
+    def test_fires_for_alternate_mode_prepare_commander(self, conn):
+        """Abigale-shape commander (AlternateMode:Prepare on its port set)
+        should produce complements for every other Prepared payoff card."""
+        # Commander has AlternateMode:Prepare on its port set
+        cmdr_ports = [
+            _port_row(
+                port_type="static",
+                event_class="AlternateMode",
+                granted_keyword="Prepare",
+            ),
+        ]
+        # Insert three other Prepared payoff candidates
+        for name in ("Adventurous Eater", "Cheerful Osteomancer", "Emeritus of Woe"):
+            _insert_alternate_mode_prepare_port(conn, name)
+        conn.commit()
+
+        results = _find_prepared_mechanic_complements(conn, cmdr_ports, {"Abigale, Poet Laureate"})
+        candidates = {r.candidate for r in results}
+        assert candidates == {"Adventurous Eater", "Cheerful Osteomancer", "Emeritus of Woe"}
+
+    def test_excludes_self(self, conn):
+        """Commander itself must not appear in its own complement set."""
+        cmdr_ports = [
+            _port_row(
+                port_type="static",
+                event_class="AlternateMode",
+                granted_keyword="Prepare",
+            ),
+        ]
+        # Insert the commander itself + one other Prepared card in card_ports
+        _insert_alternate_mode_prepare_port(conn, "Abigale, Poet Laureate")
+        _insert_alternate_mode_prepare_port(conn, "Adventurous Eater")
+        conn.commit()
+
+        results = _find_prepared_mechanic_complements(conn, cmdr_ports, {"Abigale, Poet Laureate"})
+        candidates = {r.candidate for r in results}
+        assert "Abigale, Poet Laureate" not in candidates
+        assert candidates == {"Adventurous Eater"}
+
+    def test_complement_metadata_is_stable(self, conn):
+        """Emitted PortComplement carries the expected rule_id / event tags
+        so the IDF basis and recommend.py --explain rendering stay
+        deterministic across rebuilds.
+        """
+        cmdr_ports = [
+            _port_row(
+                port_type="static",
+                event_class="AlternateMode",
+                granted_keyword="Prepare",
+            ),
+        ]
+        _insert_alternate_mode_prepare_port(conn, "Adventurous Eater")
+        conn.commit()
+
+        results = _find_prepared_mechanic_complements(conn, cmdr_ports, {"Abigale, Poet Laureate"})
+        assert len(results) == 1
+        c = results[0]
+        assert c.rule_id == "prepared_mechanic"
+        assert c.direction == "synergy"
+        assert c.cmdr_event == "Prepared_ecosystem"
+        assert c.cand_event == "AlternateMode_Prepare"
+
+    def test_alternate_mode_with_non_prepare_value_does_not_activate(self, conn):
+        """A commander with AlternateMode:Modal (e.g., Tergrid) must NOT be
+        treated as a Prepared ecosystem commander. Regression for the
+        ``_ALTERNATE_MODE_PORT_VALUES`` narrowing — Modal/Adventure/Split
+        synthetic ports shouldn't even exist post-import, but the rule's
+        cheap-path predicate still checks ``granted_keyword == 'Prepare'``
+        as a defense-in-depth.
+        """
+        cmdr_ports = [
+            _port_row(
+                port_type="static",
+                event_class="AlternateMode",
+                granted_keyword="Modal",
+            ),
+        ]
+        _insert_alternate_mode_prepare_port(conn, "Adventurous Eater")
+        conn.commit()
+
+        results = _find_prepared_mechanic_complements(conn, cmdr_ports, {"Tergrid, God of Fright"})
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# _find_prepared_mechanic_complements — slow path
+# ---------------------------------------------------------------------------
+
+
+class TestSlowPathPrepareEnablerCommander:
+    """Commander has an ``effect AlterAttribute`` port whose port_attributes
+    include ``(attribute, Prepared)``, but no ``AlternateMode:Prepare`` of
+    its own. Covers hypothetical enabler-only legendary creatures (the only
+    current example is Skycoach Waypoint, a land — not a commander).
+    """
+
+    def test_fires_via_port_attributes_join(self, conn):
+        """Commander has an AlterAttribute Prepared port (no AlternateMode
+        static). Rule should fall through to the slow path and still emit
+        complements for every Prepared payoff candidate."""
+        # Commander has NO AlternateMode static port on its ports list.
+        # cmdr_ports passed to the rule is the in-memory list; the slow path
+        # queries the DB directly, so we also need the commander's
+        # AlterAttribute port in card_ports.
+        cmdr_ports: list[dict] = []
+        _insert_alter_attribute_prepared(conn, "Synthetic Enabler")
+        _insert_alternate_mode_prepare_port(conn, "Adventurous Eater")
+        _insert_alternate_mode_prepare_port(conn, "Emeritus of Woe")
+        conn.commit()
+
+        results = _find_prepared_mechanic_complements(conn, cmdr_ports, {"Synthetic Enabler"})
+        candidates = {r.candidate for r in results}
+        assert candidates == {"Adventurous Eater", "Emeritus of Woe"}
+
+    def test_alter_attribute_other_attribute_does_not_activate(self, conn):
+        """An AlterAttribute port that grants Suspected (not Prepared) must
+        NOT put the commander in the Prepared ecosystem.
+        """
+        # Insert an AlterAttribute Suspected on the commander side
+        cur = conn.execute(
+            "INSERT INTO card_ports (card_name, port_type, event_class, granted_keyword) VALUES (?, ?, ?, ?)",
+            ("Suspected Tribesman", "effect", "AlterAttribute", None),
+        )
+        port_id = cur.lastrowid
+        conn.execute(
+            "INSERT INTO port_attributes (port_id, attr_kind, attr_value) VALUES (?, ?, ?)",
+            (port_id, "attribute", "Suspected"),
+        )
+        # Prepared candidate exists in the universe but should not be paired.
+        _insert_alternate_mode_prepare_port(conn, "Adventurous Eater")
+        conn.commit()
+
+        results = _find_prepared_mechanic_complements(conn, [], {"Suspected Tribesman"})
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# _find_prepared_mechanic_complements — negative paths
+# ---------------------------------------------------------------------------
+
+
+class TestNonPreparedCommander:
+    def test_no_prepared_signals_returns_empty(self, conn):
+        """Korvold-shape commander (no Prepared signal anywhere) returns []
+        even when Prepared candidates exist in the universe."""
+        cmdr_ports = [
+            _port_row(
+                port_type="trigger",
+                event_class="Sacrificed",
+                valid_filter="Permanent.YouCtrl",
+            ),
+        ]
+        _insert_alternate_mode_prepare_port(conn, "Adventurous Eater")
+        conn.commit()
+
+        results = _find_prepared_mechanic_complements(conn, cmdr_ports, {"Korvold, Fae-Cursed King"})
+        assert results == []
+
+    def test_empty_universe_returns_empty(self, conn):
+        """Commander IS Prepared but no other Prepared cards exist —
+        result is empty, not crash."""
+        cmdr_ports = [
+            _port_row(
+                port_type="static",
+                event_class="AlternateMode",
+                granted_keyword="Prepare",
+            ),
+        ]
+        # Don't insert any Prepared candidates.
+        conn.commit()
+
+        results = _find_prepared_mechanic_complements(conn, cmdr_ports, {"Abigale, Poet Laureate"})
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# _commander_has_alternate_mode_prepare — cheap-path predicate
+# ---------------------------------------------------------------------------
+
+
+class TestCheapPathPredicate:
+    def test_matches_static_alternate_mode_prepare(self):
+        ports = [
+            _port_row(
+                port_type="static",
+                event_class="AlternateMode",
+                granted_keyword="Prepare",
+            ),
+        ]
+        assert _commander_has_alternate_mode_prepare(ports) is True
+
+    def test_rejects_alternate_mode_with_other_value(self):
+        ports = [
+            _port_row(
+                port_type="static",
+                event_class="AlternateMode",
+                granted_keyword="Modal",
+            ),
+        ]
+        assert _commander_has_alternate_mode_prepare(ports) is False
+
+    def test_rejects_non_static_port_type(self):
+        ports = [
+            _port_row(
+                port_type="trigger",
+                event_class="AlternateMode",
+                granted_keyword="Prepare",
+            ),
+        ]
+        assert _commander_has_alternate_mode_prepare(ports) is False
+
+    def test_rejects_non_alternate_mode_event_class(self):
+        ports = [
+            _port_row(
+                port_type="static",
+                event_class="Continuous",
+                granted_keyword="Prepare",
+            ),
+        ]
+        assert _commander_has_alternate_mode_prepare(ports) is False
+
+    def test_handles_empty_port_list(self):
+        assert _commander_has_alternate_mode_prepare([]) is False
+
+
+# ---------------------------------------------------------------------------
+# RuleGate registry entry
+# ---------------------------------------------------------------------------
+
+
+class TestPreparedMechanicRuleGate:
+    """The registry gate predicate is what the auditor uses to attribute
+    rule firings to a specific commander port. It must agree with the
+    cheap-path predicate above on its single-port signature.
+    """
+
+    @pytest.fixture()
+    def gate(self):
+        for g in RULE_GATES:
+            if g.rule_id == "prepared_mechanic":
+                return g.predicate
+        raise AssertionError("prepared_mechanic gate not registered in RULE_GATES")
+
+    def test_gate_matches_alternate_mode_prepare_port(self, gate):
+        port = _port_row(
+            port_type="static",
+            event_class="AlternateMode",
+            granted_keyword="Prepare",
+        )
+        assert gate(port) is True
+
+    def test_gate_rejects_alternate_mode_modal(self, gate):
+        port = _port_row(
+            port_type="static",
+            event_class="AlternateMode",
+            granted_keyword="Modal",
+        )
+        assert gate(port) is False
+
+    def test_gate_rejects_non_static_port(self, gate):
+        port = _port_row(
+            port_type="trigger",
+            event_class="AlternateMode",
+            granted_keyword="Prepare",
+        )
+        assert gate(port) is False
+
+    def test_gate_rejects_unrelated_static_port(self, gate):
+        port = _port_row(
+            port_type="static",
+            event_class="Continuous",
+            granted_keyword="",
+        )
+        assert gate(port) is False


### PR DESCRIPTION
## Summary

- Captures the new `AlternateMode:Prepare` / `Attributes$ Prepared` mechanic (~48 cards added in the 2026-05-19 Forge refresh).
- Importer extension surfaces two new queryable signals: synthetic `static AlternateMode Prepare` port (47 cards) and exploded `port_attributes` under `attr_kind='attribute'` (81 rows across 7 mechanics: Prepared, Suspected, Solved, Plotted, Commander, Saddled, Harnessed).
- New complement rule `prepared_mechanic` with dual-path commander detection.

Rebased onto main after #45 merged (was previously stacked on `feat/forge-refresh-f42b9abc1`; that branch was deleted by the squash-merge, which auto-closed the original PR #46).

## What "Prepared" does

A creature with `AlternateMode:Prepare` has a back-face spell castable when the creature becomes prepared (via `DB$ AlterAttribute | Attributes$ Prepared`). Two roles in the ecosystem:

1. **Prepared-payoff cards** (~47) — creatures with the alt-face spell. Most self-prepare via a trigger / ETB / activated ability.
2. **Prepare-enablers** — cards that grant the Prepared attribute via AlterAttribute targeting other creatures (currently just Skycoach Waypoint, a land).

The mechanic is gated by reciprocity ("only creatures with prepare spells can become prepared"), so Prepared cards co-deck like a tribe.

## Data layer

| Change | Effect |
|---|---|
| `parser.py` recognizes `AlternateMode:` header | Stashes value on `card["alternate_mode"]` |
| `ports.py::extract_alternate_mode_ports` | Emits synthetic `static AlternateMode Prepare` port (Prepare-only via `_ALTERNATE_MODE_PORT_VALUES` frozenset — see scope note below) |
| `ports.py::extract_effect_ports` | Captures `Attributes$ <V>` from AlterAttribute as transient `_attributes` |
| `importer.py` | Explodes `_attributes` into `port_attributes` with `attr_kind='attribute'` |

**Scope note on `_ALTERNATE_MODE_PORT_VALUES`**: restricted to `Prepare` only. Initially emitted for all values (DoubleFaced, Adventure, Split, Modal, Flip, Specialize, Omen, Meld) but that perturbed the depth-2 cascade walker's Stage-1 relevant-event prefilter — caught Tergrid (Modal DFC) regressing -0.21 on the golden set. The narrower vocabulary keeps the audit identity-preserving on historical commanders.

## Rule layer

`complement_rules/prepared.py::_find_prepared_mechanic_complements`:

- **Cheap path**: commander has the synthetic `static AlternateMode Prepare` port. Covers all 47 self-preparing payoff creatures, including the ~20 that self-prepare via `K:ETBReplacement:Other:DBPrepare` (which the SVar walker doesn't follow).
- **Slow path**: SQL join through `port_attributes` for AlterAttribute Prepared. Covers enabler-only commanders that prepare other creatures.
- IDF-weighted like every other rule. Maps to `port_match` bucket for `recommend.py --explain` rendering.

`RuleGate` registered in `registry.py` for per-port auditor attribution.

## Validation

| Check | Result |
|---|---|
| `rule_quality_gate.py --rule prepared_mechanic` | WARN (47 targets, cov=2.0, cv=0.613) — same shape as documented-acceptable `ward_2_tribal` WARN for new-mechanic targets |
| `bench.py audit` | aggregate Δ = **+0.0000**, 100/100 no_change |
| `pytest tests/` | 1,840 pass · 2 skipped · 25 deselected · coverage 90.39% (+3 tests vs #45) |
| Pre-commit hooks | ruff / pyright / pytest / bench-audit all pass |
| Qualitative on Abigale | `port_match = 0.180` per Prepared candidate (Bloodline Recollector, Adventurous Eater, Cheerful Osteomancer, Defacing Duskmage, Emeritus of Truce/Woe, Spiritcall Enthusiast, …) |

## Test plan

- [x] TDD: 7 new tests in `tests/test_importer.py` covering both code paths and synthetic-card edge cases.
- [x] Integration: Abigale / Repeat Offender (existing Suspected) / Skycoach Waypoint cardsfolder reads.
- [x] Audit: aggregate Δ = +0.0000, no commander regression.
- [x] Qualitative: Abigale's top-60 surfaces Prepared cards with rule-contribution scores.

## Follow-up

- **Rule weight tuning**: Prepared candidates score ~0.187 vs ~0.516 for generic WB staples (Bontu's Monument). If Prepared commanders should weight Prepared-tribal cards above generic mana-rocks, bump via `_RULE_QUALITY_MULTIPLIER` in `data/scoring_weights.json`.
- **`CopyFaceFrom:<Name>` resolution**: the back-face spell for some Prepared cards references existing cards (Brainstorm, Reanimate, Demonic Tutor) by name. Today the importer doesn't materialize those references into the merged port set. Out of scope for v1.
- **`K:ETBReplacement` SVar walking**: 20 Prepared cards self-prepare via this keyword form and don't surface an AlterAttribute port. The cheap path on the AlternateMode static port covers them as commanders; full effect-surfacing is deferred.

## Brainstorm

`docs/brainstorms/2026-05-19-prepared-mechanic-requirements.md`

Supersedes auto-closed #46.