### PR TITLE
ci: auto-merge Dependabot PRs when checks pass

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,44 @@
+name: Dependabot auto-merge
+
+# Turns on GitHub's native auto-merge for Dependabot PRs. GitHub then
+# squash-merges each PR by itself once the required status checks (lint +
+# test (3.13)) are green AND the branch is up to date with main — both are
+# demanded by the branch ruleset, so nothing merges until CI passes.
+#
+# No human step. When several Dependabot PRs are open at once, the strict
+# "up to date" rule serializes them: one merges, Dependabot auto-rebases the
+# rest, their checks re-run, and the next merges — hands-off. (Do NOT run
+# `gh pr update-branch` on a Dependabot PR yourself: it disowns the PR and
+# Dependabot stops rebasing it. See memory/project_dependabot_merge_gotchas.)
+#
+# Security: triggered by `pull_request` (not pull_request_target), checks out
+# no PR code, and only runs the gh CLI — so there is no path to execute
+# Dependabot-authored content with the elevated token.
+
+on: pull_request
+
+# default_workflow_permissions for this repo is "read"; elevate just this
+# workflow so the token can enable auto-merge and squash into main.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Only Dependabot's own PRs. A forked/spoofed PR cannot set this actor.
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98  # v3.1.0
+
+      - name: Enable auto-merge (squash)
+        # Default: auto-merge every Dependabot update once checks are green.
+        # To hold MAJOR bumps for manual review instead, add to this step:
+        #   if: ${{ steps.meta.outputs.update-type != 'version-update:semver-major' }}
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/dependabot-auto-merge.yml` so Dependabot PRs merge
**automatically once all checks are green** — no manual step.

How it works: on each Dependabot `pull_request`, the workflow enables
GitHub's native **auto-merge (squash)**. GitHub then merges the PR by itself
only when the required status checks (`lint` + `test (3.13)`) pass **and** the
branch is up to date with `main` — exactly what the branch ruleset requires.

When a weekly batch opens several PRs at once, the strict "up-to-date" rule
serializes them: one merges, Dependabot auto-rebases the rest, their checks
re-run, the next merges — fully hands-off. (Lesson from the last manual batch:
don't `gh pr update-branch` a Dependabot PR yourself — it disowns the PR and
Dependabot stops rebasing it.)

### Defaults & options
- **Auto-merges all update types** on green (per request). To hold **major**
  bumps for manual review, uncomment the one-line `if:` shown above the
  enable step (uses `dependabot/fetch-metadata` output).
- Squash only (matches the ruleset's allowed merge method); deletes the head
  branch on merge.

### Security
- `on: pull_request` (not `pull_request_target`); **no PR code is checked
  out or executed** with the elevated token.
- Minimal scoped `permissions:` (`contents: write`, `pull-requests: write`) —
  the repo default is read-only.
- Guarded by `if: github.actor == 'dependabot[bot]'`.
- `dependabot/fetch-metadata` pinned to a commit SHA (`25dd0e3`, v3.1.0).
- `html_url` passed via `env:` and quoted — no shell injection.

## Test plan
- [x] YAML validates; structure verified (trigger, permissions, actor guard, pinned action).
- [x] No untrusted free-text interpolated into `run:`.
- [ ] First real exercise: next Dependabot PR (or `@dependabot recreate` on a future one) should auto-merge once `lint` + `test (3.13)` pass. Takes effect after this PR merges (new workflows don't run on the PR that adds them).