### PR TITLE
fix(test): isolate GIT_* env in test_commit_sha_empty_on_non_git_dir

### DIFF
--- a/tests/bench/test_history.py
+++ b/tests/bench/test_history.py
@@ -239,6 +239,14 @@ def test_commit_sha_empty_on_non_git_dir(
 ) -> None:
     """Running the real ``_commit_sha`` in a non-git directory → empty string."""
     monkeypatch.setattr(bench_history, "_commit_sha", _REAL_COMMIT_SHA)
+    # ``git`` exports GIT_DIR / GIT_INDEX_FILE / GIT_WORK_TREE into hook
+    # environments (and CI may set them too). When present they override
+    # CWD-based repo discovery, so ``git rev-parse HEAD`` resolves the parent
+    # repo even from ``tmp_path``. Clear them so the directory is genuinely
+    # outside any git checkout — without this the test fails when the suite
+    # runs from a git worktree's pre-commit hook, where GIT_DIR is absolute.
+    for var in ("GIT_DIR", "GIT_INDEX_FILE", "GIT_WORK_TREE"):
+        monkeypatch.delenv(var, raising=False)
     monkeypatch.chdir(tmp_path)
     sha = bench_history._commit_sha()
     assert sha == ""


### PR DESCRIPTION
## Summary

`tests/bench/test_history.py::test_commit_sha_empty_on_non_git_dir` was not
hook-safe: it failed the `pytest` pre-commit hook **whenever a commit was made
from a git worktree**, blocking commits in that (common, agent-used) setup.

### Root cause

The test simulates "not a git repo" with `monkeypatch.chdir(tmp_path)` and
asserts the real `_commit_sha()` returns `""`. But git exports
`GIT_DIR` / `GIT_INDEX_FILE` / `GIT_WORK_TREE` into hook environments, and in a
**worktree** `GIT_DIR` is an absolute path to the worktree's git dir. Those
env vars override CWD-based repo discovery, so `git rev-parse HEAD` resolves
the parent repo even from `tmp_path` → a real SHA is returned → the assertion
fails.

Verified:
- absolute `GIT_DIR` (worktree hook) → **FAIL** (before fix)
- relative `GIT_DIR=.git` (normal-repo hook) or unset → PASS

`_commit_sha()` itself is correct (it intentionally reads the ambient repo);
only the test's simulation was incomplete.

### Fix

Clear the three `GIT_*` vars in the test before `chdir`, so `tmp_path` is
genuinely outside any checkout (one-line-per-var `monkeypatch.delenv(...,
raising=False)`).

## Test plan

- [x] Reproduced RED in a worktree: test fails with absolute `GIT_DIR` set.
- [x] GREEN after fix: passes under absolute `GIT_DIR`, relative `GIT_DIR`, and
      unset; full `test_history.py` green (15 passed).
- [x] **Committed this change from a git worktree** — the full pre-commit hook
      (ruff, ruff-format, pyright, pytest full suite) passed under the exact
      absolute-`GIT_DIR` condition that previously failed.
- [x] `ruff check` + `ruff format --check` clean on the edited file.

Context: discovered while merging the Dependabot PR batch (#58/#62/#64–68),
where manual conflict resolutions had to be committed from outside a worktree
to dodge this exact failure.