### PR TITLE
chore(scoring): tune prepared_mechanic multiplier 1.0 → 3.0

### DIFF
--- a/data/scoring_weights.json
+++ b/data/scoring_weights.json
@@ -160,6 +160,10 @@
       "value": 2.5,
       "comment": ""
     },
+    "prepared_mechanic": {
+      "value": 3.0,
+      "comment": "Reciprocal niche tribe (47 cards). Pushes Prepared-payoff candidates above generic WB staples on commanders that are themselves Prepared-payoff cards or grant Prepared via AlterAttribute. Golden-set-neutral (no 100-cmdr golden commander triggers the rule)."
+    },
     "prowess_tribal": {
       "value": 2.0,
       "comment": ""

--- a/docs/RULE_HISTORY.md
+++ b/docs/RULE_HISTORY.md
@@ -5,6 +5,40 @@ impact notes. See `scripts/_audit_rule_impact.py` for the per-rule impact
 methodology (NDCG@30 metric + golden-set safety net + CONTENTIOUS verdict).
 See `docs/RULE_PLANNING.md` for the forward-looking planning workflow.
 
+## 2026-05-20
+
+### `prepared_mechanic` rule weight tuned 1.0 → 3.0
+
+Follow-up to the 2026-05-19 landing. The `recommend.py` qualitative check
+on `Abigale, Poet Laureate` flagged that Prepared candidates scored
+~0.187 (port_match) vs ~0.516 for generic WB staples (Bontu's /
+Oketra's / Hazoret's / Rhonas's / Kefnet's Monuments + the medallion
+cycle), so they sank to rank #50-60 below mana-rock noise. Set
+`data/scoring_weights.json::rule_quality_multiplier.prepared_mechanic
+= 3.0` to push them above the staple band.
+
+- **`bench.py audit`**: Δ = **+0.0000** on the 100-cmdr golden set
+  (100/100 no_change, hidden_gem_hit_rate stable at 0.8053). Golden-
+  set-neutral because no commander in the 100-cmdr canonical triggers
+  the rule (cheap path: no `AlternateMode|Prepare` static port; slow
+  path: no `AlterAttribute → Prepared` effect port). Re-pinned the
+  fixture for the new config_hash; underlying scores unchanged.
+- **Qualitative validation**: `recommend.py "Abigale, Poet Laureate"
+  --top 60`. All 17 WB-castable Prepared-payoff cards now occupy
+  ranks **#1-17** (score 0.5); Bontu's Monument dropped from #1 to
+  **#18**. Prepared cards now tie the staple band rather than under-
+  shoot it, which is the intended ordering for a Prepared-payoff
+  commander.
+
+### `prepared_mechanic` rule_id literal inlined
+
+Minor: `prepared.py` originally used `rule_id=_RULE_ID` (constant)
+where the rest of `complement_rules/` uses inline `rule_id="..."`
+literals. The dead-key-detector test
+(`tests/test_scoring_weights.py::test_no_dead_rule_ids_in_quality_multiplier`)
+scrapes literal strings via regex, so the constant form was invisible
+to it. Inlined to match codebase convention and unblock the test.
+
 ## 2026-05-19
 
 ### `prepared_mechanic` rule (LANDED)

--- a/src/mtg_synergy_graph/complement_rules/prepared.py
+++ b/src/mtg_synergy_graph/complement_rules/prepared.py
@@ -30,8 +30,6 @@ import sqlite3
 
 from .core import PortComplement, PortRow
 
-_RULE_ID = "prepared_mechanic"
-
 
 def _commander_has_alternate_mode_prepare(cmdr_ports: list[PortRow]) -> bool:
     """Cheap path — commander itself is a Prepared-payoff card.
@@ -95,7 +93,7 @@ def _find_prepared_mechanic_complements(
 
     return [
         PortComplement(
-            rule_id=_RULE_ID,
+            rule_id="prepared_mechanic",
             direction="synergy",
             candidate=r["card_name"],
             cmdr_event="Prepared_ecosystem",

--- a/tests/fixtures/golden_set_run.json
+++ b/tests/fixtures/golden_set_run.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
-  "config_hash": "48b1db2caec6d5922fbf91a7db65b5873a396484a7887c510e76a39733d365fe",
-  "created_at": "2026-05-20T00:30:13+00:00",
+  "config_hash": "a0a3879532461273b3d49115e31742e4814fde22e05751f5a15f3bb69b0ac161",
+  "created_at": "2026-05-20T04:37:15+00:00",
   "entries": [
     {
       "edhrec_top10": [

--- a/tests/test_scoring_weights.py
+++ b/tests/test_scoring_weights.py
@@ -31,7 +31,7 @@ from mtg_synergy_graph.universal_scorer import (
 # Edit this only when a value in data/scoring_weights.json (or another
 # input to compute_config_hash) legitimately changes — at which point
 # bench.py audit --repin --yes is also required.
-_PRODUCTION_HASH = "48b1db2caec6d5922fbf91a7db65b5873a396484a7887c510e76a39733d365fe"
+_PRODUCTION_HASH = "a0a3879532461273b3d49115e31742e4814fde22e05751f5a15f3bb69b0ac161"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up #1 from PR #47. Pushes Prepared-payoff candidates above generic WB mana-rock staples on Prepared-payoff commanders by setting `data/scoring_weights.json::rule_quality_multiplier.prepared_mechanic = 3.0`.

- **Audit (golden_set_run.json, 100 cmdrs):** Δ=+0.0000, 100/100 no_change, hidden_gem_hit_rate 0.8053 (unchanged). Golden-set-neutral — no canonical commander triggers the rule, so the multiplier only affects pages where the cheap or slow path fires. Re-pinned the fixture for the new config_hash.
- **Qualitative validation** (`recommend.py "Abigale, Poet Laureate" --top 60`): all 17 WB-castable Prepared cards now occupy ranks #1-17 (score 0.5); Bontu's Monument dropped from #1 to #18. Prepared candidates now tie the staple band, the intended ordering for a Prepared-payoff commander.

### Drive-by

Inlined the `rule_id="prepared_mechanic"` literal in `complement_rules/prepared.py` — was hidden behind a `_RULE_ID` constant that the dead-key scraper test (`tests/test_scoring_weights.py::test_no_dead_rule_ids_in_quality_multiplier`) couldn't see via its string-literal regex. Matches the convention used by the rest of `complement_rules/`.

## Test plan

- [x] `uv run pytest tests/` → 1865 passed, 90.49% coverage
- [x] `uv run scripts/bench.py audit` → PASS, Δ=+0.0000, 100/100 no_change
- [x] `uv run python scripts/recommend.py --commander "Abigale, Poet Laureate" --top 60 --explain` → 17 Prepared cards at ranks #1-17, Bontu's Monument at #18
- [x] pre-commit hooks (ruff/pyright/pytest/bench-audit) green